### PR TITLE
Minor wording fixes for Service Worker tooling

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/service-workers/index.md
+++ b/microsoft-edge/devtools-guide-chromium/service-workers/index.md
@@ -10,7 +10,7 @@ keywords: microsoft edge, web development, f12 tools, devtools, service worker, 
 ---
 # Service Worker improvements  
 
-This article teaches you about improvements to [service workers][MdnServiceWorkerApi] and the network requests that pass through each one.  The **service worker improvements** are in the **Network**, **Application**, and **Sources** tools.  The improvements include the following tasks.  
+This article teaches you about improvements to developer tools for working with [service workers][MdnServiceWorkerApi] and the network requests that pass through each one.  The **service worker improvements** are in the **Network**, **Application**, and **Sources** tools.  The improvements simplify the following tasks.  
 
 *   Debug based on Service Worker timelines.  
     *   The start of a request and duration of the bootstrap.  


### PR DESCRIPTION
> improvements to service workers

The improvements specified are to tooling, not service workers themselves.

> The improvements include the following tasks

The improvements make the tasks easier, they don't "include" them