### PR TITLE
Added JavaScript samples since Selenium Tools now available via npm

### DIFF
--- a/microsoft-edge/webdriver-chromium.md
+++ b/microsoft-edge/webdriver-chromium.md
@@ -3,7 +3,7 @@ description: Learn how to test your website or app in Microsoft Edge or automate
 title: WebDriver (Chromium)
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: 05/18/2020
+ms.date: 05/20/2020
 ms.topic: article
 ms.prod: microsoft-edge
 ms.technology: devtools
@@ -88,7 +88,7 @@ var driver = new EdgeDriver();
 driver = Edge()
 ```  
 
-#### [JavaScript](#tab/javascript/)
+#### [JavaScript](#tab/javascript/)  
 
 <a id="basic-usage-code" />  
 
@@ -218,14 +218,14 @@ driver = Edge(service_args = service_args)
 
 <a id="customizing-microsoft-edge-driver-services-code" />  
 
-When using JavaScript, create and configure a `Service` with the `ServiceBuilder` class. You may optionally pass this `Service` object to the `Driver` object which will start and stop the service for you.
+When using JavaScript, create and configure a `Service` with the `ServiceBuilder` class.  You may optionally pass the `Service` object to the `Driver` object which starts and stops the service for you.  
 
-To configure the `Service`, run additional methods within the `ServiceBuilder` class before calling the `build()` method and then pass the service as a parameter in the `Driver.createSession()` method.
+To configure the `Service`, run additional methods in the `ServiceBuilder` class before using the `build()` method and  then pass the `service` as a parameter in the `Driver.createSession()` method.  
 
 ```javascript
 let service = new edge.ServiceBuilder().enableVerboseLogging().build();
 let driver = edge.Driver.createSession(options, service);
-```
+```  
 
 * * *  
 

--- a/microsoft-edge/webdriver-chromium.md
+++ b/microsoft-edge/webdriver-chromium.md
@@ -88,6 +88,14 @@ var driver = new EdgeDriver();
 driver = Edge()
 ```  
 
+#### [JavaScript](#tab/javascript/)
+
+<a id="basic-usage-code" />  
+
+```javascript
+let driver = edge.Driver.createSession();
+```  
+
 * * *  
 
 ### Driving Microsoft Edge (Chromium)  
@@ -96,7 +104,7 @@ To use with Microsoft Edge \(Chromium\) instead, create a new `EdgeDriver` class
 
 #### [C#](#tab/c-sharp/)  
 
-<a id="diving-microsoft-edge-chromium-code" />  
+<a id="driving-microsoft-edge-chromium-code" />  
 
 ```csharp
 var options = new EdgeOptions();
@@ -107,13 +115,24 @@ var driver = new EdgeDriver(options);
 
 #### [Python](#tab/python/)  
 
-<a id="diving-microsoft-edge-chromium-code" />  
+<a id="driving-microsoft-edge-chromium-code" />  
 
 ```python
 options = EdgeOptions()
 options.use_chromium = True
 
 driver = Edge(options)
+```  
+
+#### [JavaScript](#tab/javascript/)  
+
+<a id="driving-microsoft-edge-chromium-code" />  
+
+```javascript
+let options = new edge.Options();
+options.setEdgeChromium(true);
+
+let driver = edge.Driver.createSession(options);
 ```  
 
 * * *  
@@ -144,6 +163,18 @@ options.use_chromium = True
 options.binary_location = r"C:\Program Files (x86)\Microsoft\Edge Beta\Application\msedge.exe"
 
 driver = Edge(options)
+```  
+
+#### [JavaScript](#tab/javascript/)  
+
+<a id="choosing-specific-browser-binaries-chrome-only-code" />  
+
+```javascript
+let options = new edge.Options();
+options.setEdgeChromium(true);
+options.setBinaryPath("C:\Program Files (x86)\Microsoft\Edge Beta\Application\msedge.exe");
+
+let driver = edge.Driver.createSession(options);
 ```  
 
 * * *  
@@ -183,6 +214,19 @@ service_args = ['--verbose']
 driver = Edge(service_args = service_args)
 ```  
 
