### PR TITLE
wv2: Fixed subheading "Registry override: release channel preference"

### DIFF
--- a/microsoft-edge/webview2/how-to/set-preview-channel.md
+++ b/microsoft-edge/webview2/how-to/set-preview-channel.md
@@ -196,7 +196,7 @@ To undo the above setting, run the following command:
 
 `REG DELETE HKLM\Software\Policies\Microsoft\Edge\WebView2\BrowserExecutableFolder /f`
 
-### Registry override: browser executable folder
+### Registry override: release channel preference
 
 To make your application use a Microsoft Edge preview channel by using a registry override that changes the release channel preference by changing the order of searching for a channel:
 


### PR DESCRIPTION
Fixes https://github.com/MicrosoftDocs/edge-developer/issues/1411