### PR TITLE
Legal updates from CELA

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Attribution 4.0 International
+﻿Attribution 4.0 International
 
 =======================================================================
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
 # How to contribute to Microsoft Edge documentation
 
 ## Legal Notices

--- a/ThirdPartyNotices
+++ b/ThirdPartyNotices
@@ -1,0 +1,15 @@
+##Legal Notices
+Microsoft and any contributors grant you a license to the Microsoft documentation and other content
+in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),
+see the [LICENSE](LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the
+[LICENSE-CODE](LICENSE-CODE) file.
+
+Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
+may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
+The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
+Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
+
+Privacy information can be found at https://privacy.microsoft.com/en-us/
+
+Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
+or trademarks, whether by implication, estoppel or otherwise.


### PR DESCRIPTION
CELA has provided replacement licence files which include separate licenses for CC and code snippets. The Content Engineering Team has been tasked with replacing the license files on all existing repos. The changes to the README file must be at the top of the file to be recognized by license scanners.
 
Please see this communication for more details: [Legal Update Notice](https://microsoft.sharepoint.com/teams/STBCSI/e/CE/_layouts/15/guestaccess.aspx?guestaccesstoken=m4R%2fQ5Es3YlfV%2fUTJ09pb8x50MXjJNNO20%2b9YHpi5%2bo%3d&docid=2_0a46b1b0a931049e5afab07102ab5c0df&rev=11)
 
Please accept the PR as soon as possible.