### PR TITLE
Remove additional closing tag for window element

### DIFF
--- a/microsoft-edge/webview2/gettingstarted/wpf.md
+++ b/microsoft-edge/webview2/gettingstarted/wpf.md
@@ -102,7 +102,7 @@ Next add a WebView to your application.
             Title="MainWindow"
             Height="450"
             Width="800"
-    />
+    >
         <Grid>
         
         </Grid>


### PR DESCRIPTION
There is an additional closing tag for the `window` element that fails the project to start on Visual Studio. This PR is to fix the same.