### PR TITLE
Removing runtime.sendMessage() from Insiders table

### DIFF
--- a/microsoft-edge/extensions/api-support/extension-api-roadmap.md
+++ b/microsoft-edge/extensions/api-support/extension-api-roadmap.md
@@ -37,7 +37,6 @@ Popup debugging | Supported — Microsoft Edge (38) / Windows 10 (14971)
 [port.postMessage](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/Port#Type) | Supported — Microsoft Edge (38) / Windows 10 (15002)
 [runtime.connectNative](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connectNative) | Supported — Microsoft Edge (38) / Windows 10 (15002)
 [runtime.reload](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/reload) | Supported — Microsoft Edge (38) / Windows 10 (15002)
-[runtime.sendMessage](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage) | Supported — Microsoft Edge (38) / Windows 10 (15002)
 [runtime.sendNativeMessage](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage) | Supported — Microsoft Edge (38) / Windows 10 (15002)
 [runtime.setUninstallUrl](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/setUninstallURL) | Supported — Microsoft Edge (38) / Windows 10 (14971)
 Shared cookies (Fix for [8438075](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8438075/)) |In Development


### PR DESCRIPTION
This was actually supported in 14393