### PR TITLE
Removed unnecessary refs to old edge versions from webdriver doc

### DIFF
--- a/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
+++ b/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
@@ -11,7 +11,7 @@ keywords: microsoft edge, web development, html, css, javascript, developer, web
 ---
 # Capabilities and EdgeOptions  
 
-Capabilities are options that you may use to customize and configure an `EdgeDriver` session.  To learn about starting a new `EdgeDriver` session, navigate to [Automating Microsoft Edge][WebdriverIndexAutomateMicrosoftEdgeChromium].  This article describes all supported capabilities for [Microsoft Edge][WebdriverIndexInstallMicrosoftEdgeChromium] and details on passing the capabilities to `EdgeDriver` sessions.  
+Capabilities are options that you may use to customize and configure an `EdgeDriver` session.  To learn about starting a new `EdgeDriver` session, navigate to [Automating Microsoft Edge][WebdriverIndexAutomateMicrosoftEdgeChromium].  This article describes all supported capabilities for Microsoft Edge and details on passing the capabilities to `EdgeDriver` sessions.  
 
 Capabilities are passed to a WebDriver session as a JSON map.  A WebDriver testing framework provides a WebDriver language binding.  WebDriver language bindings typically provide type-safe convenience methods so you don't need to configure the JSON map yourself.  Different WebDriver language bindings use different mechanisms to configure capabilities.  [Selenium][SeleniumMain] configures capabilities through the `EdgeOptions` class.
 
@@ -85,7 +85,6 @@ The following list contains all of the Microsoft Edge-specific capabilities that
 [DevtoolsRemoteDebuggingWindows]: ../devtools-guide-chromium/remote-debugging/windows.md "Get started with Remote Debugging Windows 10 devices | Microsoft Docs"  
 [WebdriverIndexChooseAWebdriverTestingFramework]: ./index.md#choose-a-webdriver-testing-framework "Choose a WebDriver testing framework - Use WebDriver (Chromium) for test automation | Microsoft Docs"
 [WebdriverIndexAutomateMicrosoftEdgeChromium]: ./index.md#automate-microsoft-edge-chromium "Automate Microsoft Edge (Chromium) - WebDriver (Chromium) | Microsoft Docs"    
-[WebdriverIndexInstallMicrosoftEdgeChromium]: ./index.md#install-microsoft-edge-chromium "Install Microsoft Edge (Chromium) - WebDriver (Chromium) | Microsoft Docs"  
 <!-- external links -->
 [SeleniumMain]: https://www.selenium.dev "SeleniumHQ Browser Automation"  
 [SharedCapabilitiesSeleniumDocumentation]: https://www.selenium.dev/documentation/en/driver_idiosyncrasies/shared_capabilities/ "Shared capabilities | Selenium Documentation"   

--- a/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
+++ b/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
@@ -11,7 +11,8 @@ keywords: microsoft edge, web development, html, css, javascript, developer, web
 ---
 # Capabilities and EdgeOptions  
 
-Capabilities are options that you may use to customize and configure an `EdgeDriver` session.  To learn about starting a new `EdgeDriver` session, navigate to [Automating Microsoft Edge][WebdriverIndexAutomateMicrosoftEdgeChromium].  This article describes all supported capabilities for Microsoft Edge and details on passing the capabilities to `EdgeDriver` sessions.  
+Capabilities are options that you can use to customize and configure an `EdgeDriver` session.  To learn about starting a new `EdgeDriver` session, navigate to [Automating Microsoft Edge][WebdriverIndexAutomateMicrosoftEdgeChromium].  This article describes all supported capabilities for Microsoft Edge and provides details about passing the capabilities to `EdgeDriver` sessions.  
+
 
 Capabilities are passed to a WebDriver session as a JSON map.  A WebDriver testing framework provides a WebDriver language binding.  WebDriver language bindings typically provide type-safe convenience methods so you don't need to configure the JSON map yourself.  Different WebDriver language bindings use different mechanisms to configure capabilities.  [Selenium][SeleniumMain] configures capabilities through the `EdgeOptions` class.
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -39,11 +39,6 @@ The functional relationship between these components is as follows.
 The following sections describe how to get started with WebDriver for Microsoft Edge \(Chromium\).  
 
 
-## Install Microsoft Edge (Chromium)  
-
-Ensure you install [Microsoft Edge (Chromium)][MicrosoftEdge].  To confirm that you have Microsoft Edge \(Chromium\) installed, navigate to `edge://settings/help`, and verify that the version number is 75 or later.
-
-
 ## Download Microsoft Edge Driver
 
 To begin automating tests, use the following steps to ensure that the WebDriver version you install matches your browser version.  
@@ -73,10 +68,7 @@ This article provides instructions for using the Selenium framework, but you can
 
 If you are using Selenium, the Microsoft Edge team recommends [Selenium 4.0.0-beta2][NugetPackagesSeleniumWebdriver400beta02] or later, because that version of Selenium supports Microsoft Edge \(Chromium\).  However, you can control Microsoft Edge \(Chromium\) in all older versions of Selenium, including the current stable Selenium 3 release.  
 
-> [!IMPORTANT]
-> If you previously automated or tested Microsoft Edge \(Chromium\) using `ChromeDriver` and `ChromeOptions` classes, your WebDriver code does not run on Microsoft Edge Version 80 or later.  To solve the problem, update your tests to use the `EdgeOptions` class and download [Microsoft Edge Driver][MicrosoftDeveloperMicrosoftEdgeToolsWebdriver].  
-
-### Using Selenium 4
+### Using Selenium 4  
 
 The Selenium WebDriver testing framework can be used on any platform, and is available for Java, Python, C#, Ruby, and JavaScript.
 


### PR DESCRIPTION
This removes a couple of old Edge version references from our webdriver docs, as discussed with @bwalderman on #1427.