### PR TITLE
Quick fix to client hint brand detection snippet

### DIFF
--- a/microsoft-edge/web-platform/user-agent-guidance.md
+++ b/microsoft-edge/web-platform/user-agent-guidance.md
@@ -120,7 +120,7 @@ Use this method to verify the `Chromium` brand and apply detection to all affect
 
 ```javascript
 function isChromium() {
-    for (brand_version_pair in navigator.userAgentData.brands) {
+    for (brand_version_pair of navigator.userAgentData.brands) {
         if (brand_version_pair.brand == "Chromium"){
             return true;
         }


### PR DESCRIPTION
Just a typo fix in a code snippet to address issue #1425.
The code was iterating over an array but was using `for..in` instead of `for..of`.