### PR TITLE
Incorrect documentation for MSApp.createFileFromStorageFile

### DIFF
--- a/microsoft-edge/windows-runtime/reference/msapp.md
+++ b/microsoft-edge/windows-runtime/reference/msapp.md
@@ -136,7 +136,7 @@ The returned data package for the selection contains HTML markup in clipboard fo
 There are no available properties for the returned data package.
  
 ### createFileFromStorageFile 
-Converts a standard W3C [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) object to the [WinRT](https://docs.microsoft.com/en-us/uwp/api/) equivalent [`StorageFile`](https://docs.microsoft.com/en-us/uwp/api/windows.storage.storagefile).
+Converts a [WinRT](https://docs.microsoft.com/en-us/uwp/api/) [`StorageFile`](https://docs.microsoft.com/en-us/uwp/api/windows.storage.storagefile) to a standard W3C [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) object.
 
 ```javascript
 var retVal = MSApp.createFileFromStorageFile(storageFile); 


### PR DESCRIPTION
This documentation has been wrong for many years. The description of the function states the reverse of what the function actually does (as is obvious from the function's name). See https://stackoverflow.com/questions/16824415/how-to-get-a-standard-javascript-file-api-object-using-the-windows-storage-fileo from 2013 showing how long this has been incorrect (at least).

Details: The documentation states: "Converts a standard W3C File object to the WinRT equivalent StorageFile." Clearly, it should be: "Converts a WinRT StorageFile to a standard W3C File object".