### PR TITLE
Windows Store app to UWP app, Windows Store to Microsoft Store

### DIFF
--- a/microsoft-edge/extensions/extensions-for-enterprise.md
+++ b/microsoft-edge/extensions/extensions-for-enterprise.md
@@ -27,18 +27,18 @@ Before an enterprise can distribute an extension to its employees, it must first
 
 ## Distributing extensions
 
-Once an extension has been packaged, it can be distributed to employees through the Windows Store, Windows Store for Business, or by sideloading.
+Once an extension has been packaged, it can be distributed to employees through the Microsoft Store, Microsoft Store for Business, or by sideloading.
 
-Extensions distributed though the Windows Store for Business can either be assigned to employees, or added to a private store where all employees can access them. This can be done by following the [Distribute "Line-of-Business" (LOB) apps to enterprises](https://msdn.microsoft.com/windows/uwp/publish/distribute-lob-apps-to-enterprises) guide.
+Extensions distributed though the Microsoft Store for Business can either be assigned to employees, or added to a private store where all employees can access them. This can be done by following the [Distribute "Line-of-Business" (LOB) apps to enterprises](https://msdn.microsoft.com/windows/uwp/publish/distribute-lob-apps-to-enterprises) guide.
 
 To sideload extensions, devices (unmanaged or managed) must be unlocked for sideloading. See [Sideload LOB apps in Windows 10](https://technet.microsoft.com/itpro/windows/deploy/sideload-apps-in-windows-10) for more info on how to sideload packaged extensions.
 
 
 ### Behavior of sideloaded extensions
 
-Unlike extensions distributed through the Windows Store (or the Windows Store for Business), sideloaded extensions are treated differently in Microsoft Edge.
+Unlike extensions distributed through the Microsoft Store (or the Microsoft Store for Business), sideloaded extensions are treated differently in Microsoft Edge.
 
-The first difference affects how sideloaded extensions behave after installation. Unlike extensions from the Windows Store, sideloaded extensions do not immediately display the "You have a new extension" notification and need to be manually turned on by the user.
+The first difference affects how sideloaded extensions behave after installation. Unlike extensions from the Microsoft Store, sideloaded extensions do not immediately display the "You have a new extension" notification and need to be manually turned on by the user.
 
 To turn on the extension, open the **More (...)** menu, select **"Extensions"** and you should see the sideloaded extension in the list of installed extensions. Click on the extension and turn it on.
 
@@ -48,7 +48,7 @@ The second difference affects how sideloaded extensions appear in the browser. F
 
 ![sideload warning 2](./media/sideload-l1warning.PNG)
 
-The third and final difference affects how sideloaded extensions behave on browser startup. Sideloaded extensions on devices that are either domain-joined or MDM enabled will behave like extensions from the Windows Store. However, sideloaded extensions on devices that are not domain-joined or MDM enabled will be turned off during browser startup and require the user to take explicit action.
+The third and final difference affects how sideloaded extensions behave on browser startup. Sideloaded extensions on devices that are either domain-joined or MDM enabled will behave like extensions from the Microsoft Store. However, sideloaded extensions on devices that are not domain-joined or MDM enabled will be turned off during browser startup and require the user to take explicit action.
 
 Shortly after browser startup (after ~10 seconds of inactivity) the following notification will appear near the bottom of the window.
 

--- a/microsoft-edge/extensions/getting-started.md
+++ b/microsoft-edge/extensions/getting-started.md
@@ -68,9 +68,9 @@ Once you've submitted a request, we'll receive a notification and will try to ge
 The process for publishing an extension to the Microsoft Store (whether it's a brand new extension or an update to an existing one) can take up to 72 hours to complete. In order to expedite this process, please ensure you have verified these common gotchas before submitting to avoid having to resubmit later: 
 > - Your screenshots are correctly sized and are of your extension running in Microsoft Edge 
 > - Your extension description references "Microsoft Edge" instead of "Edge" (this is a legal requirement) 
-> - Your 150x150 icon in your extension package [does not have a transparent background](./guides/design.md#windows-store-icon) (The Microsoft Store client does not correctly render images with transparent backgrounds) 
+> - Your 150x150 icon in your extension package [does not have a transparent background](./guides/design.md#microsoft-store-icon) (The Microsoft Store client does not correctly render images with transparent backgrounds) 
 
-In addition to the above, and if applicable, please ensure that any platform availability information on your website correctly mentions your extension's availability on Microsoft Edge. While the Microsoft Store does not allow for one-click inline extension installs, you can [deep-link to your extension in the Microsoft Store](./tips-and-tricks.md#get-a-direct-link-to-your-extension-in-the-windows-store) to make it easy for users to acquire it. 
+In addition to the above, and if applicable, please ensure that any platform availability information on your website correctly mentions your extension's availability on Microsoft Edge. While the Microsoft Store does not allow for one-click inline extension installs, you can [deep-link to your extension in the Microsoft Store](./tips-and-tricks.md#get-a-direct-link-to-your-extension-in-the-microsoft-store) to make it easy for users to acquire it. 
 
 The Microsoft Store also allows you to [control the visibility of your extension](https://blogs.windows.com/buildingapps/2015/09/10/managing-hidden-apps-beta-apps-and-visibility-of-in-app-purchases-in-dev-center/) in the Microsoft Store catalog. Some of our partners have taken advantage of this functionality to achieve the following: 
 - Publishing a second beta version of their extension as hidden in the Microsoft Store.

--- a/microsoft-edge/extensions/getting-started.md
+++ b/microsoft-edge/extensions/getting-started.md
@@ -44,36 +44,36 @@ So your extension works in Microsoft Edge. What happens next? Before you continu
 
 ## Packaging an extension
 
-Now your extension is finally polished up and ready to be packaged. Whether you wish to package it to prepare for submission to the Windows Store, or to make it easier to distribute within your development/testing teams, there are plenty of resources available to help you: 
+Now your extension is finally polished up and ready to be packaged. Whether you wish to package it to prepare for submission to the Microsoft Store, or to make it easier to distribute within your development/testing teams, there are plenty of resources available to help you: 
 
 - Our recommended solution for creating an extension package is to follow our [ManifoldJS packaging guide](./guides/packaging/using-manifoldjs-to-package-extensions.md) which will walk you through the steps of using a Node.js based tool to easily package your extension no matter what platform you develop on. If you want a more manual and in-depth look into our extension packaging format, please refer to our [AppX package creation guide](./guides/packaging/creating-and-testing-extension-packages.md#preparing-the-submission-folder). 
 - If your extension supports multiple languages, you'll also need to follow our guide on [localizing extension packages](./guides/packaging/localizing-extension-packages.md) so that the languages you have in your extension are correctly registered after packaging. 
 
 If you're an enterprise customer looking to distribute your packaged extensions via internal channels, please see our [extensions for enterprise guide](./extensions-for-enterprise.md) to see how to do this.  
 
-## Publishing to the Windows Store
+## Publishing to the Microsoft Store
 
-Since our extensions platform is still in its infancy, we're purposely managing extension submissions to the Windows Store so that we can focus on delivering a quality experience for our users and developers. That being said, we want to make it as easy as possible for developers to publish their extensions. As a result, we have recently launched a new [extension submission form](http://aka.ms/extension-request) where developers can request permission to submit their extension AppX to the Windows Store.
+Since our extensions platform is still in its infancy, we're purposely managing extension submissions to the Microsoft Store so that we can focus on delivering a quality experience for our users and developers. That being said, we want to make it as easy as possible for developers to publish their extensions. As a result, we have recently launched a new [extension submission form](http://aka.ms/extension-request) where developers can request permission to submit their extension AppX to the Microsoft Store.
  
 
-The first step of the publishing process is to make sure your extension conforms to our [browser extension policy](./microsoft-browser-extension-policy.md) as well as the [Microsoft Edge extensions section of the Windows Store Policies](https://msdn.microsoft.com/library/windows/apps/dn764944.aspx#pol_10_12). 
+The first step of the publishing process is to make sure your extension conforms to our [browser extension policy](./microsoft-browser-extension-policy.md) as well as the [Microsoft Edge extensions section of the Microsoft Store Policies](https://msdn.microsoft.com/library/windows/apps/dn764944.aspx#pol_10_12). 
 
-Once you've confirmed that your extension follows the policies, you will need to register for a [Windows Dev Center account and reserve the name of your extension](./guides/packaging/extensions-in-the-windows-dev-center.md). Then, you'll need to submit a request via our [extension submission form](http://aka.ms/extension-request) in order to request permission to publish to the Windows Store. If you try to submit your extension AppX without first obtaining permission, you'll receive the following error:
+Once you've confirmed that your extension follows the policies, you will need to register for a [Windows Dev Center account and reserve the name of your extension](./guides/packaging/extensions-in-the-windows-dev-center.md). Then, you'll need to submit a request via our [extension submission form](http://aka.ms/extension-request) in order to request permission to publish to the Microsoft Store. If you try to submit your extension AppX without first obtaining permission, you'll receive the following error:
 
 `Package acceptance validation error: com.microsoft.edge.extension is a reserved extension type. Your app does not have permission to use this extension type.`
 
-Once you've submitted a request, we'll receive a notification and will try to get to your submission as soon as possible. This may take a bit due to the high volume of submissions we've received, but we'll notify you via email the moment you're approved! Once you've received the mail, you'll be able to submit your extension AppX to the Windows Store via Dev Center. Please note that you do not have to sign your AppX before submitting it; the Windows Store ingestion process will take care of that for you!
+Once you've submitted a request, we'll receive a notification and will try to get to your submission as soon as possible. This may take a bit due to the high volume of submissions we've received, but we'll notify you via email the moment you're approved! Once you've received the mail, you'll be able to submit your extension AppX to the Microsoft Store via Dev Center. Please note that you do not have to sign your AppX before submitting it; the Microsoft Store ingestion process will take care of that for you!
  
 > [!NOTE]
-The process for publishing an extension to the Windows Store (whether it's a brand new extension or an update to an existing one) can take up to 72 hours to complete. In order to expedite this process, please ensure you have verified these common gotchas before submitting to avoid having to resubmit later: 
+The process for publishing an extension to the Microsoft Store (whether it's a brand new extension or an update to an existing one) can take up to 72 hours to complete. In order to expedite this process, please ensure you have verified these common gotchas before submitting to avoid having to resubmit later: 
 > - Your screenshots are correctly sized and are of your extension running in Microsoft Edge 
 > - Your extension description references "Microsoft Edge" instead of "Edge" (this is a legal requirement) 
-> - Your 150x150 icon in your extension package [does not have a transparent background](./guides/design.md#windows-store-icon) (The Windows Store client does not correctly render images with transparent backgrounds) 
+> - Your 150x150 icon in your extension package [does not have a transparent background](./guides/design.md#windows-store-icon) (The Microsoft Store client does not correctly render images with transparent backgrounds) 
 
-In addition to the above, and if applicable, please ensure that any platform availability information on your website correctly mentions your extension's availability on Microsoft Edge. While the Windows Store does not allow for one-click inline extension installs, you can [deep-link to your extension in the Windows Store](./tips-and-tricks.md#get-a-direct-link-to-your-extension-in-the-windows-store) to make it easy for users to acquire it. 
+In addition to the above, and if applicable, please ensure that any platform availability information on your website correctly mentions your extension's availability on Microsoft Edge. While the Microsoft Store does not allow for one-click inline extension installs, you can [deep-link to your extension in the Microsoft Store](./tips-and-tricks.md#get-a-direct-link-to-your-extension-in-the-windows-store) to make it easy for users to acquire it. 
 
-The Windows Store also allows you to [control the visibility of your extension](https://blogs.windows.com/buildingapps/2015/09/10/managing-hidden-apps-beta-apps-and-visibility-of-in-app-purchases-in-dev-center/) in the Windows Store catalog. Some of our partners have taken advantage of this functionality to achieve the following: 
-- Publishing a second beta version of their extension as hidden in the Windows Store.
+The Microsoft Store also allows you to [control the visibility of your extension](https://blogs.windows.com/buildingapps/2015/09/10/managing-hidden-apps-beta-apps-and-visibility-of-in-app-purchases-in-dev-center/) in the Microsoft Store catalog. Some of our partners have taken advantage of this functionality to achieve the following: 
+- Publishing a second beta version of their extension as hidden in the Microsoft Store.
 - Initially publishing their extension as hidden to monitor initial telemetry before eventually changing its status to visible once a certain level of confidence is reached.
 
 ## That's it!

--- a/microsoft-edge/extensions/guides/design.md
+++ b/microsoft-edge/extensions/guides/design.md
@@ -86,10 +86,10 @@ Once your extension is ready to be packaged, you'll need to have three additiona
 
 - 44px - Used in the Windows UI (App List, Settings->System->Apps & features)
 - 50px - Packaging requirement (not visible anywhere)
-- 150px - Icon for the Windows Store
+- 150px - Icon for the Microsoft Store
 
-#### Windows Store icon
-If the 150px icon for the Windows Store has a transparent background, the accent color of the user's device will appear as the icon's background color.
+#### Microsoft Store icon
+If the 150px icon for the Microsoft Store has a transparent background, the accent color of the user's device will appear as the icon's background color.
 
 
 For example, if the user has selected pink as their accent color, the transparent background of your store icon will appear as pink to them.
@@ -97,9 +97,9 @@ For example, if the user has selected pink as their accent color, the transparen
 ![Windows accent color](./../media/windows-accent-color.png)
 ![Background color auto selected](./../media/store-icon-with-transparent-background.png)
 
- If you want to pick your own background color for your Windows Store, you'll need to make the background opaque.
+ If you want to pick your own background color for your Microsoft Store, you'll need to make the background opaque.
 
 
 
 > [!NOTE]
-> Submitting a Microsoft Edge extension to the Windows Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Windows Store, and we’ll consider you for a future update.
+> Submitting a Microsoft Edge extension to the Microsoft Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Microsoft Store, and we’ll consider you for a future update.

--- a/microsoft-edge/extensions/guides/native-messaging.md
+++ b/microsoft-edge/extensions/guides/native-messaging.md
@@ -34,7 +34,7 @@ Native messaging adds a whole new layer to your extension. By implementing a UWP
 There are a few instances where native messaging can't be used due to security or policy restrictions:
 
 * Modifying user settings in either Microsoft Edge or Windows, e.g. changing the default browser or search provider.
-* Actions that violate Windows Store policies for both apps and extensions.
+* Actions that violate Microsoft Store policies for both apps and extensions.
 * Transferring data to remote endpoint via native message host.
 * Allowing other apps to download content that changes extension behavior.
 
@@ -368,7 +368,7 @@ Once the solution is correctly deployed, you should see your extension in Micros
 ## Packaging
 
 > [!NOTE]
-> Submitting a Microsoft Edge extension to the Windows Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Windows Store, and we’ll consider you for a future update.
+> Submitting a Microsoft Edge extension to the Microsoft Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Microsoft Store, and we’ll consider you for a future update.
 
 
 You can generate a Store package for submission to the Windows Dev Center using built-in Visual Studio functionality:

--- a/microsoft-edge/extensions/guides/packaging.md
+++ b/microsoft-edge/extensions/guides/packaging.md
@@ -43,7 +43,7 @@ Also included is info on how to [test and unpack a packaged extension](./packagi
 The package localization step falls between creating your appxmanifest.xml file and running the final command to package your extension.
 This allows you to indicate which languages your extensions supports in your Microsoft Store listing, and what language your extension's name appears in in Windows.
 
-You can jump to [Localizing name and description for the Microsoft Store](./packaging/localizing-extension-packages.md#localizing-name-and-description-in-the-windows-store) in this section of the guide if your extension doesn't support multiple languages.
+You can jump to [Localizing name and description for the Microsoft Store](./packaging/localizing-extension-packages.md#localizing-name-and-description-in-the-microsoft-store) in this section of the guide if your extension doesn't support multiple languages.
 
 ## [Using ManifoldJS to package extensions](./packaging/using-ManifoldJS-to-package-extensions.md)
 

--- a/microsoft-edge/extensions/guides/packaging.md
+++ b/microsoft-edge/extensions/guides/packaging.md
@@ -17,7 +17,7 @@ So you've finally completed your extension and are ready to package it up. You m
 The extension packaging guide is comprehensive in that it covers everything you'd want to know about packaging, even the finer, nitty gritty details. If you don't want to learn everything there is to know about packaging your extension, you're in luck. We've added support for extensions to ManifoldJS, an open source Node.js tool that takes the majority of your packaging woes away.
 
 > [!NOTE]
-> Submitting a Microsoft Edge extension to the Windows Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Windows Store, and we’ll consider you for a future update.
+> Submitting a Microsoft Edge extension to the Microsoft Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Microsoft Store, and we’ll consider you for a future update.
 
 
 Use the process outline below to map out your packaging adventure!
@@ -30,7 +30,7 @@ No matter which package creation route you choose, manual or ManifoldJS, the fir
 Once you've done this, you can either move on to [Creating and testing extension packages](./packaging/creating-and-testing-extension-packages.md) to learn how AppXs are created and manually package your extension, or go the easier route and jump to [Using ManifoldJS to package extensions](./packaging/using-ManifoldJS-to-package-extensions.md).
 
 > [!NOTE]
-> Once you've reached out to us and have been approved to have your extension in the Windows Store, check out the [app submission checklist](https://docs.microsoft.com/windows/uwp/publish/app-submissions).
+> Once you've reached out to us and have been approved to have your extension in the Microsoft Store, check out the [app submission checklist](https://docs.microsoft.com/windows/uwp/publish/app-submissions).
 
 
 ## [Creating and testing extension packages](./packaging/creating-and-testing-extension-packages.md)
@@ -41,17 +41,17 @@ Also included is info on how to [test and unpack a packaged extension](./packagi
 
 ## [Localizing extension packages](./packaging/localizing-extension-packages.md)
 The package localization step falls between creating your appxmanifest.xml file and running the final command to package your extension.
-This allows you to indicate which languages your extensions supports in your Windows Store listing, and what language your extension's name appears in in Windows.
+This allows you to indicate which languages your extensions supports in your Microsoft Store listing, and what language your extension's name appears in in Windows.
 
-You can jump to [Localizing name and description for the Windows Store](./packaging/localizing-extension-packages.md#localizing-name-and-description-in-the-windows-store) in this section of the guide if your extension doesn't support multiple languages.
+You can jump to [Localizing name and description for the Microsoft Store](./packaging/localizing-extension-packages.md#localizing-name-and-description-in-the-windows-store) in this section of the guide if your extension doesn't support multiple languages.
 
 ## [Using ManifoldJS to package extensions](./packaging/using-ManifoldJS-to-package-extensions.md)
 
-The tool route for packaging your extension, ManifoldJS will package up your extension in a snap with minimal effort on your end. Provide a few Windows/Windows Store assets after filling out some AppXManifest properties and you're extension will be packaged in no time.
+The tool route for packaging your extension, ManifoldJS will package up your extension in a snap with minimal effort on your end. Provide a few Windows/Microsoft Store assets after filling out some AppXManifest properties and you're extension will be packaged in no time.
 
 Once your extension is packaged, see the [testing](./packaging/creating-and-testing-extension-packages.md#testing-an-appx-package) section of Creating and testing your Microsoft Edge extension to learn how to sideload or unpack it.
 
 
 ## [Running the Windows App Certification Kit](./packaging/running-the-windows-app-certification-kit.md)
 
-Once you have a packaged extension, you can then run it through the Windows App Certification Kit. Doing so will run a number of tests on your extension package to ensure that it's ready for the Windows Store.
+Once you have a packaged extension, you can then run it through the Windows App Certification Kit. Doing so will run a number of tests on your extension package to ensure that it's ready for the Microsoft Store.

--- a/microsoft-edge/extensions/guides/packaging/creating-and-testing-extension-packages.md
+++ b/microsoft-edge/extensions/guides/packaging/creating-and-testing-extension-packages.md
@@ -17,7 +17,7 @@ Microsoft Edge extensions are packaged as AppX, similar to how Universal Windows
 If you already know how Microsoft Edge extension AppXs are created, you can skip to [Using ManifoldJS to package extension](./using-manifoldjs-to-package-extensions.md) to learn how to use a Node.js based tool to do all of this for you!
 
 > [!NOTE]
-> Submitting a Microsoft Edge extension to the Windows Store is currently a restricted capability. Once you've created, packaged and tested your extension, please submit a request on our [extension submission form](http://aka.ms/extension-request).
+> Submitting a Microsoft Edge extension to the Microsoft Store is currently a restricted capability. Once you've created, packaged and tested your extension, please submit a request on our [extension submission form](http://aka.ms/extension-request).
 
 
 
@@ -29,7 +29,7 @@ To prepare your extension for submission, you need to create a folder with the f
 
 At the root of the folder, you should include an AppXManifest.xml file. This file is used to specify the contents and layout of the package.
 
-You should also have an Assets folder which contains the UI assets to be used in the Windows Store, and an Extension folder that contains your extension's files (scripts, icons, etc).
+You should also have an Assets folder which contains the UI assets to be used in the Microsoft Store, and an Extension folder that contains your extension's files (scripts, icons, etc).
 
 >important You can create a different folder structure for your package, but the folder structure must match the AppXManifest values.
 
@@ -156,7 +156,7 @@ Some values in the AppXManifest need to match those that are defined in the JSON
 
 ### Assets folder
 
-Within the Assets folder you will need three different icon sizes. These icons will be used in the Windows Store and the Windows UI. For more information on these icons, see the [Design](./../design.md#icons-for-packaging) guide.
+Within the Assets folder you will need three different icon sizes. These icons will be used in the Microsoft Store and the Windows UI. For more information on these icons, see the [Design](./../design.md#icons-for-packaging) guide.
 
 ![assets folder with three icon sizes in it](./../../media/assets-folder.png)
 
@@ -188,7 +188,7 @@ Copy your extension files (keeping the folder structure) into the Extension fold
 
 
 ### Supporting more than one locale
-If your extension supports more than one language, you may want to configure the AppX package with all the locales that you need so that the correct localized icon and description appear in the Windows Store. See [Localizing extension packages](./localizing-extension-packages.md) for more information.
+If your extension supports more than one language, you may want to configure the AppX package with all the locales that you need so that the correct localized icon and description appear in the Microsoft Store. See [Localizing extension packages](./localizing-extension-packages.md) for more information.
 
 ### Creating an Appx
 
@@ -227,7 +227,7 @@ You can test your Microsoft Edge extension AppX package by sideloading it in Mic
 See [How to create an app package signing certificate](https://msdn.microsoft.com/en-us/library/windows/desktop/jj835832.aspx) and [How to sign an app package using SignTool](https://msdn.microsoft.com/en-us/library/windows/desktop/jj835835.aspx) for info on the signing and certification process for packages.
 
 > [!NOTE]
-> You do not need to sign an extension package before submitting it to the Windows Store; the Store ingestion process will take care of that for you!
+> You do not need to sign an extension package before submitting it to the Microsoft Store; the Store ingestion process will take care of that for you!
 
 After you’ve signed the package with the certificate that you created, the certificate is still not trusted by the local machine for deployment of app packages until you install it into the trusted certificates store of the local computer. You can use Certutil.exe, which comes with Windows to do this.
 

--- a/microsoft-edge/extensions/guides/packaging/extensions-in-the-windows-dev-center.md
+++ b/microsoft-edge/extensions/guides/packaging/extensions-in-the-windows-dev-center.md
@@ -16,7 +16,7 @@ The Windows Dev Center dashboard lets you publish and manage all of your apps fo
 > You will need a [Microsoft account](https://login.live.com/) to sign up for a developer account.
 
 
-###	Multi-users organization account management for Windows Store
+###	Multi-users organization account management for Microsoft Store
 In a large organization, you may assign different roles to different accounts for managing your Microsoft Edge Extension. You can assign different roles [using Azure Active Directory to manage account users](https://msdn.microsoft.com/en-us/windows/uwp/publish/manage-account-users) in your Dev Center account.
 
 For example, you could set up the following structure:
@@ -28,7 +28,7 @@ Each user/group/or Azure AD application is assigned a role that gives them a spe
 
 ###	Name reservation
 
-Reserving a name is the first step towards getting your extension in the Windows Store.
+Reserving a name is the first step towards getting your extension in the Microsoft Store.
 It's recommended that you [reserve the name of your extension](https://msdn.microsoft.com/en-us/windows/uwp/publish/create-your-app-by-reserving-a-name) as soon as possible through the Windows Dev Center dashboard before it gets taken by someone else. You can do this even if you haven’t started building your extension yet.
 
 > [!NOTE]
@@ -38,4 +38,4 @@ It's recommended that you [reserve the name of your extension](https://msdn.micr
 You can also [reserve additional names to use for your extension](https://msdn.microsoft.com/en-us/windows/uwp/publish/manage-app-names), which is especially useful if you are offering the extension in multiple languages and want to use different names for different languages. You can find more information on localization in [Localizing extension packages](./localizing-extension-packages.md).
 
 > [!NOTE]
-> Once you've [reached out to us](http://aka.ms/extension-request) and have been approved to have your extension in the Windows Store, check out the [app submission checklist](https://docs.microsoft.com/windows/uwp/publish/app-submissions).
+> Once you've [reached out to us](http://aka.ms/extension-request) and have been approved to have your extension in the Microsoft Store, check out the [app submission checklist](https://docs.microsoft.com/windows/uwp/publish/app-submissions).

--- a/microsoft-edge/extensions/guides/packaging/localizing-extension-packages.md
+++ b/microsoft-edge/extensions/guides/packaging/localizing-extension-packages.md
@@ -10,15 +10,15 @@ ms.prod: microsoft-edge
 keywords: edge, web development, html, css, javascript, developer
 ---
 
-# Localizing Microsoft Edge extensions for Windows and the Windows Store
+# Localizing Microsoft Edge extensions for Windows and the Microsoft Store
 
-This guide walks through how to localize your Microsoft Edge extension so that it's ready for multiple locales upon release. To fully localize your extension, you'll need to follow the steps for both Windows and the Windows Store.
+This guide walks through how to localize your Microsoft Edge extension so that it's ready for multiple locales upon release. To fully localize your extension, you'll need to follow the steps for both Windows and the Microsoft Store.
 
 If you want to localize your extension resources for Microsoft Edge, you can learn how to use the i18n framework in the [Internationalization guide](../internationalization.md).
 
 
 > [!NOTE]
-> If your extension doesn't support multiple languages, you can skip to [Localizing name and description in the Windows Store](#localizing-name-and-description-in-the-windows-store).
+> If your extension doesn't support multiple languages, you can skip to [Localizing name and description in the Microsoft Store](#localizing-name-and-description-in-the-windows-store).
 
 
 
@@ -26,7 +26,7 @@ If you want to localize your extension resources for Microsoft Edge, you can lea
 
 ## The localization process overview
 
-The first step towards getting your extension available to a wide audience is to [configure its AppxManifest](#configuring-the-appxmanifest) for multiple languages. In the Windows Store, this will show users what languages your extension supports. Certain fields in the AppxManifest will also need to be changed if you want the name of your extension to be [localized in the Windows UI and the Windows Store](#localizing-extension-resources-for-windows-and-the-windows-store).
+The first step towards getting your extension available to a wide audience is to [configure its AppxManifest](#configuring-the-appxmanifest) for multiple languages. In the Microsoft Store, this will show users what languages your extension supports. Certain fields in the AppxManifest will also need to be changed if you want the name of your extension to be [localized in the Windows UI and the Microsoft Store](#localizing-extension-resources-for-windows-and-the-windows-store).
 
 
 Once your AppxManifest is configured, you'll need to [create JSON string resources](#creating-json-string-resources) for the languages that you indicated as supported. This requires creating a .resjson file for each language, where each file has all the UI strings of that language within it.
@@ -35,21 +35,21 @@ Once your AppxManifest is configured, you'll need to [create JSON string resourc
 After the .resjson files for the supported languages have been made, a [.pri resource file will need to be created](#creating-the-resources-file). This will be created by using a configuration file to the **MakePRI** tool that comes with the Windows 10 SDK.
 
 
-Once you've uploaded your extension, the final step is to [localize the name and description in the Windows Store](#localizing-name-and-description-in-the-windows-store).
+Once you've uploaded your extension, the final step is to [localize the name and description in the Microsoft Store](#localizing-name-and-description-in-the-windows-store).
 
 > [!NOTE]
-> Submitting a Microsoft Edge extension to the Windows Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Windows Store, and we’ll consider you for a future update.
+> Submitting a Microsoft Edge extension to the Microsoft Store is currently a restricted capability. [Reach out to us](http://aka.ms/extension-request) with your requests to be a part of the Microsoft Store, and we’ll consider you for a future update.
 
 
 
 ## Configuring the AppXManifest
 
-Your extension's "Supported languages" list in the Windows Store is generated based on its AppXManifest values. This list is specified using the `Resource` element.
+Your extension's "Supported languages" list in the Microsoft Store is generated based on its AppXManifest values. This list is specified using the `Resource` element.
 
 
 ![settings image](./../../media/language-app-details.png)
 
-To specify the list of languages that are supported by your extension, you can add a `Resource` element in the format seen below (this `Resource` element will show support for English, German, and French in the Windows Store):
+To specify the list of languages that are supported by your extension, you can add a `Resource` element in the format seen below (this `Resource` element will show support for English, German, and French in the Microsoft Store):
 ```xml
 <Resources>
     <Resource Language="en-us"/>
@@ -58,7 +58,7 @@ To specify the list of languages that are supported by your extension, you can a
 </Resources>
 ```
 
-See [Supported languages](https://msdn.microsoft.com/windows/uwp/publish/supported-languages) for info on the languages/language codes that the Windows Store supports.
+See [Supported languages](https://msdn.microsoft.com/windows/uwp/publish/supported-languages) for info on the languages/language codes that the Microsoft Store supports.
 
 
 In order to specify localized strings for all publically visible elements in the AppxManifest, you'll have to use a resource identifier in the format of `ms-resource:<resource id>`.
@@ -108,9 +108,9 @@ The snippets below make a complete AppxManifest. The following values should be 
 ```
 
 
-## Localizing extension resources for Windows and the Windows Store
+## Localizing extension resources for Windows and the Microsoft Store
 
-Now that your AppxManifest is configured for multiple languages, there are some key differences you should know between localizing the UI within your extension and localizing your extension for Windows and the Windows Store.
+Now that your AppxManifest is configured for multiple languages, there are some key differences you should know between localizing the UI within your extension and localizing your extension for Windows and the Microsoft Store.
 
 While Microsoft Edge extensions don't run outside of Microsoft Edge, the management of them can occur within Windows. For example, users can manage their extensions in the Settings app:
 
@@ -130,7 +130,7 @@ The name of the extension that shows up in the Settings app in Windows comes fro
 
 The i18n based localization infrastructure that's defined for JavaScript extensions is only applicable within the Microsoft Edge environment.
 
-Outside of Microsoft Edge, within Windows and the Windows Store, the only supported localization framework is based on the Universal Windows Platform (UWP) localization framework.
+Outside of Microsoft Edge, within Windows and the Microsoft Store, the only supported localization framework is based on the Universal Windows Platform (UWP) localization framework.
 
 While we do support JSON based resources for HTML based Windows apps, the schema for the JSON resources doesn't match the one defined for JavaScript extensions.
 
@@ -218,24 +218,24 @@ You should now have one resources.pri file in your root folder:
 ![resources folder](./../../media/resources.png)
 
 
-## Localizing name and description in the Windows Store
+## Localizing name and description in the Microsoft Store
 
 Once you try to upload your complete, localized package, the Windows Dev Center will detect that more than one language is supported and check that you have corresponding localized names and descriptions for each. If any of the localized values are missing, your submission will be blocked until you provide the values.
 
-If you are only interested in providing a localized name and description for the Windows Store (and not Windows), you can do so by [reserving all the localized names for your extension](./extensions-in-the-windows-dev-center.md#name-reservation).
+If you are only interested in providing a localized name and description for the Microsoft Store (and not Windows), you can do so by [reserving all the localized names for your extension](./extensions-in-the-windows-dev-center.md#name-reservation).
 
 
-Once you've reserved additional localized names, you can create an updated submission. In the description section you can manage additional languages for your Windows Store listing:
+Once you've reserved additional localized names, you can create an updated submission. In the description section you can manage additional languages for your Microsoft Store listing:
 
 ![japanese app description](./../../media/manage-description-languages.png)
 
-Once you've selected "Manage additional languages", you'll get to select which languages you want to add to your Windows Store listing. The new language will show up as 'Additional description language' in the "Description" section.
+Once you've selected "Manage additional languages", you'll get to select which languages you want to add to your Microsoft Store listing. The new language will show up as 'Additional description language' in the "Description" section.
 
-You can click on the individual link in the "Description" section to provide a localized name and description, release notes, and visual assets for each language. The description for the Windows Store is not extracted from the AppXManifest. Each localized description needs to be manually entered in the Windows Dev Center:
+You can click on the individual link in the "Description" section to provide a localized name and description, release notes, and visual assets for each language. The description for the Microsoft Store is not extracted from the AppXManifest. Each localized description needs to be manually entered in the Windows Dev Center:
 
 ![japanese app description](./../../media/japanese-app-description.png)
 
-Once the localized descriptions are submitted and the extension is published, anyone accessing a localized page of the extension in the Windows Store will see the following UI:
+Once the localized descriptions are submitted and the extension is published, anyone accessing a localized page of the extension in the Microsoft Store will see the following UI:
 
 ![japanese windows store](./../../media/japanese-windows-store.png)
  

--- a/microsoft-edge/extensions/guides/packaging/running-the-windows-app-certification-kit.md
+++ b/microsoft-edge/extensions/guides/packaging/running-the-windows-app-certification-kit.md
@@ -11,11 +11,11 @@ keywords: edge, web development, html, css, javascript, developer
 
 # Running the Windows App Certification Kit
 
-To improve the chances of your extension getting published to the Windows Store, you'll need to install and run the [Windows App Certification Kit](http://go.microsoft.com/fwlink/p/?LinkID=309666).
-This runs a [series of tests](https://docs.microsoft.com/windows/uwp/debug-test-perf/windows-app-certification-kit-tests) on your extension package to ensure that it's ready for the Windows Store.
+To improve the chances of your extension getting published to the Microsoft Store, you'll need to install and run the [Windows App Certification Kit](http://go.microsoft.com/fwlink/p/?LinkID=309666).
+This runs a [series of tests](https://docs.microsoft.com/windows/uwp/debug-test-perf/windows-app-certification-kit-tests) on your extension package to ensure that it's ready for the Microsoft Store.
 
 > [!NOTE]
-> Submitting a Microsoft Edge extension to the Windows Store is currently a restricted capability. Once you've created, packaged and tested your extension, please submit a request on our [extension submission form](http://aka.ms/extension-request).
+> Submitting a Microsoft Edge extension to the Microsoft Store is currently a restricted capability. Once you've created, packaged and tested your extension, please submit a request on our [extension submission form](http://aka.ms/extension-request).
 
 Before learning about how to use the kit, make sure you meet the following prerequisites: 
 

--- a/microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions.md
+++ b/microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions.md
@@ -12,7 +12,7 @@ keywords: edge, web development, html, css, javascript, developer
 
 # Using ManifoldJS to create extension AppX packages
 
-ManifoldJS is an open source Node.js tool that allows you to quickly and painlessly create a package that you can then use for submission to the Windows Store.
+ManifoldJS is an open source Node.js tool that allows you to quickly and painlessly create a package that you can then use for submission to the Microsoft Store.
 
 If you use native messaging in your extension, you should skip this and go to [Native messaging in Microsoft Edge](../native-messaging.md#creating-an-extension-with-native-messaging) for packaging instruction. 
 
@@ -22,7 +22,7 @@ Before getting started, you will still need to read up on the following articles
 - [Localizing extension packages](./localizing-extension-packages.md)
 
 > [!NOTE]
-> Submitting a Microsoft Edge extension to the Windows Store is currently a restricted capability. Once you've created, packaged and tested your extension, please submit a request on our [extension submission form](http://aka.ms/extension-request).
+> Submitting a Microsoft Edge extension to the Microsoft Store is currently a restricted capability. Once you've created, packaged and tested your extension, please submit a request on our [extension submission form](http://aka.ms/extension-request).
 
 
 ## Installing Node.js and ManifoldJS
@@ -76,7 +76,7 @@ After ManifoldJS has finished running, you'll have a folder with the following c
                     ...
                 ...
 
-The generationInfo.json file is a log produced by running ManifoldJS and won't be included in your extension package. Only the contents of the **manifest** folder will be packaged. Within the manifest folder, the Assets folder contains the images that will be used in the Windows and Windows Store UI, while the Extension folder has the contents of your extension within it.
+The generationInfo.json file is a log produced by running ManifoldJS and won't be included in your extension package. Only the contents of the **manifest** folder will be packaged. Within the manifest folder, the Assets folder contains the images that will be used in the Windows and Microsoft Store UI, while the Extension folder has the contents of your extension within it.
 
 
 Now that you have the correct files, you'll need to edit the generated AppXManifest file within the **manifest** folder. If the extension’s manifest.json file has an internationalized string for the "name" field, once ManifoldJS is run, the most top layer folder’s name will have no underscores and include "MSG".
@@ -90,7 +90,7 @@ will have a manifest folder that lives in `\<CURRENT DIRECTORY>\MSGappName\edgee
 In the AppXManifest file, you'll need to:
  -	Replace the required Identity fields and PublisherDisplayName field as outlined [here](./creating-and-testing-extension-packages.md#app-identity-template-values). Note that if you're only packaging for testing purposes or for enterprise distribution, you can use placeholder values instead of registering for a Windows Dev Center account.
  -	Replace the placeholder icons in the Assets folder with icons for your extension with the same sizes (150x150, 50x50, 44x44) and names. See the [Design](./../design.md#icons-for-packaging) guide for information about where these icons are used.
- - If your extension is localized, follow the entire [Localizing Microsoft Edge extensions](./localizing-extension-packages.md) guide. If it isn't localized, only read the [Localizing name and description in the Windows Store](./localizing-extension-packages.md#localizing-name-and-description-in-the-windows-store) section.
+ - If your extension is localized, follow the entire [Localizing Microsoft Edge extensions](./localizing-extension-packages.md) guide. If it isn't localized, only read the [Localizing name and description in the Microsoft Store](./localizing-extension-packages.md#localizing-name-and-description-in-the-windows-store) section.
 
 Once your appxmanifest.xml file is sorted out, run the following command to create your package:
 
@@ -98,4 +98,4 @@ Once your appxmanifest.xml file is sorted out, run the following command to crea
 
 Your package will now be in the **package** folder located within the edgeextension folder. See Creating and testing extension packages' [testing](./creating-and-testing-extension-packages.md#testing-an-appx-package) section for info on how to sideload your new package.
 
-Once your package has been tested, feel free to submit a request on our [extension submission form](http://aka.ms/extension-request) in order to be considered for publication to the Windows Store.
+Once your package has been tested, feel free to submit a request on our [extension submission form](http://aka.ms/extension-request) in order to be considered for publication to the Microsoft Store.

--- a/microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions.md
+++ b/microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions.md
@@ -90,7 +90,7 @@ will have a manifest folder that lives in `\<CURRENT DIRECTORY>\MSGappName\edgee
 In the AppXManifest file, you'll need to:
  -	Replace the required Identity fields and PublisherDisplayName field as outlined [here](./creating-and-testing-extension-packages.md#app-identity-template-values). Note that if you're only packaging for testing purposes or for enterprise distribution, you can use placeholder values instead of registering for a Windows Dev Center account.
  -	Replace the placeholder icons in the Assets folder with icons for your extension with the same sizes (150x150, 50x50, 44x44) and names. See the [Design](./../design.md#icons-for-packaging) guide for information about where these icons are used.
- - If your extension is localized, follow the entire [Localizing Microsoft Edge extensions](./localizing-extension-packages.md) guide. If it isn't localized, only read the [Localizing name and description in the Microsoft Store](./localizing-extension-packages.md#localizing-name-and-description-in-the-windows-store) section.
+ - If your extension is localized, follow the entire [Localizing Microsoft Edge extensions](./localizing-extension-packages.md) guide. If it isn't localized, only read the [Localizing name and description in the Microsoft Store](./localizing-extension-packages.md#localizing-name-and-description-in-the-microsoft-store) section.
 
 Once your appxmanifest.xml file is sorted out, run the following command to create your package:
 

--- a/microsoft-edge/extensions/microsoft-browser-extension-policy.md
+++ b/microsoft-edge/extensions/microsoft-browser-extension-policy.md
@@ -23,21 +23,21 @@ Software that uses unsupported techniques or practices to extend or modify the b
 
  Microsoft Edge is designed to be secure, reliable, fast and responsive by default, and to ensure that the user is always in control of their experience.  
 
-Microsoft Edge Extensions, available exclusively from the Windows Store, are the **only supported** mechanism to modify the end-user experience of Microsoft Edge, including the browser configuration and the content displayed in the browser.
+Microsoft Edge Extensions, available exclusively from the Microsoft Store, are the **only supported** mechanism to modify the end-user experience of Microsoft Edge, including the browser configuration and the content displayed in the browser.
 
 Any other mechanism that impacts the configuration of Microsoft Edge, or the content that the browser displays, unless explicitly listed in this document is **unsupported**.  
 
 ### Installation, Management, and Removal
 
-All extensions for Microsoft Edge must be deployed from the Windows Store. The installation must be initiated and completed by the user, using only the user experience provided by Microsoft Edge and the Windows Store. Software may refer to the extension in the Windows Store, but may not change the experience of acquiring the extension, or otherwise apply undue influence or false pretenses to the user to make them install the extension.  
+All extensions for Microsoft Edge must be deployed from the Microsoft Store. The installation must be initiated and completed by the user, using only the user experience provided by Microsoft Edge and the Microsoft Store. Software may refer to the extension in the Microsoft Store, but may not change the experience of acquiring the extension, or otherwise apply undue influence or false pretenses to the user to make them install the extension.  
 
 Software may not interfere with the user’s ability to disable, or remove any extension, or modify in any way the extension management user experience of Microsoft Edge.
 
-All extensions must follow the current Windows Store policy for Microsoft Edge extensions.
+All extensions must follow the current Microsoft Store policy for Microsoft Edge extensions.
 
 ### Extension development
 
-An exception to the Windows Store requirement is provided only for developers and testers of in-development extensions. These may be loaded into an instance of Microsoft Edge temporarily with full knowledge of the user, who will be alerted to their presence. Extensions will be disabled automatically if the user does not consent to their ongoing presence.
+An exception to the Microsoft Store requirement is provided only for developers and testers of in-development extensions. These may be loaded into an instance of Microsoft Edge temporarily with full knowledge of the user, who will be alerted to their presence. Extensions will be disabled automatically if the user does not consent to their ongoing presence.
 
 ### Modification of Microsoft Edge settings
 
@@ -81,5 +81,5 @@ Starting with Internet Explorer 11, extensions must be compatible with Enhanced 
 
 #### Change Log 
 - April 2016: Document Published
-- October 2016: Updated for publishing Microsoft Edge extensions to Windows Store 
+- October 2016: Updated for publishing Microsoft Edge extensions to Microsoft Store 
 - August 2017: Clarification for managed devices

--- a/microsoft-edge/extensions/tips-and-tricks.md
+++ b/microsoft-edge/extensions/tips-and-tricks.md
@@ -13,28 +13,28 @@ keywords: edge, web development, html, css, javascript, developer, extensions
 
 Whether you're currently working on a Micrsoft Edge extension or have already published one, the following tips and tricks might come in handy.
 
-## Get a direct link to your extension in the Windows Store
-In the Windows Dev Center dashboard, you can find a direct link to your extension in the Windows Store. This link can be useful for advertising and sharing out your extension.
+## Get a direct link to your extension in the Microsoft Store
+In the Windows Dev Center dashboard, you can find a direct link to your extension in the Microsoft Store. This link can be useful for advertising and sharing out your extension.
 
 
 After logging in to the Windows Dev Center and navigating to your extension through the dashboard, on the App identity page you’ll find the link in the **Store protocol link** row:
 
 ![store protocol link](./media/store-link.png)
  
-## Make sure you’re following the Windows Store Policy
-When creating your extension, make sure you keep in mind the guidelines for submitting to the Windows Store highlighted in the [Windows Store Policy](https://msdn.microsoft.com/library/windows/apps/dn764944.aspx). 
+## Make sure you’re following the Microsoft Store Policy
+When creating your extension, make sure you keep in mind the guidelines for submitting to the Microsoft Store highlighted in the [Microsoft Store Policy](https://msdn.microsoft.com/library/windows/apps/dn764944.aspx). 
  
 Microsoft Edge extensions also have an additional set of policies to follow seen [here](https://msdn.microsoft.com/library/windows/apps/dn764944.aspx#pol_10_12).
 
-## Improve your extension’s discoverability in the Windows Store
+## Improve your extension’s discoverability in the Microsoft Store
 You can add keywords to your extension submission to imporove its discoverability through searches. For example, "Microsoft Edge Extensions" and "name of my extension". 
 
 This can be be done in the Windows Dev Center under the description section of your extension. These keywords will need to be added for every language your extension supports.
 
 ![Submitting a response to a review](./media/keywords.png)
 
-## Automate your submission to the Windows Store
-You can automate and streamline your submissions to the Windows Store by using the new Windows Store Submission API, which allows you to update apps/games, add-ons (in-app purchases), and package flights through a REST API. Check out the [documentation and samples](https://docs.microsoft.com/windows/uwp/monetize/create-and-manage-submissions-using-windows-store-services) or use the open source [Submission API VSTS extension](https://github.com/Microsoft/windows-dev-center-vsts-extension) to get started.
+## Automate your submission to the Microsoft Store
+You can automate and streamline your submissions to the Microsoft Store by using the new Microsoft Store Submission API, which allows you to update apps/games, add-ons (in-app purchases), and package flights through a REST API. Check out the [documentation and samples](https://docs.microsoft.com/windows/uwp/monetize/create-and-manage-submissions-using-windows-store-services) or use the open source [Submission API VSTS extension](https://github.com/Microsoft/windows-dev-center-vsts-extension) to get started.
 
 ## Use the Windows Feedback Hub to gather feedback/reviews/feature requests
 
@@ -45,9 +45,9 @@ You can direct users to the Windows Feedback Hub subcategory for your extension 
 You will need to substitute `<PFN>` with the Package Family Name of you extension. This can be found under the **App identity** section for your extension in the Windows Dev Center.
 
 ## Check out your ratings and reviews
-Log in regularly to check your user reviews and ratings. While the Windows Store app will only have info on the current user market, logging into the Windows Dev Center will display average rating across all markets.
+Log in regularly to check your user reviews and ratings. While the UWP app will only have info on the current user market, logging into the Windows Dev Center will display average rating across all markets.
 
 ## Respond to user reviews
-You can respond to user reviews in the Windows Store through the Windows Dev Center's dashboard. Navigate to your extension and under Analytics select **Reviews**. A link will appear underneath each review that will allow you to respond directly to the customer. This channel of communication enables you to offer feedback, resolutions, or send a thank you for the review!
+You can respond to user reviews in the Microsoft Store through the Windows Dev Center's dashboard. Navigate to your extension and under Analytics select **Reviews**. A link will appear underneath each review that will allow you to respond directly to the customer. This channel of communication enables you to offer feedback, resolutions, or send a thank you for the review!
 
 ![Submitting a response to a review](./media/reviews.png)

--- a/microsoft-edge/extensions/troubleshooting.md
+++ b/microsoft-edge/extensions/troubleshooting.md
@@ -39,7 +39,7 @@ Unspecified error: `<error>` | Generic catch-all error message. `<error>` will b
 
 
 ## 2. I don't see the "Load extension" button
-Until extensions are available via the Windows Store, this button *should* be visible by default. If you open the "More" (...) menu, select the "Extensions" menu item and don't see the button, follow these steps:
+Until extensions are available via the Microsoft Store, this button *should* be visible by default. If you open the "More" (...) menu, select the "Extensions" menu item and don't see the button, follow these steps:
 
 1. In the address bar type **"about:flags"** and press the **"Enter"** key.
 2. Under the heading **"Developer settings"** make sure the checkbox next to **"Enable extension developer features"** is selected.


### PR DESCRIPTION
On 10/26, the Windows Store is changing its name to the Microsoft Store.  To prepare for the name change, I’ve made these changes :

•	Windows Store -> Microsoft Store
•	Windows Store app -> UWP app
•	Xbox Store -> Microsoft Store