+#### [JavaScript](#tab/javascript/)  
+
+<a id="customizing-microsoft-edge-driver-services-code" />  
+
+When using JavaScript, the `edge` object has a `ServiceBuilder` method that returns a `service` you may optionally pass to the `edge.driver` object, which creates and starts the service for you. 
+
+To configure the `EdgeService`, run additional methods within `edge.ServiceBuilder()` before calling the `build()` method and then pass the service as a parameter in the `edge.Driver.createSession()` method.
+
+```javascript
+let service = new edge.ServiceBuilder().enableVerboseLogging().build();
+let driver = edge.Driver.createSession(options, service);
+```
+
 * * *  
 
 ### Using Chromium-Specific Options  
@@ -207,10 +251,20 @@ options.AddArgument("disable-gpu");
 ```python
 options = EdgeOptions()
 options.use_chromium = True
-options.add_argument('headless')
-options.add_argument('disable-gpu')
+options.add_argument("headless")
+options.add_argument("disable-gpu")
 ```  
 
+#### [JavaScript](#tab/javascript/)  
+
+<a id="using-chromium-specific-options-code" />  
+
+```javascript
+let options = new edge.Options();
+options.setEdgeChromium(true);
+options.addArguments("headless");
+options.addArguments("disable-gpu");
+```
 * * *  
 
 > [!NOTE]

--- a/microsoft-edge/webdriver-chromium.md
+++ b/microsoft-edge/webdriver-chromium.md
@@ -218,9 +218,9 @@ driver = Edge(service_args = service_args)
 
 <a id="customizing-microsoft-edge-driver-services-code" />  
 
-When using JavaScript, the `edge` object has a `ServiceBuilder` method that returns a `service` you may optionally pass to the `edge.driver` object, which creates and starts the service for you. 
+When using JavaScript, create and configure a `Service` with the `ServiceBuilder` class. You may optionally pass this `Service` object to the `Driver` object which will start and stop the service for you.
 
-To configure the `EdgeService`, run additional methods within `edge.ServiceBuilder()` before calling the `build()` method and then pass the service as a parameter in the `edge.Driver.createSession()` method.
+To configure the `Service`, run additional methods within the `ServiceBuilder` class before calling the `build()` method and then pass the service as a parameter in the `Driver.createSession()` method.
 
 ```javascript
 let service = new edge.ServiceBuilder().enableVerboseLogging().build();


### PR DESCRIPTION
Preview link here: https://review.docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium?branch=user%2Fzoghadya%2Fselenium-tools-js-update&tabs=javascript#use-microsoft-edge-chromium-with-webdriver

This PR adds JavaScipt code snippets to our WebDriver (Chromium) doc since the Selenium Tools for Microsoft Edge are now available for JavaScript via npm. The package is available here: https://www.npmjs.com/package/@microsoft/edge-selenium-tools and I tested these samples with the following snippet: 

```javascript
const edge = require("@microsoft/edge-selenium-tools");
const {By, Key, until} = require('selenium-webdriver');

(async function example() {
    let options = new edge.Options().setEdgeChromium(true)
    options.setBinaryPath("C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe");
    // options.addArguments("headless");
    // options.addArguments("disable-gpu");
    let service = new edge.ServiceBuilder("C:\\Users\\zoghadya\\Documents\\My_Apps\\DevTools-todomvc\\tests\\edgedriver_win64\\msedgedriver.exe").enableVerboseLogging().build();

    let driver = edge.Driver.createSession(options, service);
    try {
        await driver.get('http://www.google.com/');
        await driver.findElement(By.name('q')).sendKeys('webdriver', Key.RETURN);
        let condition = until.titleIs('webdriver - Google Search');
        await driver.wait(async driver => condition.fn(driver), 10000, 'Loading failed.');
    }
    finally {
        await driver.quit();
        await service.kill();
    }
})();
```