### PR TITLE
Fixes caption on screenshot

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/customize/localization.md
+++ b/microsoft-edge/devtools-guide-chromium/customize/localization.md
@@ -53,8 +53,8 @@ Your Developer Tools matches your browser language by default, if it is one of t
    :::column-end:::
 :::row-end:::  
 
-:::image type="complex" source="../media/localization-jp.msft.png" alt-text="DevTools in Japanese" lightbox="../media/localization-jp.msft.png":::
-   DevTools in Japanese  
+:::image type="complex" source="../media/localization-jp.msft.png" alt-text="DevTools in Chinese" lightbox="../media/localization-jp.msft.png":::
+   DevTools in Chinese  
 :::image-end:::  
 
 If you want to revert DevTools to English, navigate to [DevTools Settings][DevtoolsCustomizeIndexSettings] or select `F1`, choose **Preferences**, and turn off the **Match browser language** checkbox.  


### PR DESCRIPTION
Screenshot was miscaptioned: It should be "DevTools in Chinese."