### PR TITLE
WebView2: Add WinRT reference entry point

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -500,7 +500,13 @@
               items:
                 - name: Microsoft.Web.WebView2.Core
                   href: /dotnet/api/microsoft.web.webview2.core
-                - name: Microsoft.Web.WebView2.WPF
+                - name: Microsoft.Web.WebView2.Wpf
                   href: /dotnet/api/microsoft.web.webview2.wpf
                 - name: Microsoft.Web.WebView2.WinForms
                   href: /dotnet/api/microsoft.web.webview2.winforms
+            - name: WinRT
+              items:
+                - name: Microsoft.Web.WebView2.Core
+                  href: /microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index
+                - name: COM Interop
+                  href: /microsoft-edge/webview2/reference/winrt/interop/index

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -3,7 +3,7 @@ description: API Reference for Microsoft Edge WebView2 SDK
 title: Microsoft Edge WebView2 API Reference
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: 05/06/2021
+ms.date: 08/16/2021
 ms.topic: reference
 ms.prod: microsoft-edge
 ms.technology: webview
@@ -22,9 +22,14 @@ Select the Languages and Framework of WebView2 you would like to use form the fo
     *   [Core][DotnetMicrosoftWebWebView2CoreNamespace]  
     *   [WPF][DotnetMicrosoftWebWebView2WpfNamespace]  
     *   [Windows Forms][DotnetMicrosoftWebWebView2WinformsNamespace]  
-        
+*   WinRT  
+    *   [Core][WinrtMicrosoftWebWebview2CoreNamespace]  
+    *   [COM Interop][DotnetMicrosoftWebWebView2CoreNamespace]  
+
 <!-- links -->  
 
 [DotnetMicrosoftWebWebview2CoreNamespace]: /dotnet/api/microsoft.web.webview2.core "Microsoft.Web.WebView2.Core Namespace | Microsoft Docs"
 [DotnetMicrosoftWebWebview2WpfNamespace]: /dotnet/api/microsoft.web.webview2.wpf "Microsoft.Web.WebView2.Wpf Namespace | Microsoft Docs"
 [DotnetMicrosoftWebWebview2WinformsNamespace]: /dotnet/api/microsoft.web.webview2.winforms "Microsoft.Web.WebView2.WinForms Namespace | Microsoft Docs"
+[WinrtMicrosoftWebWebview2CoreNamespace]: /microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index "Microsoft.Web.WebView2.Core Namespace | Microsoft Docs"
+[WinrtComInteropInterfaces]: /microsoft-edge/webview2/reference/winrt/interop/index "WebView2 WinRT COM Interop Reference | Microsoft Docs"

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -13,7 +13,7 @@ keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edg
 
 The Microsoft Edge WebView2 control enables you to host web content in your application using [Microsoft Edge (Chromium)](https://www.microsoftedgeinsider.com) as the rendering engine.  For more information, navigate to [Overview of Microsoft Edge WebView2](./index.md) and [Get Started with WebView2](./get-started/win32.md).  
 
-Select the Languages and Framework of WebView2 you would like to use form the following list.  
+Select the Languages and Framework of WebView2 you would like to use from the following list.  
 
 ## Languages and Frameworks  
 

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -24,7 +24,7 @@ Select the Languages and Framework of WebView2 you would like to use form the fo
     *   [Windows Forms][DotnetMicrosoftWebWebView2WinformsNamespace]  
 *   WinRT  
     *   [Core][WinrtMicrosoftWebWebview2CoreNamespace]  
-    *   [COM Interop][DotnetMicrosoftWebWebView2CoreNamespace]  
+    *   [COM Interop][WinrtComInteropInterfaces]  
 
 <!-- links -->  
 

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -13,10 +13,9 @@ keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edg
 
 The Microsoft Edge WebView2 control enables you to host web content in your application using [Microsoft Edge (Chromium)](https://www.microsoftedgeinsider.com) as the rendering engine.  For more information, navigate to [Overview of Microsoft Edge WebView2](./index.md) and [Get Started with WebView2](./get-started/win32.md).  
 
-Select the Languages and Framework of WebView2 you would like to use from the following list.  
 
 ## Languages and Frameworks  
-
+WebView2 is available for the following languages and frameworks.
 *   [Win32 C++](/microsoft-edge/webview2/reference/win32/index)  
 *   .NET  
     *   [Core][DotnetMicrosoftWebWebView2CoreNamespace]  


### PR DESCRIPTION
Add [WebView2 WinRT reference content](/MicrosoftDocs/webview2-winrt-reference.git) entry points to WebView2 conceptual repo. This is for WinUI2+WebView2 preview on the week of 8/16.

COM Interop: https://docs.microsoft.com/microsoft-edge/webview2/reference/winrt/interop/
Core DLL: https://docs.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/