### PR TITLE
Policy updates to native messaging documents

### DIFF
--- a/microsoft-edge/extensions/guides/native-messaging.md
+++ b/microsoft-edge/extensions/guides/native-messaging.md
@@ -13,7 +13,10 @@ keywords: edge, web development, html, css, javascript, developer, native, messa
  
 ## Native messaging architecture overview
 
-With the upcoming Windows 10 Creators Update, Edge extensions will be able to use native messaging to communicate with a companion Universal Windows Platform (UWP) app.  At a high level, Edge extensions use the same APIs for native messaging as Chrome and Firefox extensions. However, the native messaging host will need to be implemented using the Universal Windows Platform. 
+With the upcoming Windows 10 Creators Update, Edge extensions will be able to use native messaging to communicate with a companion Universal Windows Platform (UWP) app.  At a high level, Edge extensions use the same APIs for native messaging as Chrome and Firefox extensions. However, the native messaging host will need to be implemented using the Universal Windows Platform.
+
+> [!NOTE]
+> The method outlined below (connecting to a UWP app via AppService) is the only supported mechanism for enabling communication between Edge extensions and native components. Please see the [Adding a Desktop Bridge component](#adding-a-desktop-bridge-component) section of this guide for more information on how to enable communication with legacy Win32 components. 
 
  Edge’s native messaging architecture leverages the existing [`AppService`](https://msdn.microsoft.com/library/windows/apps/windows.applicationmodel.appservice.aspx) API as the underlying inter-process communication (IPC) infrastructure. UWP apps use the `AppService` API to communicate with one another. Because of this, Edge extensions can now communicate with UWP apps.
 


### PR DESCRIPTION
AppService was always the only mechanism we planned to support due to strategic and security reasons, however, this was not 100% spelled out. This change updates the wording in our documentation to reflect this