### PR TITLE
Updated hub page and TOC to match landing page cards

### DIFF
--- a/microsoft-edge/accessibility/build/aria-and-ui-automation.md
+++ b/microsoft-edge/accessibility/build/aria-and-ui-automation.md
@@ -1,7 +1,7 @@
 ---
 ms.assetid: ffd1bc60-2ef1-4f11-8156-b63544cede77
 description: Learn how Microsoft Edge can recognize ARIA info, then expose it to assistive technologies that can then use Microsoft UI Automation APIs.
-title: Accessibility - ARIA and UI automation
+title: ARIA and UI automation in Microsoft Edge
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 03/05/2020
@@ -11,7 +11,7 @@ keywords: accessibility, accessibility for developers, accessible websites, edge
 ms.custom: seodec18
 ---
 
-# ARIA and UI Automation in Microsoft Edge
+# ARIA and UI automation in Microsoft Edge
 
 The W3C defines Accessible Rich Internet Applications (ARIA) as a syntax for making dynamic web content and custom UI accessible. Microsoft Edge recognizes the ARIA role, state, and property information and exposes it to assistive technologies, which in turn can use the [Microsoft UI Automation](https://blogs.msdn.microsoft.com/winuiautomation/) APIs to retrieve the information.
 

--- a/microsoft-edge/accessibility/build/aria-and-ui-automation.md
+++ b/microsoft-edge/accessibility/build/aria-and-ui-automation.md
@@ -13,7 +13,7 @@ ms.custom: seodec18
 
 # ARIA and UI automation in Microsoft Edge
 
-The W3C defines Accessible Rich Internet Applications (ARIA) as a syntax for making dynamic web content and custom UI accessible. Microsoft Edge recognizes the ARIA role, state, and property information and exposes it to assistive technologies, which in turn can use the [Microsoft UI Automation](https://blogs.msdn.microsoft.com/winuiautomation/) APIs to retrieve the information.
+The W3C defines Accessible Rich Internet Applications (ARIA) as a syntax for making dynamic web content and custom UI accessible. Microsoft Edge recognizes the ARIA role, state, and property information and exposes it to assistive technologies, which in turn can use the [Microsoft UI Automation](https://blogs.msdn.microsoft.com/winuiautomation/) APIs to retrieve the information. 
 
 Visit [HTML5Accessibility](https://html5accessibility.com) for information on which new HTML5 features are accessibly supported by Microsoft Edge.
 

--- a/microsoft-edge/accessibility/build/index.md
+++ b/microsoft-edge/accessibility/build/index.md
@@ -1,7 +1,7 @@
 ---
 ms.assetid: 1b3ebc25-d023-4f23-bbba-dce066c20de8
-description: Walk through how best practices and Accessible Rich Internet Applications (ARIA) can come together to create an accessible website.
-title: Build | Accessibility
+description: How best practices and Accessible Rich Internet Applications (ARIA) can come together to create an accessible website.
+title: Building accessible websites
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 05/11/2021
@@ -10,17 +10,17 @@ ms.prod: microsoft-edge
 keywords: accessibility, accessibility for developers, accessible websites, edge, web development, ARIA, developer, UIA, UI Automation
 ms.custom: seodec18
 ---
-# Building Accessible Websites  
+# Building accessible websites
 
 The web is filled with dynamic and complex websites, applications, and user interfaces built using a combination of HTML, CSS, and JavaScript.  However, when designed and built without accessibility in mind, these complex websites are difficult to use by people who rely on [assistive technologies](https://webaim.org/articles/motor/assistive) to browse the web.  Building websites that are accessible to people with disabilities requires semantic information about the user interface.  This allows for assistive technologies, like screen readers, to convey the necessary information to help people with a range of abilities use the website.  
 
 Visit [HTML5Accessibility](https://html5accessibility.com) for information on which new HTML5 features are accessibly supported by Microsoft Edge.  
 
-## How Accessibility Works  
+## How accessibility works  
 
 Assistive technologies add capabilities that computers don't usually have.  For example, a visually impaired user might use their keyboard in combination with assistive technology such as a screen reader, rather than directly using the browser with the mouse and screen.  For applications on Microsoft platforms and on the web, the assistive technology interacts with Microsoft [UI Automation](/windows/win32/winauto/uiauto-specandcommunitypromise), an application-specific object model such as the Document Object Model \(DOM\) in Microsoft Edge, or a combination of these.  
 
-For web developers, certain HTML elements are mapped to UI Automation objects, so in selecting those HTML elements, the developer can use the accessibility properties and events built in to those elements.  While developing your website, you usually only need to be concerned with ensuring that the API is correctly written to \(or that the appropriate element is specified\), in order for the application to be accessible.  Check out [ARIA and UI Automation in Microsoft Edge](./aria-and-ui-automation.md) for more information.  For information on accessible Universal Windows Platform \(UWP\) apps, navigate to the [Accessibility](/windows/uwp/design/accessibility/accessibility) topic in the Windows Dev Center.  
+For web developers, certain HTML elements are mapped to UI Automation objects, so in selecting those HTML elements, the developer can use the accessibility properties and events built in to those elements.  While developing your website, you usually only need to be concerned with ensuring that the API is correctly written to \(or that the appropriate element is specified\), in order for the application to be accessible.  Check out [ARIA and UI automation in Microsoft Edge](./aria-and-ui-automation.md) for more information.  For information on accessible Universal Windows Platform \(UWP\) apps, navigate to the [Accessibility](/windows/uwp/design/accessibility/accessibility) topic in the Windows Dev Center.  
 
 Many common accessibility issues with dynamic content can be addressed by good coding practice, and the [WCAG 2.0](https://www.w3.org/TR/WCAG20) documentation includes many techniques and best practices to help you create more accessible dynamic web applications.  Even when coded properly, however, dynamic content is not necessarily accessible.  [Accessible Rich Internet Applications (ARIA)](#aria) helps overcome this issue.  
 
@@ -30,7 +30,7 @@ For more information on web accessibility, check out the [Introduction to Web Ac
 
 The [Accessible Rich Internet Applications (ARIA)](https://www.w3.org/TR/wai-aria) specification by the W3C's [Web Accessibility Initiative](https://www.w3.org/WAI) defines as a syntax for making dynamic web content and custom user interfaces accessible to all people.  ARIA extends HTML by using additional attributes \(roles, properties, and states\) that are designed to convey custom semantics.  These attributes are used by browsers to pass along the controls' state and role to the accessibility API.  
 
-### Roles, Properties, and States  
+### Roles, properties, and states  
 
 ARIA roles are set on elements using the [role](https://developer.mozilla.org/docs/Web/HTML/Reference) attribute to give assistive technologies and accessibility APIs information about the element.  For example, the below `<li>` element is assigned `role="menuitem"` to signify it's an item in a menu.  
 
@@ -54,7 +54,7 @@ Go to [The Roles Model](https://www.w3.org/TR/wai-aria-1.1#roles) by the W3C to 
 
 For more information on ARIA, navigate to ARIA in the [Resources](#resources) section.  
 
-## Assistive Technology Compatibility Testing  
+## Assistive technology compatibility testing  
 
 Verifying that the website you are building works with real assistive technologies is the best way to ensure a good experience for your users with disabilities.  Since many assistive technologies make use of the keyboard, testing the keyboard accessibility of your website is a good place to start.  [Keyboard compatibility testing][W3cPerspectiveVideosKeyboard] validates that users have access to all interactive controls without requiring a mouse.  Microsoft [Accessibility Insights for Web][AccessibilityinsightsWebOverview] is a browser extension for Microsoft Edge and Chrome that guides you and reveals several common issues.  
 
@@ -67,17 +67,17 @@ Different browsers may map elements to platform accessibility APIs differently t
 
 WebAIM conducts surveys with [screen reader][WebaimProjectsScreenreadersurvey8] and [low vision][WebaimProjectsLowvisionsurvey2] users that help you decide which assistive technologies and browsers you want to test.  
 
-### Learning How to Test  
+### Learning how to test  
 
 Assistive technologies are sophisticated tools.  Do not assume that you are able to immediately start testing with an assistive technology without first learning about how it works.  Learning to test with a screen reader has an especially steep learning curve.  A novice screen reader user may assume that a screen reader bug has occurred while the issue is related to misuse of the screen reader.  
 
 For more information about learning to test with assistive technologies, navigate to [Testing with Screen Readers][WebaimArticlesScreenreaderTesting] on WebAIM.  
 
-### Testing Locally  
+### Testing locally  
 
 Most devices include assistive technology that is built-in to the OS.  Microsoft Windows includes the [Windows Narrator][MicrosoftSupport22798] screen reader and [Windows Magnifier][MicrosoftSupportWindows414948ba8b1cD3bd86150e5e32204198].  3rd party assistive technologies like [NVDA][NvaccessAboutNvda], [FreedomscientificSoftwareJaws], and [ZoomText][FreedomscientificSoftwareZoomtext] are available to download.  Apple macOS includes the [VoiceOver][AppleAccessibilityMacVision] screen reader.  And iOS, Android, and Linux all support a variety of assistive technologies.  
 
-### Testing in Virtual Machines and Emulators  
+### Testing in virtual machines and emulators  
 
 Under macOS, if you want to test with an assistive technology only available for Windows, like Windows Narrator or NVDA, create a Windows virtual machine.  Virtual machines with Microsoft Edge \(EdgeHTML\) and IE are available for VirtualBox and VMWare on the [Virtual Machines download page][MicrosoftDeveloperEdgeVms].  
 
@@ -86,17 +86,18 @@ Under macOS, if you want to test with an assistive technology only available for
 > [!NOTE]
 > The iOS Simulator does not currently include VoiceOver.  
 
-### Cloud-based Testing Tools  
+### Cloud-based testing tools  
 
 If an assistive technology is not available on your OS or you not possible to install one on a virtual machine or emulator, cloud-based assistive technology testing tools are the next best thing.  
 
 *   [Assistiv Labs (commercial)][AssistivlabsMain] enables you to manually test with assistive technologies through any modern web browser.  Choose an assistive technology and browser and it connects you with a virtual machine, emulator, or real device with which you may interact.  
 
+
 ## Resources  
 
-### Accessibility Basics  
+### Accessibility basics  
 
-#### The A11Y Project  
+#### The A11Y project  
 
 [The A11Y Project](http://a11yproject.com) is a community-driven effort to make web accessibility easier.  Check out [The A11Y Project](https://a11yproject.com) site to learn about basic accessibility principles, their accessible pattern and widget [library](https://a11yproject.com/patterns), and their [resources](http://a11yproject.com/resources.html) on accessibility software, blogs, books, and tools.  
 
@@ -104,7 +105,7 @@ If an assistive technology is not available on your OS or you not possible to in
 
 The W3C [Web Accessibility Initiative (WAI)](https://w3.org/WAI) is an effort to help improve the accessibility of the web.  Their site provides a variety of resources for [Getting Started with Web Accessibility](https://www.w3.org/WAI/gettingstarted/Overview.html), [Designing for Inclusion](https://www.w3.org/WAI/users/Overview.html), [tutorials and presentations](https://www.w3.org/WAI/train.html), and more.  
 
-### Accessibility Blogs  
+### Accessibility blogs  
 
 #### TPGi, LLC  
 
@@ -118,13 +119,13 @@ The W3C [Web Accessibility Initiative (WAI)](https://w3.org/WAI) is an effort to
 
 [Level Access](https://www.levelaccess.com/blog) is a digital accessibility firm supporting their clients in developing and deploying accessible products and services.  Their blog addresses topics like ARIA best practices, accessibility trends, webinars, and more.  
 
-### Accessible Examples  
+### Accessible examples  
 
 #### ally.js - Tutorials  
 
 JavaScript library to help modern web applications with accessibility concerns by making accessibility simpler.  For more information, navigate to [ally.js - Tutorials](http://allyjs.io/tutorials).  
 
-#### OpenAjax Examples  
+#### OpenAjax examples  
 
 The [OpenAjax Alliance website](http://oaa-accessibility.org) is an excellent resource for verifying the rules for WAI-ARIA and provides a number of examples of WAI-ARIA implementations.  
 
@@ -132,9 +133,9 @@ The [OpenAjax Alliance website](http://oaa-accessibility.org) is an excellent re
 
 [The A11Y Project](http://a11yproject.com) offers a library of accessible widgets and patterns like menus, buttons, tooltips, and more.  For more information, navigate to [Patterns](http://a11yproject.com/patterns.html).  
 
-### Accessibility Techniques & Tools
+### Accessibility techniques and tools
 
-#### Accessibility:  Creating accessible extension icons for Microsoft Edge  
+#### Accessibility: Creating accessible extension icons for Microsoft Edge  
 
 Get guidance on creating accessible extensions icons for Microsoft Edge.  For more information, navigate to [Accessibility: Creating accessible extension icons for Microsoft Edge](/archive/microsoft-edge/legacy/developer/extensions/guides/accessibility).  
 

--- a/microsoft-edge/accessibility/design.md
+++ b/microsoft-edge/accessibility/design.md
@@ -1,6 +1,6 @@
 ---
-description: Read up on resources for inclusive design tools and best practices.
-title: Accessibility - Design
+description: Resources for inclusive design tools and best practices.
+title: Designing accessible websites
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 10/27/2020
@@ -9,7 +9,7 @@ ms.prod: microsoft-edge
 ms.assetid: 8468f8e1-9f4a-426c-a969-76eab9419137
 keywords: accessibility, accessibility for developers, accessible websites, edge, web development, ARIA, developer, UIA, UI Automation
 ---
-# Designing Accessible Websites  
+# Designing accessible websites
 
 Creating an inclusive design makes technology usable by all people no matter their age, education, geographic location, language, or disability.  People using technology and browsing the web have a wide range of abilities and preferences.  As you design your website, keep in mind the following key accessibility scenarios:
 
@@ -21,7 +21,7 @@ Creating an inclusive design makes technology usable by all people no matter the
     *   Using shortcut keys to efficiently access other app functionality.
 *   Accessible visual experience—Users who are visually impaired need a sufficient text contrast ratio for text content, and a good visual experience with high contrast themes overall.  Users who are color blind need information to be conveyed in ways other than through color.
 
-Many common accessibility issues on the web can be solved through good coding practice.  The [Web Content Accessibility Guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20) documentation provides techniques and best practices to help you design more accessible dynamic web applications.  For more information on building accessible websites, navigate to [Building Accessible Websites](./build/index.md) .
+Many common accessibility issues on the web can be solved through good coding practice.  The [Web Content Accessibility Guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20) documentation provides techniques and best practices to help you design more accessible dynamic web applications.  For more information, navigate to [Building accessible websites](./build/index.md).
 
 ## Resources  
 

--- a/microsoft-edge/accessibility/index.md
+++ b/microsoft-edge/accessibility/index.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to build, design, and test accessible websites within Microsoft Edge.
-title: Accessibility
+title: Accessibility overview
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 04/16/2020
@@ -45,13 +45,13 @@ The [Web Accessibility Initiative (WAI)][W3CWaiHome] provided bt the W3C is an e
 
 <!-- links -->  
 
-[AccessibilityBuild]: ./build/index.md "Building Accessible Websites | Microsoft Doc"  
-[AccessibilityDesign]: ./design.md "Designing Accessible Websites | Microsoft Doc"  
-[AccessibilityTest]: ./test.md "Accessibility Testing | Microsoft Docs"  
+[AccessibilityBuild]: ./build/index.md "Building accessible websites | Microsoft Doc"  
+[AccessibilityDesign]: ./design.md "Designing accessible websites | Microsoft Doc"  
+[AccessibilityTest]: ./test.md "Accessibility testing | Microsoft Docs"  
 
-[WindowsWin32AutoEntryui]: /windows/win32/winauto/entry-uiauto-win32 "UI Automation | Microsoft Doc"  
+[WindowsWin32AutoEntryui]: /windows/win32/winauto/entry-uiauto-win32 "UI automation | Microsoft Doc"  
 
-[ArchiveBlogsWinuiautomation]: /archive/blogs/winuiautomation/ "Microsoft Windows UI Automation Blog | Microsoft Doc"  
+[ArchiveBlogsWinuiautomation]: /archive/blogs/winuiautomation/ "Microsoft Windows UI Automation blog | Microsoft Doc"  
 
 [HTML5Accessibility]: https://html5accessibility.com "HTML5 Accessibility"  
 

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -152,7 +152,7 @@ landingContent:
           - text: webhint extension for Visual Studio Code
             url: /microsoft-edge/visual-studio-code/webhint
   # Card
-  - title: Accessibility
+  - title: Accessibility in Microsoft Edge
     linkLists:
       - linkListType: overview
         links:

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -94,7 +94,7 @@ landingContent:
           - text: Web App Manifests
             url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
   # Card
-  - title: WebView2
+  - title: WebView2 control
     linkLists:
       - linkListType: overview
         links:
@@ -130,7 +130,7 @@ landingContent:
           - text: webhint extension for Visual Studio Code
             url: /microsoft-edge/visual-studio-code/webhint
   # Card
-  - title: Web Platform
+  - title: Web platform
     linkLists:
       - linkListType: how-to-guide
         links:

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -32,7 +32,6 @@ metadata:
 landingContent:
 # Cards and links should be based on top customer tasks or top subjects
 # Start card title with a verb
-
   # Card
   - title: Microsoft Edge DevTools
     linkLists:
@@ -54,13 +53,12 @@ landingContent:
         links:
           - text: Keyboard shortcuts
             url: /microsoft-edge/devtools-guide-chromium/shortcuts
-
   # Card
-  - title: Microsoft Edge Extensions
+  - title: Microsoft Edge extensions
     linkLists:
       - linkListType: overview
         links:
-          - text: Extensions Overview
+          - text: Extensions overview
             url: /microsoft-edge/extensions-chromium/index
           - text: Getting started tutorial
             url: /microsoft-edge/extensions-chromium/getting-started/index
@@ -76,13 +74,12 @@ landingContent:
             url: /microsoft-edge/extensions-chromium/publish/create-dev-account
           - text: Create a simple extension
             url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
-
   # Card
   - title: Progressive Web Apps
     linkLists:
       - linkListType: overview
         links:
-          - text: Overview
+          - text: Progressive Web Apps overview
             url: /microsoft-edge/progressive-web-apps-chromium/index
           - text: Get started with Progressive Web Apps
             url: /microsoft-edge/progressive-web-apps-chromium/get-started
@@ -96,13 +93,12 @@ landingContent:
             url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
           - text: Web App Manifests
             url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
-
   # Card
   - title: WebView2
     linkLists:
       - linkListType: overview
         links:
-          - text: Overview
+          - text: WebView2 overview
             url: /microsoft-edge/webview2/index
       - linkListType: get-started
         links:
@@ -116,21 +112,23 @@ landingContent:
         links:
           - text: Microsoft Edge WebView2 API Reference
             url: /microsoft-edge/webview2/webview2-api-reference
-
   # Card
-  - title: Test & Automation
+  - title: Test and automation
     linkLists:
       - linkListType: how-to-guide
         links:
-          - text: DevTools Protocol overview
+          - text: DevTools Protocol
             url: /microsoft-edge/devtools-protocol-chromium
-          - text: WebDriver
-            url: /microsoft-edge/webdriver-chromium
+          - text: Origin Trials
+            url: /microsoft-edge/origin-trials/index
+          - text: Playwright
+            url: /microsoft-edge/playwright/index
           - text: Puppeteer
             url: /microsoft-edge/puppeteer
+          - text: WebDriver
+            url: /microsoft-edge/webdriver-chromium
           - text: webhint extension for Visual Studio Code
             url: /microsoft-edge/visual-studio-code/webhint
-
   # Card
   - title: Web Platform
     linkLists:
@@ -140,7 +138,6 @@ landingContent:
             url: /microsoft-edge/web-platform/user-agent-guidance
           - text: Site compatibility-impacting changes
             url: /microsoft-edge/web-platform/site-impacting-changes
-
   # Card
   - title: Microsoft Edge IDE integration
     linkLists:
@@ -154,7 +151,6 @@ landingContent:
             url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
           - text: webhint extension for Visual Studio Code
             url: /microsoft-edge/visual-studio-code/webhint
-
   # Card
   - title: Accessibility
     linkLists:

--- a/microsoft-edge/devtools-protocol-chromium/index.md
+++ b/microsoft-edge/devtools-protocol-chromium/index.md
@@ -1,13 +1,13 @@
 ---
 description: Update to the Microsoft Edge DevTools Protocol
-title: Microsoft Edge DevTools Protocol Update
+title: Microsoft Edge DevTools Protocol overview
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.date: 04/06/2021
 ms.topic: reference
 ms.prod: microsoft-edge
 ---
-# Microsoft Edge (Chromium) DevTools Protocol overview  
+# Microsoft Edge DevTools Protocol overview  
 
 With the shift in the underlying web platform of Microsoft Edge to Chromium, the [Microsoft Edge (EdgeHTML) DevTools Protocol](/archive/microsoft-edge/legacy/developer/devtools-protocol/index) will not be receiving any further updates.  The Microsoft Edge \(Chromium\) DevTools Protocol will match the APIs of the Chrome DevTools Protocol going forward.  
 
@@ -20,7 +20,8 @@ You can find documentation on those domains and methods by referring to the [Chr
 
 Here's how to attach a custom tooling client to the DevTools Server in Microsoft Edge \(Chromium\).  
 
-1.  Ensure all instances of Microsoft Edge \(Chromium\) are closed.  
+1.  Close all instances of Microsoft Edge \(Chromium\).
+
 1.  Launch Microsoft Edge \(Chromium\) with the remote debugging port:. 
     
     ```shell
@@ -41,7 +42,8 @@ Here's how to attach a custom tooling client to the DevTools Server in Microsoft
     
 1.  Finally, connect to the `webSocketDebuggerUrl` of the desired target and issue commands/subscribe to event messages through the DevTools web socket server.  
 
-## DevTools Protocol HTTP Endpoints  
+
+## DevTools Protocol HTTP Endpoints
 
 The Microsoft Edge \(Chromium\) DevTools Protocol supports the following HTTP endpoints.  
 

--- a/microsoft-edge/devtools-protocol-chromium/index.md
+++ b/microsoft-edge/devtools-protocol-chromium/index.md
@@ -9,12 +9,13 @@ ms.prod: microsoft-edge
 ---
 # Microsoft Edge DevTools Protocol overview  
 
-With the shift in the underlying web platform of Microsoft Edge to Chromium, the [Microsoft Edge (EdgeHTML) DevTools Protocol](/archive/microsoft-edge/legacy/developer/devtools-protocol/index) will not be receiving any further updates.  The Microsoft Edge \(Chromium\) DevTools Protocol will match the APIs of the Chrome DevTools Protocol going forward.  
-
-You can find documentation on those domains and methods by referring to the [Chrome DevTools Protocol Viewer](https://chromedevtools.github.io/devtools-protocol/tot).  
+Use the DevTools Protocol to instrument, inspect, debug, and profile browsers including Microsoft Edge.  The Microsoft Edge DevTools Protocol matches the APIs of the Chrome DevTools Protocol.  For reference documentation, navigate to [Chrome DevTools Protocol Viewer](https://chromedevtools.github.io/devtools-protocol/tot).  
 
 > [!NOTE]
+> With the shift in the underlying web platform of Microsoft Edge to Chromium, the [Microsoft Edge (EdgeHTML) DevTools Protocol](/archive/microsoft-edge/legacy/developer/devtools-protocol/index) will not be receiving any further updates.  The Microsoft Edge \(Chromium\) DevTools Protocol will match the APIs of the Chrome DevTools Protocol going forward.  
+> 
 > Any methods that were prefixed with `ms` in the [Microsoft Edge (EdgeHTML) DevTools Protocol](/archive/microsoft-edge/legacy/developer/devtools-protocol/index) are no longer supported in the Microsoft Edge \(Chromium\) DevTools Protocol.  
+
 
 ## Using the DevTools Protocol  
 

--- a/microsoft-edge/devtools-protocol-chromium/index.md
+++ b/microsoft-edge/devtools-protocol-chromium/index.md
@@ -19,17 +19,17 @@ Use the DevTools Protocol to instrument, inspect, debug, and profile browsers in
 
 ## Using the DevTools Protocol  
 
-Here's how to attach a custom tooling client to the DevTools Server in Microsoft Edge \(Chromium\).  
+To attach a custom tooling client to the DevTools Server in Microsoft Edge (Chromium):
 
 1.  Close all instances of Microsoft Edge \(Chromium\).
 
-1.  Launch Microsoft Edge \(Chromium\) with the remote debugging port:. 
+1.  Launch Microsoft Edge \(Chromium\) with the remote debugging port.
     
     ```shell
     msedge.exe --remote-debugging-port=9222
     ```  
     
-1.  Optionally, you can start a separate instance of Edge using a distinct user profile if desired.  
+1.  Optionally, you can start a separate instance of Edge using a distinct user profile.
     
     ```shell
     msedge.exe --user-data-dir=<some directory>
@@ -44,7 +44,7 @@ Here's how to attach a custom tooling client to the DevTools Server in Microsoft
 1.  Finally, connect to the `webSocketDebuggerUrl` of the desired target and issue commands/subscribe to event messages through the DevTools web socket server.  
 
 
-## DevTools Protocol HTTP Endpoints
+## DevTools Protocol HTTP endpoints
 
 The Microsoft Edge \(Chromium\) DevTools Protocol supports the following HTTP endpoints.  
 

--- a/microsoft-edge/extensions-chromium/index.md
+++ b/microsoft-edge/extensions-chromium/index.md
@@ -109,20 +109,24 @@ After you've successfully submitted your extension, your extension undergoes a r
 <!-- ====================================================================== -->
 ## See also  
 
-*   [Port a Google Chrome extension][ExtensionworkshopPorting]  
-*   [Build a Safari App extension][AppleDeveloperSafariservicesAppExtensionsBuilding]  
-*   [Your first extension (Firefox)][MDNWebextensionsYourFirst]  
-*   [Get started tutorial (Chrome)][ChromeDeveloperExtensionsGetstarted]  
-*   [Get started (Opera)][OperaDevExtensionsGettingStarted]  
-*   [Extension concepts and architecture][ExtensionsChromiumGettingStartedIndex]  
+*  [Port a Google Chrome extension][ExtensionworkshopPorting]  
+*  [Build a Safari App extension][AppleDeveloperSafariservicesAppExtensionsBuilding]  
+*  [Your first extension (Firefox)][MDNWebextensionsYourFirst]  
+*  [Get started tutorial (Chrome)][ChromeDeveloperExtensionsGetstarted]  
+*  [Get started (Opera)][OperaDevExtensionsGettingStarted]  
+*  [Extension concepts and architecture][ExtensionsChromiumGettingStartedIndex]  
+*  [Microsoft Edge DevTools extension for Visual Studio Code][EdgeDevToolsVSCode]
+*  [webhint extension for Visual Studio Code][WebhintVSCode]
 
 
 <!-- ====================================================================== -->
 <!-- links -->  
-[ExtensionsChromiumDeveloperGuidePortChrome]: ./developer-guide/port-chrome-extension.md "Port Chrome Extension To Microsoft Edge (Chromium) | Microsoft Docs"  
+[ExtensionsChromiumDeveloperGuidePortChrome]: ./developer-guide/port-chrome-extension.md "Port a Chrome extension to Microsoft Edge | Microsoft Docs"  
 [ExtensionsChromiumGettingStartedIndex]: ./getting-started/index.md "Extension concepts and architecture | Microsoft Docs"  
 [ExtensionsChromiumPublish]: ./publish/publish-extension.md "Publish a Microsoft Edge extension | Microsoft Docs"  
-
+[EdgeDevToolsVSCode]: ../visual-studio-code/microsoft-edge-devtools-extension.md "Microsoft Edge DevTools extension for Visual Studio Code | Microsoft Docs"
+[WebhintVSCode]: ../visual-studio-code/webhint.md "webhint extension for Visual Studio Code | Microsoft Docs"
+<!-- external links -->
 [MicrosoftDeveloperEdgeExtensions]: https://developer.microsoft.com/microsoft-edge/extensions "Develop extensions for Microsoft Edge | Microsoft Developer"  
 [MicrosoftDeveloperRegistration]: https://developer.microsoft.com/registration "Partner Center | Microsoft Developer"  
 

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -9,7 +9,7 @@ metadata:
   ms.topic: hub-page
   author: MSEdgeTeam
   ms.author: msedgedevrel
-  ms.date: 04/06/2021
+  ms.date: 09/09/2021
   ms.localizationpriority: high
   ms.prod: microsoft-edge
 
@@ -59,215 +59,216 @@ conceptualContent:
 #           get-started | how-to-guide | learn | overview | 
 #           quickstart | reference | tutorial | video | 
 #           whats-new
-  title: Microsoft Edge for Enterprise # < 60 chars (optional)
-  # summary:  # < 160 chars (optional)
-  items:
-    # Card
-    - title: Learn about Microsoft Edge in the enterprise
-      links:
-        - url: /deployedge/microsoft-edge-channels
-          itemType: overview
-          text: Microsoft Edge channel overview
-        - url: /deployedge/edge-ie-mode
-          itemType: reference
-          text: Use enterprise features
-    # Card
-    - title: Deploy and update Microsoft Edge
-      links:
-        - itemType: reference
-          text: Video - Deploy Microsoft Edge
-          url: /deployedge/microsoft-edge-video-deploy
-        - itemType: reference
-          text: Deploy to Windows
-          url: /configmgr/apps/deploy-use/deploy-edge
-        - itemType: reference
-          text: Deploy to macOS
-          url: /intune/apps/apps-edge-macos
-    # Card
-    - title: Configure Microsoft Edge
-      links:
-        - itemType: reference
-          text: Configure Microsoft Edge on Windows and macOS
-          url: /deployedge/configure-microsoft-edge
-        - itemType: reference
-          text: Set Microsoft Edge as the default browser
-          url: /deployedge/edge-default-browser
-    # Card
-    - title: Manage security and privacy
-      links:
-        - itemType: reference
-          text: Security
-          url: /deployedge/ms-edge-security-for-business
-        - itemType: reference
-          text: Privacy
-          url: /deployedge/microsoft-edge-enterprise-privacy-settings
-    # Card
-    - title: Policy reference
-      links:
-        - itemType: reference
-          text: Browser policy reference
-          url: /deployedge/microsoft-edge-policies
-        - itemType: reference
-          text: Update policy reference
-          url: /deployedge/microsoft-edge-update-policies
-    # Card
-    - title: Engage with enterprise community
-      links:
-        - itemType: reference
-          text: Enterprise tech community (Insider Focused)
-          url: https://techcommunity.microsoft.com/t5/Enterprise/bd-p/EdgeInsiderEnterprise
-        # - itemType: reference
-        #   text: Troubleshoot Microsoft Edge
-        #   url: /deployedge/microsoft-edge-troubleshooting
-    # Card
-    - title: Extensions for enterprise
-      links:
-        - itemType: reference
-          text: Match Patterns
-          url: /microsoft-edge/extensions-chromium/enterprise/match-patterns
-        - itemType: reference
-          text: Hosting and Updating
-          url: /microsoft-edge/extensions-chromium/enterprise/hosting-and-updating
+  sections:
+    - title: Microsoft Edge for Enterprise # < 60 chars (optional)
+      # summary:  # < 160 chars (optional)
+      items:
+        # Card
+        - title: Learn about Microsoft Edge in the enterprise
+          links:
+            - url: /deployedge/microsoft-edge-channels
+              itemType: overview
+              text: Microsoft Edge channel overview
+            - url: /deployedge/edge-ie-mode
+              itemType: reference
+              text: Use enterprise features
+        # Card
+        - title: Deploy and update Microsoft Edge
+          links:
+            - itemType: reference
+              text: Video - Deploy Microsoft Edge
+              url: /deployedge/microsoft-edge-video-deploy
+            - itemType: reference
+              text: Deploy to Windows
+              url: /configmgr/apps/deploy-use/deploy-edge
+            - itemType: reference
+              text: Deploy to macOS
+              url: /intune/apps/apps-edge-macos
+        # Card
+        - title: Configure Microsoft Edge
+          links:
+            - itemType: reference
+              text: Configure Microsoft Edge on Windows and macOS
+              url: /deployedge/configure-microsoft-edge
+            - itemType: reference
+              text: Set Microsoft Edge as the default browser
+              url: /deployedge/edge-default-browser
+        # Card
+        - title: Manage security and privacy
+          links:
+            - itemType: reference
+              text: Security
+              url: /deployedge/ms-edge-security-for-business
+            - itemType: reference
+              text: Privacy
+              url: /deployedge/microsoft-edge-enterprise-privacy-settings
+        # Card
+        - title: Policy reference
+          links:
+            - itemType: reference
+              text: Browser policy reference
+              url: /deployedge/microsoft-edge-policies
+            - itemType: reference
+              text: Update policy reference
+              url: /deployedge/microsoft-edge-update-policies
+        # Card
+        - title: Engage with enterprise community
+          links:
+            - itemType: reference
+              text: Enterprise tech community (Insider Focused)
+              url: https://techcommunity.microsoft.com/t5/Enterprise/bd-p/EdgeInsiderEnterprise
+            # - itemType: reference
+            #   text: Troubleshoot Microsoft Edge
+            #   url: /deployedge/microsoft-edge-troubleshooting
+        # Card
+        - title: Extensions for enterprise
+          links:
+            - itemType: reference
+              text: Match Patterns
+              url: /microsoft-edge/extensions-chromium/enterprise/match-patterns
+            - itemType: reference
+              text: Hosting and Updating
+              url: /microsoft-edge/extensions-chromium/enterprise/hosting-and-updating
 
 # =============================================================================
-  title: Microsoft Edge for Developers # < 60 chars (optional)
-  # summary:  # < 160 chars (optional)
-  items:
-    # Card
-    - title: Microsoft Edge DevTools
-      links:
-        - url: /microsoft-edge/devtools-guide-chromium
-          itemType: overview
-          text: DevTools overview
-        - url: /microsoft-edge/devtools-guide-chromium/beginners/html
-          itemType: overview
-          text: DevTools for beginners
-        - url: /microsoft-edge/devtools-guide-chromium/command-menu/index
-          itemType: how-to-guide
-          text: Command menu
-        - url: /microsoft-edge/devtools-guide-chromium/open
-          itemType: how-to-guide
-          text: Open DevTools
-        - url: /microsoft-edge/devtools-guide-chromium/css/index
-          itemType: how-to-guide
-          text: View and change CSS
-        - url: /microsoft-edge/devtools-guide-chromium/shortcuts
-          itemType: reference
-          text: Keyboard shortcuts
-    # Card
-    - title: Microsoft Edge Extensions
-      links:
-        - url: /microsoft-edge/extensions-chromium/index
-          itemType: overview
-          text: Extensions Overview
-        - url: /microsoft-edge/extensions-chromium/getting-started/index
-          itemType: overview
-          text: Getting started tutorial
-        - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
-          itemType: overview
-          text: Port a Chromium extension to Microsoft Edge
-        - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
-          itemType: how-to-guide
-          text: Alternate methods of distributing extensions
-        - url: /microsoft-edge/extensions-chromium/publish/publish-extension
-          itemType: how-to-guide
-          text: Step-wise publishing process
-        - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
-          itemType: how-to-guide
-          text: Register as a Microsoft Edge extension developer
-        - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
-          itemType: how-to-guide
-          text: Create a simple extension
-    # Card
-    - title: Progressive Web Apps
-      links:
-        - url: /microsoft-edge/progressive-web-apps-chromium/index
-          itemType: overview
-          text: Overview
-        - url: /microsoft-edge/progressive-web-apps-chromium/get-started
-          itemType: overview
-          text: Get started with Progressive Web Apps
-        - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
-          itemType: overview
-          text: Using DevTools with Progressive Web Apps
-        - url: /microsoft-edge/progressive-web-apps-chromium/offline
-          itemType: concept
-          text: Offline scenarios
-        - url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
-          itemType: concept
-          text: Service Workers
-        - url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
-          itemType: concept
-          text: Web App Manifests
-    # Card
-    - title: WebView2
-      links:
-        - url: /microsoft-edge/webview2/index
-          itemType: overview
-          text: Overview
-        - url: /microsoft-edge/webview2/gettingstarted/win32
-          itemType: get-started
-          text: Getting Started with WebView2
-        - url: /microsoft-edge/webview2/gettingstarted/wpf
-          itemType: get-started
-          text: Getting started with WebView2 in WPF
-        - url: /microsoft-edge/webview2/gettingstarted/winforms
-          itemType: get-started
-          text: Getting started with WebView2 in Windows Forms apps
-        - url: /microsoft-edge/webview2/webview2-api-reference
-          itemType: reference
-          text: Microsoft Edge WebView2 API Reference
-    # Card
-    - title: Test & Automation
-      links:
-        - url: /microsoft-edge/devtools-protocol-chromium
-          itemType: how-to-guide
-          text: DevTools Protocol overview
-        - url: /microsoft-edge/webdriver-chromium
-          itemType: how-to-guide
-          text: WebDriver
-        - url: /microsoft-edge/puppeteer
-          itemType: how-to-guide
-          text: Puppeteer
-        - url: /microsoft-edge/visual-studio-code/webhint
-          itemType: how-to-guide
-          text: webhint extension for Visual Studio Code
-    # Card
-    - title: Web Platform
-      links:
-        - url: /microsoft-edge/web-platform/user-agent-guidance
-          itemType: how-to-guide
-          text: Detecting Microsoft Edge from your website
-        - url: /microsoft-edge/web-platform/site-impacting-changes
-          itemType: how-to-guide
-          text: Site compatibility-impacting changes
-    # Card
-    - title: Microsoft Edge IDE integration
-      links:
-        - url: /microsoft-edge/visual-studio/
-          itemType: overview
-          text: Visual Studio
-        - url: /microsoft-edge/visual-studio-code/
-          itemType: overview
-          text: Visual Studio Code overview
-        - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
-          itemType: overview
-          text: DevTools extension for Visual Studio Code
-        - url: /microsoft-edge/visual-studio-code/webhint
-          itemType: overview
-          text: webhint extension for Visual Studio Code
-    # Card
-    - title: Accessibility
-      links:
-        - url: /microsoft-edge/accessibility/
-          itemType: overview
-          text: Accessibility overview
-        - url: /microsoft-edge/accessibility/test
-          itemType: how-to-guide
-          text: Accessibility testing
-        - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
-          itemType: how-to-guide
-          text: Accessibility-testing features in DevTools
+    - title: Microsoft Edge for Developers # < 60 chars (optional)
+    # summary:  # < 160 chars (optional)
+      items:
+        # Card
+        - title: Microsoft Edge DevTools
+          links:
+            - url: /microsoft-edge/devtools-guide-chromium
+              itemType: overview
+              text: DevTools overview
+            - url: /microsoft-edge/devtools-guide-chromium/beginners/html
+              itemType: overview
+              text: DevTools for beginners
+            - url: /microsoft-edge/devtools-guide-chromium/command-menu/index
+              itemType: how-to-guide
+              text: Command menu
+            - url: /microsoft-edge/devtools-guide-chromium/open
+              itemType: how-to-guide
+              text: Open DevTools
+            - url: /microsoft-edge/devtools-guide-chromium/css/index
+              itemType: how-to-guide
+              text: View and change CSS
+            - url: /microsoft-edge/devtools-guide-chromium/shortcuts
+              itemType: reference
+              text: Keyboard shortcuts
+        # Card
+        - title: Microsoft Edge Extensions
+          links:
+            - url: /microsoft-edge/extensions-chromium/index
+              itemType: overview
+              text: Extensions Overview
+            - url: /microsoft-edge/extensions-chromium/getting-started/index
+              itemType: overview
+              text: Getting started tutorial
+            - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
+              itemType: overview
+              text: Port a Chromium extension to Microsoft Edge
+            - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
+              itemType: how-to-guide
+              text: Alternate methods of distributing extensions
+            - url: /microsoft-edge/extensions-chromium/publish/publish-extension
+              itemType: how-to-guide
+              text: Step-wise publishing process
+            - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
+              itemType: how-to-guide
+              text: Register as a Microsoft Edge extension developer
+            - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
+              itemType: how-to-guide
+              text: Create a simple extension
+        # Card
+        - title: Progressive Web Apps
+          links:
+            - url: /microsoft-edge/progressive-web-apps-chromium/index
+              itemType: overview
+              text: Overview
+            - url: /microsoft-edge/progressive-web-apps-chromium/get-started
+              itemType: overview
+              text: Get started with Progressive Web Apps
+            - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
+              itemType: overview
+              text: Using DevTools with Progressive Web Apps
+            - url: /microsoft-edge/progressive-web-apps-chromium/offline
+              itemType: concept
+              text: Offline scenarios
+            - url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
+              itemType: concept
+              text: Service Workers
+            - url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
+              itemType: concept
+              text: Web App Manifests
+        # Card
+        - title: WebView2
+          links:
+            - url: /microsoft-edge/webview2/index
+              itemType: overview
+              text: Overview
+            - url: /microsoft-edge/webview2/gettingstarted/win32
+              itemType: get-started
+              text: Getting Started with WebView2
+            - url: /microsoft-edge/webview2/gettingstarted/wpf
+              itemType: get-started
+              text: Getting started with WebView2 in WPF
+            - url: /microsoft-edge/webview2/gettingstarted/winforms
+              itemType: get-started
+              text: Getting started with WebView2 in Windows Forms apps
+            - url: /microsoft-edge/webview2/webview2-api-reference
+              itemType: reference
+              text: Microsoft Edge WebView2 API Reference
+        # Card
+        - title: Test & Automation
+          links:
+            - url: /microsoft-edge/devtools-protocol-chromium
+              itemType: how-to-guide
+              text: DevTools Protocol overview
+            - url: /microsoft-edge/webdriver-chromium
+              itemType: how-to-guide
+              text: WebDriver
+            - url: /microsoft-edge/puppeteer
+              itemType: how-to-guide
+              text: Puppeteer
+            - url: /microsoft-edge/visual-studio-code/webhint
+              itemType: how-to-guide
+              text: webhint extension for Visual Studio Code
+        # Card
+        - title: Web Platform
+          links:
+            - url: /microsoft-edge/web-platform/user-agent-guidance
+              itemType: how-to-guide
+              text: Detecting Microsoft Edge from your website
+            - url: /microsoft-edge/web-platform/site-impacting-changes
+              itemType: how-to-guide
+              text: Site compatibility-impacting changes
+        # Card
+        - title: Microsoft Edge IDE integration
+          links:
+            - url: /microsoft-edge/visual-studio/
+              itemType: overview
+              text: Visual Studio
+            - url: /microsoft-edge/visual-studio-code/
+              itemType: overview
+              text: Visual Studio Code overview
+            - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
+              itemType: overview
+              text: DevTools extension for Visual Studio Code
+            - url: /microsoft-edge/visual-studio-code/webhint
+              itemType: overview
+              text: webhint extension for Visual Studio Code
+        # Card
+        - title: Accessibility
+          links:
+            - url: /microsoft-edge/accessibility/
+              itemType: overview
+              text: Accessibility overview
+            - url: /microsoft-edge/accessibility/test
+              itemType: how-to-guide
+              text: Accessibility testing
+            - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+              itemType: how-to-guide
+              text: Accessibility-testing features in DevTools
 
 # =============================================================================
 # additionalContent section (optional)

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -127,150 +127,151 @@ conceptualContent:
           text: Hosting and Updating
           url: /microsoft-edge/extensions-chromium/enterprise/hosting-and-updating
 
-# additionalContent section (optional)
-# Card with links style
-additionalContent:
-  # Supports up to 3 sections
-  sections:
-    - title: Microsoft Edge for Developers # < 60 chars (optional)
-      # summary: # < 160 chars (optional)
-      items:
-        # Card
-        - title: Microsoft Edge DevTools
-          links:
-            - itemType: overview
-              text: DevTools overview
-              url: /microsoft-edge/devtools-guide-chromium
-            - itemType: overview
-              text: DevTools for beginners
-              url: /microsoft-edge/devtools-guide-chromium/beginners/html
-            - itemType: how-to-guide
-              text: Command menu
-              url: /microsoft-edge/devtools-guide-chromium/command-menu/index
-            - itemType: how-to-guide
-              text: Open DevTools
-              url: /microsoft-edge/devtools-guide-chromium/open
-            - itemType: how-to-guide
-              text: View and change CSS
-              url: /microsoft-edge/devtools-guide-chromium/css/index
-            - itemType: reference
-              text: Keyboard shortcuts
-              url: /microsoft-edge/devtools-guide-chromium/shortcuts
-        # Card
-        - title: Microsoft Edge Extensions
-          links:
-            - itemType: overview
-              text: Extensions Overview
-              url: /microsoft-edge/extensions-chromium/index
-            - itemType: overview
-              text: Getting started tutorial
-              url: /microsoft-edge/extensions-chromium/getting-started/index
-            - itemType: overview
-              text: Port a Chromium extension to Microsoft Edge
-              url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
-            - itemType: how-to-guide
-              text: Alternate methods of distributing extensions
-              url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
-            - itemType: how-to-guide
-              text: Step-wise publishing process
-              url: /microsoft-edge/extensions-chromium/publish/publish-extension
-            - itemType: how-to-guide
-              text: Register as a Microsoft Edge extension developer
-              url: /microsoft-edge/extensions-chromium/publish/create-dev-account
-            - itemType: how-to-guide
-              text: Create a simple extension
-              url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
-        # Card
-        - title: Progressive Web Apps
-          links:
-            - itemType: overview
-              text: Overview
-              url: /microsoft-edge/progressive-web-apps-chromium/index
-            - itemType: overview
-              text: Get started with Progressive Web Apps
-              url: /microsoft-edge/progressive-web-apps-chromium/get-started
-            - itemType: overview
-              text: Using DevTools with Progressive Web Apps
-              url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
-            - itemType: concept
-              text: Offline scenarios
-              url: /microsoft-edge/progressive-web-apps-chromium/offline
-            - itemType: concept
-              text: Service Workers
-              url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
-            - itemType: concept
-              text: Web App Manifests
-              url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
-        # Card
-        - title: WebView2
-          links:
-            - itemType: overview
-              text: Overview
-              url: /microsoft-edge/webview2/index
-            - itemType: get-started
-              text: Getting Started with WebView2
-              url: /microsoft-edge/webview2/gettingstarted/win32
-            - itemType: get-started
-              text: Getting started with WebView2 in WPF
-              url: /microsoft-edge/webview2/gettingstarted/wpf
-            - itemType: get-started
-              text: Getting started with WebView2 in Windows Forms apps
-              url: /microsoft-edge/webview2/gettingstarted/winforms
-            - itemType: reference
-              text: Microsoft Edge WebView2 API Reference
-              url: /microsoft-edge/webview2/webview2-api-reference
-        # Card
-        - title: Test & Automation
-          links:
-            - itemType: how-to-guide
-              text: DevTools Protocol overview
-              url: /microsoft-edge/devtools-protocol-chromium
-            - itemType: how-to-guide
-              text: WebDriver
-              url: /microsoft-edge/webdriver-chromium
-            - itemType: how-to-guide
-              text: Puppeteer
-              url: /microsoft-edge/puppeteer
-            - itemType: how-to-guide
-              text: webhint extension for Visual Studio Code
-              url: /microsoft-edge/visual-studio-code/webhint
-        # Card
-        - title: Web Platform
-          links:
-            - itemType: how-to-guide
-              text: Detecting Microsoft Edge from your website
-              url: /microsoft-edge/web-platform/user-agent-guidance
-            - itemType: how-to-guide
-              text: Site compatibility-impacting changes
-              url: /microsoft-edge/web-platform/site-impacting-changes
-        # Card
-        - title: Microsoft Edge IDE integration
-          links:
-            - itemType: overview
-              text: Visual Studio
-              url: /microsoft-edge/visual-studio/
-            - itemType: overview
-              text: Visual Studio Code overview
-              url: /microsoft-edge/visual-studio-code/
-            - itemType: overview
-              text: DevTools extension for Visual Studio Code
-              url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
-            - itemType: overview
-              text: webhint extension for Visual Studio Code
-              url: /microsoft-edge/visual-studio-code/webhint
-        # Card
-        - title: Accessibility
-          links:
-            - itemType: overview
-              text: Accessibility overview
-              url: /microsoft-edge/accessibility/
-            - itemType: how-to-guide
-              text: Accessibility testing
-              url: /microsoft-edge/accessibility/test
-            - itemType: how-to-guide
-              text: Accessibility-testing features in DevTools
-              url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
-# end of Developer cards
+# conceptualContent section (optional)
+conceptualContent:
+# itemType: architecture | concept | deploy | download | 
+#           get-started | how-to-guide | learn | overview | 
+#           quickstart | reference | tutorial | video | 
+#           whats-new
+  title: Microsoft Edge for Developers # < 60 chars (optional)
+  # summary:  # < 160 chars (optional)
+  items:
+    # Card
+    - title: Microsoft Edge DevTools
+      links:
+        - url: /microsoft-edge/devtools-guide-chromium
+          itemType: overview
+          text: DevTools overview
+        - url: /microsoft-edge/devtools-guide-chromium/beginners/html
+          itemType: overview
+          text: DevTools for beginners
+        - url: /microsoft-edge/devtools-guide-chromium/command-menu/index
+          itemType: how-to-guide
+          text: Command menu
+        - url: /microsoft-edge/devtools-guide-chromium/open
+          itemType: how-to-guide
+          text: Open DevTools
+        - url: /microsoft-edge/devtools-guide-chromium/css/index
+          itemType: how-to-guide
+          text: View and change CSS
+        - url: /microsoft-edge/devtools-guide-chromium/shortcuts
+          itemType: reference
+          text: Keyboard shortcuts
+    # Card
+    - title: Microsoft Edge Extensions
+      links:
+        - url: /microsoft-edge/extensions-chromium/index
+          itemType: overview
+          text: Extensions Overview
+        - url: /microsoft-edge/extensions-chromium/getting-started/index
+          itemType: overview
+          text: Getting started tutorial
+        - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
+          itemType: overview
+          text: Port a Chromium extension to Microsoft Edge
+        - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
+          itemType: how-to-guide
+          text: Alternate methods of distributing extensions
+        - url: /microsoft-edge/extensions-chromium/publish/publish-extension
+          itemType: how-to-guide
+          text: Step-wise publishing process
+        - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
+          itemType: how-to-guide
+          text: Register as a Microsoft Edge extension developer
+        - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
+          itemType: how-to-guide
+          text: Create a simple extension
+    # Card
+    - title: Progressive Web Apps
+      links:
+        - url: /microsoft-edge/progressive-web-apps-chromium/index
+          itemType: overview
+          text: Overview
+        - url: /microsoft-edge/progressive-web-apps-chromium/get-started
+          itemType: overview
+          text: Get started with Progressive Web Apps
+        - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
+          itemType: overview
+          text: Using DevTools with Progressive Web Apps
+        - url: /microsoft-edge/progressive-web-apps-chromium/offline
+          itemType: concept
+          text: Offline scenarios
+        - url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
+          itemType: concept
+          text: Service Workers
+        - url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
+          itemType: concept
+          text: Web App Manifests
+    # Card
+    - title: WebView2
+      links:
+        - url: /microsoft-edge/webview2/index
+          itemType: overview
+          text: Overview
+        - url: /microsoft-edge/webview2/gettingstarted/win32
+          itemType: get-started
+          text: Getting Started with WebView2
+        - url: /microsoft-edge/webview2/gettingstarted/wpf
+          itemType: get-started
+          text: Getting started with WebView2 in WPF
+        - url: /microsoft-edge/webview2/gettingstarted/winforms
+          itemType: get-started
+          text: Getting started with WebView2 in Windows Forms apps
+        - url: /microsoft-edge/webview2/webview2-api-reference
+          itemType: reference
+          text: Microsoft Edge WebView2 API Reference
+    # Card
+    - title: Test & Automation
+      links:
+        - url: /microsoft-edge/devtools-protocol-chromium
+          itemType: how-to-guide
+          text: DevTools Protocol overview
+        - url: /microsoft-edge/webdriver-chromium
+          itemType: how-to-guide
+          text: WebDriver
+        - url: /microsoft-edge/puppeteer
+          itemType: how-to-guide
+          text: Puppeteer
+        - url: /microsoft-edge/visual-studio-code/webhint
+          itemType: how-to-guide
+          text: webhint extension for Visual Studio Code
+    # Card
+    - title: Web Platform
+      links:
+        - url: /microsoft-edge/web-platform/user-agent-guidance
+          itemType: how-to-guide
+          text: Detecting Microsoft Edge from your website
+        - url: /microsoft-edge/web-platform/site-impacting-changes
+          itemType: how-to-guide
+          text: Site compatibility-impacting changes
+    # Card
+    - title: Microsoft Edge IDE integration
+      links:
+        - url: /microsoft-edge/visual-studio/
+          itemType: overview
+          text: Visual Studio
+        - url: /microsoft-edge/visual-studio-code/
+          itemType: overview
+          text: Visual Studio Code overview
+        - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
+          itemType: overview
+          text: DevTools extension for Visual Studio Code
+        - url: /microsoft-edge/visual-studio-code/webhint
+          itemType: overview
+          text: webhint extension for Visual Studio Code
+    # Card
+    - title: Accessibility
+      links:
+        - url: /microsoft-edge/accessibility/
+          itemType: overview
+          text: Accessibility overview
+        - url: /microsoft-edge/accessibility/test
+          itemType: how-to-guide
+          text: Accessibility testing
+        - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+          itemType: how-to-guide
+          text: Accessibility-testing features in DevTools
+
     - title: Help and Support # < 60 chars (optional)
       # summary: sectionsummary # < 160 chars (optional)
       items:
@@ -290,6 +291,7 @@ additionalContent:
         - summary: Helpful support resources for users is available.
           title: User Support
           url: https://support.microsoft.com/microsoft-edge
+
     - title: Reference and Legacy Docs # < 60 chars (optional)
       # summary: sectionsummary # < 160 chars (optional)
       items:

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -133,144 +133,145 @@ conceptualContent:
 #           get-started | how-to-guide | learn | overview | 
 #           quickstart | reference | tutorial | video | 
 #           whats-new
-  title: Microsoft Edge for Developers # < 60 chars (optional)
-  # summary:  # < 160 chars (optional)
-  items:
-    # Card
-    - title: Microsoft Edge DevTools
-      links:
-        - url: /microsoft-edge/devtools-guide-chromium
-          itemType: overview
-          text: DevTools overview
-        - url: /microsoft-edge/devtools-guide-chromium/beginners/html
-          itemType: overview
-          text: DevTools for beginners
-        - url: /microsoft-edge/devtools-guide-chromium/command-menu/index
-          itemType: how-to-guide
-          text: Command menu
-        - url: /microsoft-edge/devtools-guide-chromium/open
-          itemType: how-to-guide
-          text: Open DevTools
-        - url: /microsoft-edge/devtools-guide-chromium/css/index
-          itemType: how-to-guide
-          text: View and change CSS
-        - url: /microsoft-edge/devtools-guide-chromium/shortcuts
-          itemType: reference
-          text: Keyboard shortcuts
-    # Card
-    - title: Microsoft Edge Extensions
-      links:
-        - url: /microsoft-edge/extensions-chromium/index
-          itemType: overview
-          text: Extensions Overview
-        - url: /microsoft-edge/extensions-chromium/getting-started/index
-          itemType: overview
-          text: Getting started tutorial
-        - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
-          itemType: overview
-          text: Port a Chromium extension to Microsoft Edge
-        - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
-          itemType: how-to-guide
-          text: Alternate methods of distributing extensions
-        - url: /microsoft-edge/extensions-chromium/publish/publish-extension
-          itemType: how-to-guide
-          text: Step-wise publishing process
-        - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
-          itemType: how-to-guide
-          text: Register as a Microsoft Edge extension developer
-        - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
-          itemType: how-to-guide
-          text: Create a simple extension
-    # Card
-    - title: Progressive Web Apps
-      links:
-        - url: /microsoft-edge/progressive-web-apps-chromium/index
-          itemType: overview
-          text: Overview
-        - url: /microsoft-edge/progressive-web-apps-chromium/get-started
-          itemType: overview
-          text: Get started with Progressive Web Apps
-        - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
-          itemType: overview
-          text: Using DevTools with Progressive Web Apps
-        - url: /microsoft-edge/progressive-web-apps-chromium/offline
-          itemType: concept
-          text: Offline scenarios
-        - url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
-          itemType: concept
-          text: Service Workers
-        - url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
-          itemType: concept
-          text: Web App Manifests
-    # Card
-    - title: WebView2
-      links:
-        - url: /microsoft-edge/webview2/index
-          itemType: overview
-          text: Overview
-        - url: /microsoft-edge/webview2/gettingstarted/win32
-          itemType: get-started
-          text: Getting Started with WebView2
-        - url: /microsoft-edge/webview2/gettingstarted/wpf
-          itemType: get-started
-          text: Getting started with WebView2 in WPF
-        - url: /microsoft-edge/webview2/gettingstarted/winforms
-          itemType: get-started
-          text: Getting started with WebView2 in Windows Forms apps
-        - url: /microsoft-edge/webview2/webview2-api-reference
-          itemType: reference
-          text: Microsoft Edge WebView2 API Reference
-    # Card
-    - title: Test & Automation
-      links:
-        - url: /microsoft-edge/devtools-protocol-chromium
-          itemType: how-to-guide
-          text: DevTools Protocol overview
-        - url: /microsoft-edge/webdriver-chromium
-          itemType: how-to-guide
-          text: WebDriver
-        - url: /microsoft-edge/puppeteer
-          itemType: how-to-guide
-          text: Puppeteer
-        - url: /microsoft-edge/visual-studio-code/webhint
-          itemType: how-to-guide
-          text: webhint extension for Visual Studio Code
-    # Card
-    - title: Web Platform
-      links:
-        - url: /microsoft-edge/web-platform/user-agent-guidance
-          itemType: how-to-guide
-          text: Detecting Microsoft Edge from your website
-        - url: /microsoft-edge/web-platform/site-impacting-changes
-          itemType: how-to-guide
-          text: Site compatibility-impacting changes
-    # Card
-    - title: Microsoft Edge IDE integration
-      links:
-        - url: /microsoft-edge/visual-studio/
-          itemType: overview
-          text: Visual Studio
-        - url: /microsoft-edge/visual-studio-code/
-          itemType: overview
-          text: Visual Studio Code overview
-        - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
-          itemType: overview
-          text: DevTools extension for Visual Studio Code
-        - url: /microsoft-edge/visual-studio-code/webhint
-          itemType: overview
-          text: webhint extension for Visual Studio Code
-    # Card
-    - title: Accessibility
-      links:
-        - url: /microsoft-edge/accessibility/
-          itemType: overview
-          text: Accessibility overview
-        - url: /microsoft-edge/accessibility/test
-          itemType: how-to-guide
-          text: Accessibility testing
-        - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
-          itemType: how-to-guide
-          text: Accessibility-testing features in DevTools
+  sections:
+      title: Microsoft Edge for Developers # < 60 chars (optional)
+      # summary:  # < 160 chars (optional)
+      items:
+        # Card
+        - title: Microsoft Edge DevTools
+          links:
+            - url: /microsoft-edge/devtools-guide-chromium
+              itemType: overview
+              text: DevTools overview
+            - url: /microsoft-edge/devtools-guide-chromium/beginners/html
+              itemType: overview
+              text: DevTools for beginners
+            - url: /microsoft-edge/devtools-guide-chromium/command-menu/index
+              itemType: how-to-guide
+              text: Command menu
+            - url: /microsoft-edge/devtools-guide-chromium/open
+              itemType: how-to-guide
+              text: Open DevTools
+            - url: /microsoft-edge/devtools-guide-chromium/css/index
+              itemType: how-to-guide
+              text: View and change CSS
+            - url: /microsoft-edge/devtools-guide-chromium/shortcuts
+              itemType: reference
+              text: Keyboard shortcuts
+        # Card
+        - title: Microsoft Edge Extensions
+          links:
+            - url: /microsoft-edge/extensions-chromium/index
+              itemType: overview
+              text: Extensions Overview
+            - url: /microsoft-edge/extensions-chromium/getting-started/index
+              itemType: overview
+              text: Getting started tutorial
+            - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
+              itemType: overview
+              text: Port a Chromium extension to Microsoft Edge
+            - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
+              itemType: how-to-guide
+              text: Alternate methods of distributing extensions
+            - url: /microsoft-edge/extensions-chromium/publish/publish-extension
+              itemType: how-to-guide
+              text: Step-wise publishing process
+            - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
+              itemType: how-to-guide
+              text: Register as a Microsoft Edge extension developer
+            - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
+              itemType: how-to-guide
+              text: Create a simple extension
+        # Card
+        - title: Progressive Web Apps
+          links:
+            - url: /microsoft-edge/progressive-web-apps-chromium/index
+              itemType: overview
+              text: Overview
+            - url: /microsoft-edge/progressive-web-apps-chromium/get-started
+              itemType: overview
+              text: Get started with Progressive Web Apps
+            - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
+              itemType: overview
+              text: Using DevTools with Progressive Web Apps
+            - url: /microsoft-edge/progressive-web-apps-chromium/offline
+              itemType: concept
+              text: Offline scenarios
+            - url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
+              itemType: concept
+              text: Service Workers
+            - url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
+              itemType: concept
+              text: Web App Manifests
+        # Card
+        - title: WebView2
+          links:
+            - url: /microsoft-edge/webview2/index
+              itemType: overview
+              text: Overview
+            - url: /microsoft-edge/webview2/gettingstarted/win32
+              itemType: get-started
+              text: Getting Started with WebView2
+            - url: /microsoft-edge/webview2/gettingstarted/wpf
+              itemType: get-started
+              text: Getting started with WebView2 in WPF
+            - url: /microsoft-edge/webview2/gettingstarted/winforms
+              itemType: get-started
+              text: Getting started with WebView2 in Windows Forms apps
+            - url: /microsoft-edge/webview2/webview2-api-reference
+              itemType: reference
+              text: Microsoft Edge WebView2 API Reference
+        # Card
+        - title: Test & Automation
+          links:
+            - url: /microsoft-edge/devtools-protocol-chromium
+              itemType: how-to-guide
+              text: DevTools Protocol overview
+            - url: /microsoft-edge/webdriver-chromium
+              itemType: how-to-guide
+              text: WebDriver
+            - url: /microsoft-edge/puppeteer
+              itemType: how-to-guide
+              text: Puppeteer
+            - url: /microsoft-edge/visual-studio-code/webhint
+              itemType: how-to-guide
+              text: webhint extension for Visual Studio Code
+        # Card
+        - title: Web Platform
+          links:
+            - url: /microsoft-edge/web-platform/user-agent-guidance
+              itemType: how-to-guide
+              text: Detecting Microsoft Edge from your website
+            - url: /microsoft-edge/web-platform/site-impacting-changes
+              itemType: how-to-guide
+              text: Site compatibility-impacting changes
+        # Card
+        - title: Microsoft Edge IDE integration
+          links:
+            - url: /microsoft-edge/visual-studio/
+              itemType: overview
+              text: Visual Studio
+            - url: /microsoft-edge/visual-studio-code/
+              itemType: overview
+              text: Visual Studio Code overview
+            - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
+              itemType: overview
+              text: DevTools extension for Visual Studio Code
+            - url: /microsoft-edge/visual-studio-code/webhint
+              itemType: overview
+              text: webhint extension for Visual Studio Code
+        # Card
+        - title: Accessibility
+          links:
+            - url: /microsoft-edge/accessibility/
+              itemType: overview
+              text: Accessibility overview
+            - url: /microsoft-edge/accessibility/test
+              itemType: how-to-guide
+              text: Accessibility testing
+            - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+              itemType: how-to-guide
+              text: Accessibility-testing features in DevTools
 
     - title: Help and Support # < 60 chars (optional)
       # summary: sectionsummary # < 160 chars (optional)

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -263,7 +263,7 @@ conceptualContent:
               itemType: overview
               text: webhint extension for Visual Studio Code
         # Card
-        - title: Accessibility
+        - title: Accessibility in Microsoft Edge
           links:
             - url: /microsoft-edge/accessibility/
               itemType: overview

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -200,7 +200,7 @@ conceptualContent:
               itemType: concept
               text: Web App Manifests
         # Card
-        - title: WebView2
+        - title: WebView2 control
           links:
             - url: /microsoft-edge/webview2/index
               itemType: overview
@@ -239,7 +239,7 @@ conceptualContent:
               itemType: how-to-guide
               text: webhint extension for Visual Studio Code
         # Card
-        - title: Web Platform
+        - title: Web platform
           links:
             - url: /microsoft-edge/web-platform/user-agent-guidance
               itemType: how-to-guide

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -136,101 +136,141 @@ additionalContent:
       # summary: # < 160 chars (optional)
       items:
         # Card
-        - title: DevTools
+        - title: Microsoft Edge DevTools
           links:
-            - text: DevTools overview
+            - itemType: overview
+              text: DevTools overview
               url: /microsoft-edge/devtools-guide-chromium
-            - text: DevTools for beginners
+            - itemType: overview
+              text: DevTools for beginners
               url: /microsoft-edge/devtools-guide-chromium/beginners/html
-            - text: Keyboard shortcuts
-              url: /microsoft-edge/devtools-guide-chromium/shortcuts
-            - text: Command menu
+            - itemType: how-to-guide
+              text: Command menu
               url: /microsoft-edge/devtools-guide-chromium/command-menu/index
-            - text: Open DevTools
+            - itemType: how-to-guide
+              text: Open DevTools
               url: /microsoft-edge/devtools-guide-chromium/open
-            - text: CSS
+            - itemType: how-to-guide
+              text: View and change CSS
               url: /microsoft-edge/devtools-guide-chromium/css/index
+            - itemType: reference
+              text: Keyboard shortcuts
+              url: /microsoft-edge/devtools-guide-chromium/shortcuts
         # Card
-        - title: Test & Automation
+        - title: Microsoft Edge Extensions
           links:
-            - text: Accessibility
-              url: /microsoft-edge/accessibility 
-            - text: DevTools Protocol
-              url: /microsoft-edge/devtools-protocol-chromium
-            - text: WebDriver
-              url: /microsoft-edge/webdriver-chromium
-            - text: Puppeteer
-              url: /microsoft-edge/puppeteer
-            - text: Site compatibility
-              url: /microsoft-edge/web-platform/site-impacting-changes
-            - text: webhint
-              url: /microsoft-edge/visual-studio-code/webhint
-        # Card
-        - title: Get started with Extensions
-          links:
-            - text: Extensions Overview
+            - itemType: overview
+              text: Extensions Overview
               url: /microsoft-edge/extensions-chromium/index
-            - text: Getting started tutorial
+            - itemType: overview
+              text: Getting started tutorial
               url: /microsoft-edge/extensions-chromium/getting-started/index
-            - text: Create a simple extension
-              url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
-        # Card
-        - title: "Extensions: Developer Guide"
-          links:
-            - text: Port Chromium extension to Microsoft Edge
+            - itemType: overview
+              text: Port a Chromium extension to Microsoft Edge
               url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
-            - text: Alternate methods of distributing extensions
+            - itemType: how-to-guide
+              text: Alternate methods of distributing extensions
               url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
-            - text: Native messaging
-              url: /microsoft-edge/extensions-chromium/developer-guide/native-messaging
-        # Card
-        - title: "Extensions: Publish to the Microsoft Store"
-          links:
-            - text: Step-wise publishing process
+            - itemType: how-to-guide
+              text: Step-wise publishing process
               url: /microsoft-edge/extensions-chromium/publish/publish-extension
-            - text: Open developer account
+            - itemType: how-to-guide
+              text: Register as a Microsoft Edge extension developer
               url: /microsoft-edge/extensions-chromium/publish/create-dev-account
-            - text: Add and manage users
-              url: /microsoft-edge/extensions-chromium/publish/aad-account
-            - text: Update Extension Listing
-              url: /microsoft-edge/extensions-chromium/publish/update
-            - text: Manage account settings
-              url: /microsoft-edge/extensions-chromium/publish/manage-settings
-        # Card
-        - title: "Extensions: Microsoft Edge Add-ons Policies"
-          links:
-            - text: Content security policy
-              url: /microsoft-edge/extensions-chromium/store-policies/csp
-            - text: Microsoft Edge Add-ons store developer policies
-              url: /microsoft-edge/extensions-chromium/store-policies/developer-policies
+            - itemType: how-to-guide
+              text: Create a simple extension
+              url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
         # Card
         - title: Progressive Web Apps
           links:
-            - text: Overview
+            - itemType: overview
+              text: Overview
               url: /microsoft-edge/progressive-web-apps-chromium/index
-            - text: Get started with Progressive Web Apps
+            - itemType: overview
+              text: Get started with Progressive Web Apps
               url: /microsoft-edge/progressive-web-apps-chromium/get-started
-            - text: Using DevTools with Progressive Web Apps
+            - itemType: overview
+              text: Using DevTools with Progressive Web Apps
               url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
-            - text: Offline scenarios
+            - itemType: concept
+              text: Offline scenarios
               url: /microsoft-edge/progressive-web-apps-chromium/offline
-            - text: Service Workers
+            - itemType: concept
+              text: Service Workers
               url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
-            - text: Web App Manifests
+            - itemType: concept
+              text: Web App Manifests
               url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
         # Card
         - title: WebView2
           links:
-            - text: Overview
+            - itemType: overview
+              text: Overview
               url: /microsoft-edge/webview2/index
-            - text: Getting Started with WebView2
+            - itemType: get-started
+              text: Getting Started with WebView2
               url: /microsoft-edge/webview2/gettingstarted/win32
-            - text: Getting started with WebView2 in WPF
+            - itemType: get-started
+              text: Getting started with WebView2 in WPF
               url: /microsoft-edge/webview2/gettingstarted/wpf
-            - text: Getting started with WebView2 in Windows Forms apps
+            - itemType: get-started
+              text: Getting started with WebView2 in Windows Forms apps
               url: /microsoft-edge/webview2/gettingstarted/winforms
-            - text: Reference
+            - itemType: reference
+              text: Microsoft Edge WebView2 API Reference
               url: /microsoft-edge/webview2/webview2-api-reference
+        # Card
+        - title: Test & Automation
+          links:
+            - itemType: how-to-guide
+              text: DevTools Protocol overview
+              url: /microsoft-edge/devtools-protocol-chromium
+            - itemType: how-to-guide
+              text: WebDriver
+              url: /microsoft-edge/webdriver-chromium
+            - itemType: how-to-guide
+              text: Puppeteer
+              url: /microsoft-edge/puppeteer
+            - itemType: how-to-guide
+              text: webhint extension for Visual Studio Code
+              url: /microsoft-edge/visual-studio-code/webhint
+        # Card
+        - title: Web Platform
+          links:
+            - itemType: how-to-guide
+              text: Detecting Microsoft Edge from your website
+              url: /microsoft-edge/web-platform/user-agent-guidance
+            - itemType: how-to-guide
+              text: Site compatibility-impacting changes
+              url: /microsoft-edge/web-platform/site-impacting-changes
+        # Card
+        - title: Microsoft Edge IDE integration
+          links:
+            - itemType: overview
+              text: Visual Studio
+              url: /microsoft-edge/visual-studio/
+            - itemType: overview
+              text: Visual Studio Code overview
+              url: /microsoft-edge/visual-studio-code/
+            - itemType: overview
+              text: DevTools extension for Visual Studio Code
+              url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
+            - itemType: overview
+              text: webhint extension for Visual Studio Code
+              url: /microsoft-edge/visual-studio-code/webhint
+        # Card
+        - title: Accessibility
+          links:
+            - itemType: overview
+              text: Accessibility overview
+              url: /microsoft-edge/accessibility/
+            - itemType: how-to-guide
+              text: Accessibility testing
+              url: /microsoft-edge/accessibility/test
+            - itemType: how-to-guide
+              text: Accessibility-testing features in DevTools
+              url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+# end of Developer cards
     - title: Help and Support # < 60 chars (optional)
       # summary: sectionsummary # < 160 chars (optional)
       items:

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -129,7 +129,6 @@ conceptualContent:
             - itemType: reference
               text: Hosting and Updating
               url: /microsoft-edge/extensions-chromium/enterprise/hosting-and-updating
-
 # =============================================================================
     - title: Microsoft Edge for Developers # < 60 chars (optional)
     # summary:  # < 160 chars (optional)
@@ -156,11 +155,11 @@ conceptualContent:
               itemType: reference
               text: Keyboard shortcuts
         # Card
-        - title: Microsoft Edge Extensions
+        - title: Microsoft Edge extensions
           links:
             - url: /microsoft-edge/extensions-chromium/index
               itemType: overview
-              text: Extensions Overview
+              text: Extensions overview
             - url: /microsoft-edge/extensions-chromium/getting-started/index
               itemType: overview
               text: Getting started tutorial
@@ -184,7 +183,7 @@ conceptualContent:
           links:
             - url: /microsoft-edge/progressive-web-apps-chromium/index
               itemType: overview
-              text: Overview
+              text: Progressive Web Apps overview
             - url: /microsoft-edge/progressive-web-apps-chromium/get-started
               itemType: overview
               text: Get started with Progressive Web Apps
@@ -205,7 +204,7 @@ conceptualContent:
           links:
             - url: /microsoft-edge/webview2/index
               itemType: overview
-              text: Overview
+              text: WebView2 overview
             - url: /microsoft-edge/webview2/gettingstarted/win32
               itemType: get-started
               text: Getting Started with WebView2
@@ -219,17 +218,23 @@ conceptualContent:
               itemType: reference
               text: Microsoft Edge WebView2 API Reference
         # Card
-        - title: Test & Automation
+        - title: Test and automation
           links:
             - url: /microsoft-edge/devtools-protocol-chromium
               itemType: how-to-guide
-              text: DevTools Protocol overview
-            - url: /microsoft-edge/webdriver-chromium
-              itemType: how-to-guide
-              text: WebDriver
+              text: DevTools Protocol
+            - url: /microsoft-edge/origin-trials/index
+              itemType: overview
+              text: Origin Trials
+            - url: /microsoft-edge/playwright/index
+              itemType: overview
+              text: Playwright
             - url: /microsoft-edge/puppeteer
               itemType: how-to-guide
               text: Puppeteer
+            - url: /microsoft-edge/webdriver-chromium
+              itemType: how-to-guide
+              text: WebDriver
             - url: /microsoft-edge/visual-studio-code/webhint
               itemType: how-to-guide
               text: webhint extension for Visual Studio Code
@@ -295,7 +300,6 @@ additionalContent:
         - summary: Helpful support resources for users is available.
           title: User Support
           url: https://support.microsoft.com/microsoft-edge
-
     - title: Reference and Legacy Docs # < 60 chars (optional)
       # summary: sectionsummary # < 160 chars (optional)
       items:

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -13,6 +13,7 @@ metadata:
   ms.localizationpriority: high
   ms.prod: microsoft-edge
 
+# =============================================================================
 # highlightedContent section (optional)
 # Maximum of 8 items
 highlightedContent:
@@ -51,6 +52,7 @@ highlightedContent:
       url: /microsoft-edge/index#microsoft-edge-for-developers
       # url: /microsoft-edge/index#microsoft-edge-for-developers #alt-link
 
+# =============================================================================
 # conceptualContent section (optional)
 conceptualContent:
 # itemType: architecture | concept | deploy | download | 
@@ -127,152 +129,152 @@ conceptualContent:
           text: Hosting and Updating
           url: /microsoft-edge/extensions-chromium/enterprise/hosting-and-updating
 
-# conceptualContent section (optional)
-conceptualContent:
-# itemType: architecture | concept | deploy | download | 
-#           get-started | how-to-guide | learn | overview | 
-#           quickstart | reference | tutorial | video | 
-#           whats-new
-  sections:
-      title: Microsoft Edge for Developers # < 60 chars (optional)
-      # summary:  # < 160 chars (optional)
-      items:
-        # Card
-        - title: Microsoft Edge DevTools
-          links:
-            - url: /microsoft-edge/devtools-guide-chromium
-              itemType: overview
-              text: DevTools overview
-            - url: /microsoft-edge/devtools-guide-chromium/beginners/html
-              itemType: overview
-              text: DevTools for beginners
-            - url: /microsoft-edge/devtools-guide-chromium/command-menu/index
-              itemType: how-to-guide
-              text: Command menu
-            - url: /microsoft-edge/devtools-guide-chromium/open
-              itemType: how-to-guide
-              text: Open DevTools
-            - url: /microsoft-edge/devtools-guide-chromium/css/index
-              itemType: how-to-guide
-              text: View and change CSS
-            - url: /microsoft-edge/devtools-guide-chromium/shortcuts
-              itemType: reference
-              text: Keyboard shortcuts
-        # Card
-        - title: Microsoft Edge Extensions
-          links:
-            - url: /microsoft-edge/extensions-chromium/index
-              itemType: overview
-              text: Extensions Overview
-            - url: /microsoft-edge/extensions-chromium/getting-started/index
-              itemType: overview
-              text: Getting started tutorial
-            - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
-              itemType: overview
-              text: Port a Chromium extension to Microsoft Edge
-            - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
-              itemType: how-to-guide
-              text: Alternate methods of distributing extensions
-            - url: /microsoft-edge/extensions-chromium/publish/publish-extension
-              itemType: how-to-guide
-              text: Step-wise publishing process
-            - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
-              itemType: how-to-guide
-              text: Register as a Microsoft Edge extension developer
-            - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
-              itemType: how-to-guide
-              text: Create a simple extension
-        # Card
-        - title: Progressive Web Apps
-          links:
-            - url: /microsoft-edge/progressive-web-apps-chromium/index
-              itemType: overview
-              text: Overview
-            - url: /microsoft-edge/progressive-web-apps-chromium/get-started
-              itemType: overview
-              text: Get started with Progressive Web Apps
-            - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
-              itemType: overview
-              text: Using DevTools with Progressive Web Apps
-            - url: /microsoft-edge/progressive-web-apps-chromium/offline
-              itemType: concept
-              text: Offline scenarios
-            - url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
-              itemType: concept
-              text: Service Workers
-            - url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
-              itemType: concept
-              text: Web App Manifests
-        # Card
-        - title: WebView2
-          links:
-            - url: /microsoft-edge/webview2/index
-              itemType: overview
-              text: Overview
-            - url: /microsoft-edge/webview2/gettingstarted/win32
-              itemType: get-started
-              text: Getting Started with WebView2
-            - url: /microsoft-edge/webview2/gettingstarted/wpf
-              itemType: get-started
-              text: Getting started with WebView2 in WPF
-            - url: /microsoft-edge/webview2/gettingstarted/winforms
-              itemType: get-started
-              text: Getting started with WebView2 in Windows Forms apps
-            - url: /microsoft-edge/webview2/webview2-api-reference
-              itemType: reference
-              text: Microsoft Edge WebView2 API Reference
-        # Card
-        - title: Test & Automation
-          links:
-            - url: /microsoft-edge/devtools-protocol-chromium
-              itemType: how-to-guide
-              text: DevTools Protocol overview
-            - url: /microsoft-edge/webdriver-chromium
-              itemType: how-to-guide
-              text: WebDriver
-            - url: /microsoft-edge/puppeteer
-              itemType: how-to-guide
-              text: Puppeteer
-            - url: /microsoft-edge/visual-studio-code/webhint
-              itemType: how-to-guide
-              text: webhint extension for Visual Studio Code
-        # Card
-        - title: Web Platform
-          links:
-            - url: /microsoft-edge/web-platform/user-agent-guidance
-              itemType: how-to-guide
-              text: Detecting Microsoft Edge from your website
-            - url: /microsoft-edge/web-platform/site-impacting-changes
-              itemType: how-to-guide
-              text: Site compatibility-impacting changes
-        # Card
-        - title: Microsoft Edge IDE integration
-          links:
-            - url: /microsoft-edge/visual-studio/
-              itemType: overview
-              text: Visual Studio
-            - url: /microsoft-edge/visual-studio-code/
-              itemType: overview
-              text: Visual Studio Code overview
-            - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
-              itemType: overview
-              text: DevTools extension for Visual Studio Code
-            - url: /microsoft-edge/visual-studio-code/webhint
-              itemType: overview
-              text: webhint extension for Visual Studio Code
-        # Card
-        - title: Accessibility
-          links:
-            - url: /microsoft-edge/accessibility/
-              itemType: overview
-              text: Accessibility overview
-            - url: /microsoft-edge/accessibility/test
-              itemType: how-to-guide
-              text: Accessibility testing
-            - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
-              itemType: how-to-guide
-              text: Accessibility-testing features in DevTools
+# =============================================================================
+  title: Microsoft Edge for Developers # < 60 chars (optional)
+  # summary:  # < 160 chars (optional)
+  items:
+    # Card
+    - title: Microsoft Edge DevTools
+      links:
+        - url: /microsoft-edge/devtools-guide-chromium
+          itemType: overview
+          text: DevTools overview
+        - url: /microsoft-edge/devtools-guide-chromium/beginners/html
+          itemType: overview
+          text: DevTools for beginners
+        - url: /microsoft-edge/devtools-guide-chromium/command-menu/index
+          itemType: how-to-guide
+          text: Command menu
+        - url: /microsoft-edge/devtools-guide-chromium/open
+          itemType: how-to-guide
+          text: Open DevTools
+        - url: /microsoft-edge/devtools-guide-chromium/css/index
+          itemType: how-to-guide
+          text: View and change CSS
+        - url: /microsoft-edge/devtools-guide-chromium/shortcuts
+          itemType: reference
+          text: Keyboard shortcuts
+    # Card
+    - title: Microsoft Edge Extensions
+      links:
+        - url: /microsoft-edge/extensions-chromium/index
+          itemType: overview
+          text: Extensions Overview
+        - url: /microsoft-edge/extensions-chromium/getting-started/index
+          itemType: overview
+          text: Getting started tutorial
+        - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
+          itemType: overview
+          text: Port a Chromium extension to Microsoft Edge
+        - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
+          itemType: how-to-guide
+          text: Alternate methods of distributing extensions
+        - url: /microsoft-edge/extensions-chromium/publish/publish-extension
+          itemType: how-to-guide
+          text: Step-wise publishing process
+        - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
+          itemType: how-to-guide
+          text: Register as a Microsoft Edge extension developer
+        - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
+          itemType: how-to-guide
+          text: Create a simple extension
+    # Card
+    - title: Progressive Web Apps
+      links:
+        - url: /microsoft-edge/progressive-web-apps-chromium/index
+          itemType: overview
+          text: Overview
+        - url: /microsoft-edge/progressive-web-apps-chromium/get-started
+          itemType: overview
+          text: Get started with Progressive Web Apps
+        - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
+          itemType: overview
+          text: Using DevTools with Progressive Web Apps
+        - url: /microsoft-edge/progressive-web-apps-chromium/offline
+          itemType: concept
+          text: Offline scenarios
+        - url: /microsoft-edge/progressive-web-apps-chromium/serviceworker
+          itemType: concept
+          text: Service Workers
+        - url: /microsoft-edge/progressive-web-apps-chromium/webappmanifests
+          itemType: concept
+          text: Web App Manifests
+    # Card
+    - title: WebView2
+      links:
+        - url: /microsoft-edge/webview2/index
+          itemType: overview
+          text: Overview
+        - url: /microsoft-edge/webview2/gettingstarted/win32
+          itemType: get-started
+          text: Getting Started with WebView2
+        - url: /microsoft-edge/webview2/gettingstarted/wpf
+          itemType: get-started
+          text: Getting started with WebView2 in WPF
+        - url: /microsoft-edge/webview2/gettingstarted/winforms
+          itemType: get-started
+          text: Getting started with WebView2 in Windows Forms apps
+        - url: /microsoft-edge/webview2/webview2-api-reference
+          itemType: reference
+          text: Microsoft Edge WebView2 API Reference
+    # Card
+    - title: Test & Automation
+      links:
+        - url: /microsoft-edge/devtools-protocol-chromium
+          itemType: how-to-guide
+          text: DevTools Protocol overview
+        - url: /microsoft-edge/webdriver-chromium
+          itemType: how-to-guide
+          text: WebDriver
+        - url: /microsoft-edge/puppeteer
+          itemType: how-to-guide
+          text: Puppeteer
+        - url: /microsoft-edge/visual-studio-code/webhint
+          itemType: how-to-guide
+          text: webhint extension for Visual Studio Code
+    # Card
+    - title: Web Platform
+      links:
+        - url: /microsoft-edge/web-platform/user-agent-guidance
+          itemType: how-to-guide
+          text: Detecting Microsoft Edge from your website
+        - url: /microsoft-edge/web-platform/site-impacting-changes
+          itemType: how-to-guide
+          text: Site compatibility-impacting changes
+    # Card
+    - title: Microsoft Edge IDE integration
+      links:
+        - url: /microsoft-edge/visual-studio/
+          itemType: overview
+          text: Visual Studio
+        - url: /microsoft-edge/visual-studio-code/
+          itemType: overview
+          text: Visual Studio Code overview
+        - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
+          itemType: overview
+          text: DevTools extension for Visual Studio Code
+        - url: /microsoft-edge/visual-studio-code/webhint
+          itemType: overview
+          text: webhint extension for Visual Studio Code
+    # Card
+    - title: Accessibility
+      links:
+        - url: /microsoft-edge/accessibility/
+          itemType: overview
+          text: Accessibility overview
+        - url: /microsoft-edge/accessibility/test
+          itemType: how-to-guide
+          text: Accessibility testing
+        - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+          itemType: how-to-guide
+          text: Accessibility-testing features in DevTools
 
+# =============================================================================
+# additionalContent section (optional)
+# Card with summary style
+additionalContent:
+  # Supports up to 4 sections
+  sections:
     - title: Help and Support # < 60 chars (optional)
       # summary: sectionsummary # < 160 chars (optional)
       items:

--- a/microsoft-edge/test-and-automation/devtools-protocol-overview-aux-node.md
+++ b/microsoft-edge/test-and-automation/devtools-protocol-overview-aux-node.md
@@ -1,0 +1,12 @@
+---
+description: Microsoft Edge DevTools Protocol (auxiliary entry in the table of contents).
+title: DevTools Protocol overview
+author: MSEdgeTeam
+ms.author: msedgedevrel
+ms.date: 09/09/2021
+ms.topic: reference
+ms.prod: microsoft-edge
+---
+# DevTools Protocol overview
+
+Navigate to [Microsoft Edge DevTools Protocol overview](../devtools-protocol-chromium/index.md).

--- a/microsoft-edge/test-and-automation/webhint-aux-node.md
+++ b/microsoft-edge/test-and-automation/webhint-aux-node.md
@@ -1,0 +1,12 @@
+---
+description: webhint (auxiliary entry in the table of contents).
+title: webhint
+author: MSEdgeTeam
+ms.author: msedgedevrel
+ms.date: 09/09/2021
+ms.topic: reference
+ms.prod: microsoft-edge
+---
+# webhint
+
+Navigate to [The webhint extension for Visual Studio Code](../visual-studio-code/webhint.md).

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -466,6 +466,8 @@
                 - name: COM Interop
                   href: /microsoft-edge/webview2/reference/winrt/interop/index
 # Card: Test & Automation =====================================================
+    - name: DevTools Protocol overview
+      href: test-and-automation/devtools-protocol-overview-aux-node.md
     - name: WebDriver
       items:
         - name: WebDriver overview
@@ -476,6 +478,8 @@
           href: webdriver-chromium/verify-selenium-tools.md
     - name: Puppeteer overview
       href: puppeteer/index.md
+    - name: webhint
+      href: test-and-automation/webhint-aux-node.md
 # Card: Web platform ==========================================================
     - name: Web platform
       items:

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -4,7 +4,7 @@
   href: developer/index.yml
 #  expanded: true
   items:
-# Card: DevTools ==============================================================
+# equivalent card: DevTools ===================================================
     - name: DevTools
       items:
         - name: DevTools overview
@@ -297,7 +297,7 @@
               href: devtools-protocol-chromium/index.md
             - name: Keyboard shortcuts
               href: devtools-guide-chromium/shortcuts/index.md
-# Card: Extensions ============================================================
+# equivalent card: Extensions =================================================
     - name: Extensions
       items:
         - name: Overview of Microsoft Edge extensions
@@ -368,7 +368,7 @@
               href: extensions-chromium/enterprise/hosting-and-updating.md
             - name: Auto-update
               href: extensions-chromium/enterprise/auto-update.md
-# Card: Progressive Web Apps ==================================================
+# equivalent card: Progressive Web Apps =======================================
     - name: Progressive Web Apps
       items:
         - name: Progressive Web Apps overview
@@ -387,7 +387,7 @@
           href: progressive-web-apps-chromium/experimental-features/index.md
         - name: Publish a PWA to the Microsoft Store
           href: progressive-web-apps-chromium/microsoft-store.md
-# Card: WebView2 ==============================================================
+# equivalent card: WebView2 ===================================================
     - name: WebView2
       items:
         - name: WebView2 overview
@@ -465,22 +465,24 @@
                   href: /microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index
                 - name: COM Interop
                   href: /microsoft-edge/webview2/reference/winrt/interop/index
-# Card: Test & Automation =====================================================
-    - name: DevTools Protocol overview
-      href: test-and-automation/devtools-protocol-overview-aux-node.md
-    - name: WebDriver
+# equivalent card: Test & Automation ==========================================
+    - name: Test and automation
       items:
-        - name: WebDriver overview
-          href: webdriver-chromium/index.md
-        - name: Capabilities and EdgeOptions
-          href: webdriver-chromium/capabilities-edge-options.md
-        - name: Verifying downloads of Selenium Tools for Microsoft Edge
-          href: webdriver-chromium/verify-selenium-tools.md
-    - name: Puppeteer overview
-      href: puppeteer/index.md
-    - name: webhint
-      href: test-and-automation/webhint-aux-node.md
-# Card: Web platform ==========================================================
+        - name: DevTools Protocol overview
+          href: test-and-automation/devtools-protocol-overview-aux-node.md
+        - name: WebDriver
+          items:
+            - name: WebDriver overview
+              href: webdriver-chromium/index.md
+            - name: Capabilities and EdgeOptions
+              href: webdriver-chromium/capabilities-edge-options.md
+            - name: Verifying downloads of Selenium Tools for Microsoft Edge
+              href: webdriver-chromium/verify-selenium-tools.md
+        - name: Puppeteer overview
+          href: puppeteer/index.md
+        - name: webhint
+          href: test-and-automation/webhint-aux-node.md
+# equivalent card: Web platform ===============================================
     - name: Web platform
       items:
         - name: Site compatibility-impacting changes coming to Microsoft Edge
@@ -493,7 +495,7 @@
           href: web-platform/user-agent-guidance.md
         - name: Customize the password reveal button
           href: web-platform/password-reveal.md
-# Card: Microsoft Edge IDE integration ========================================
+# equivalent card: Microsoft Edge IDE integration =============================
     - name: Visual Studio overview
       href: visual-studio/index.md
     - name: Visual Studio Code
@@ -506,7 +508,7 @@
           href: visual-studio-code/microsoft-edge-devtools-extension.md
         - name: webhint extension
           href: visual-studio-code/webhint.md
-# Card: Accessibility =========================================================
+# equivalent card: Accessibility ==============================================
     - name: Accessibility
       items:
         - name: Accessibility overview

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -496,18 +496,20 @@
         - name: Customize the password reveal button
           href: web-platform/password-reveal.md
 # equivalent card: Microsoft Edge IDE integration =============================
-    - name: Visual Studio overview
-      href: visual-studio/index.md
-    - name: Visual Studio Code
+    - name: Microsoft Edge IDE integration
       items:
-        - name: Visual Studio Code overview
-          href: visual-studio-code/index.md
-        - name: Debugger for Edge
-          href: visual-studio-code/debugger-for-edge.md
-        - name: Microsoft Edge DevTools extension
-          href: visual-studio-code/microsoft-edge-devtools-extension.md
-        - name: webhint extension
-          href: visual-studio-code/webhint.md
+        - name: Visual Studio overview
+          href: visual-studio/index.md
+        - name: Visual Studio Code
+          items:
+            - name: Visual Studio Code overview
+              href: visual-studio-code/index.md
+            - name: Debugger for Edge
+              href: visual-studio-code/debugger-for-edge.md
+            - name: Microsoft Edge DevTools extension
+              href: visual-studio-code/microsoft-edge-devtools-extension.md
+            - name: webhint extension
+              href: visual-studio-code/webhint.md
 # equivalent card: Accessibility ==============================================
     - name: Accessibility
       items:

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -470,6 +470,12 @@
       items:
         - name: DevTools Protocol
           href: test-and-automation/devtools-protocol-overview-aux-node.md
+        - name: Origin Trials
+          href: origin-trials/index.md
+        - name: Playwright
+          href: playwright/index.md
+        - name: Puppeteer
+          href: puppeteer/index.md
         - name: WebDriver
           items:
             - name: WebDriver overview
@@ -478,12 +484,6 @@
               href: webdriver-chromium/capabilities-edge-options.md
             - name: Verifying downloads of Selenium Tools for Microsoft Edge
               href: webdriver-chromium/verify-selenium-tools.md
-        - name: Origin Trials
-          href: origin-trials/index.md
-        - name: Playwright
-          href: playwright/index.md
-        - name: Puppeteer
-          href: puppeteer/index.md
         - name: webhint
           href: test-and-automation/webhint-aux-node.md
 # equivalent card: Web platform ===============================================

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -5,7 +5,7 @@
 #  expanded: true
   items:
 # equivalent card: DevTools ===================================================
-    - name: DevTools
+    - name: Microsoft Edge DevTools
       items:
         - name: DevTools overview
           href: devtools-guide-chromium/index.md
@@ -298,7 +298,7 @@
             - name: Keyboard shortcuts
               href: devtools-guide-chromium/shortcuts/index.md
 # equivalent card: Extensions =================================================
-    - name: Extensions
+    - name: Microsoft Edge Extensions
       items:
         - name: Overview of Microsoft Edge extensions
           href: extensions-chromium/index.md
@@ -388,7 +388,7 @@
         - name: Publish a PWA to the Microsoft Store
           href: progressive-web-apps-chromium/microsoft-store.md
 # equivalent card: WebView2 ===================================================
-    - name: WebView2
+    - name: WebView2 control
       items:
         - name: WebView2 overview
           href: webview2/index.md
@@ -465,7 +465,7 @@
                   href: /microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index
                 - name: COM Interop
                   href: /microsoft-edge/webview2/reference/winrt/interop/index
-# equivalent card: Test & Automation ==========================================
+# equivalent card: Test and automation ==========================================
     - name: Test and automation
       items:
         - name: DevTools Protocol

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -293,7 +293,7 @@
               href: devtools-guide-chromium/console/api.md
             - name: Console Utilities API reference
               href: devtools-guide-chromium/console/utilities.md
-            - name: DevTools Protocol overview
+            - name: DevTools Protocol
               href: devtools-protocol-chromium/index.md
             - name: Keyboard shortcuts
               href: devtools-guide-chromium/shortcuts/index.md
@@ -468,7 +468,7 @@
 # equivalent card: Test & Automation ==========================================
     - name: Test and automation
       items:
-        - name: DevTools Protocol overview
+        - name: DevTools Protocol
           href: test-and-automation/devtools-protocol-overview-aux-node.md
         - name: WebDriver
           items:
@@ -478,7 +478,11 @@
               href: webdriver-chromium/capabilities-edge-options.md
             - name: Verifying downloads of Selenium Tools for Microsoft Edge
               href: webdriver-chromium/verify-selenium-tools.md
-        - name: Puppeteer overview
+        - name: Origin Trials
+          href: origin-trials/index.md
+        - name: Playwright
+          href: playwright/index.md
+        - name: Puppeteer
           href: puppeteer/index.md
         - name: webhint
           href: test-and-automation/webhint-aux-node.md
@@ -525,11 +529,7 @@
         - name: Test
           href: accessibility/test.md
 # SORT into the above card sections ===========================================
-    - name: Origin Trials overview
-      href: origin-trials/index.md
     - name: Privacy whitepaper
       href: privacy-whitepaper/index.md
-    - name: Playwright overview
-      href: playwright/index.md
     - name: Web We Want overview
       href: web-we-want/index.md

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -515,18 +515,17 @@
             - name: webhint extension
               href: visual-studio-code/webhint.md
 # equivalent card: Accessibility ==============================================
-    - name: Accessibility
+    - name: Accessibility in Microsoft Edge
       items:
         - name: Accessibility overview
           href: accessibility/index.md
-        - name: Design
+        - name: Designing accessible websites
           href: accessibility/design.md
-        - name: Build
+        - name: Building accessible websites
           href: accessibility/build/index.md
-          items:
-            - name: ARIA and UI automation
-              href: accessibility/build/ARIA-and-UI-Automation.md
-        - name: Test
+        - name: ARIA and UI automation
+          href: accessibility/build/ARIA-and-UI-Automation.md
+        - name: Accessibility testing
           href: accessibility/test.md
 # SORT into the above card sections ===========================================
     - name: Privacy whitepaper

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -4,19 +4,7 @@
   href: developer/index.yml
 #  expanded: true
   items:
-    - name: Accessibility
-      items:
-        - name: Accessibility overview
-          href: accessibility/index.md
-        - name: Design
-          href: accessibility/design.md
-        - name: Build
-          href: accessibility/build/index.md
-          items:
-            - name: ARIA and UI automation
-              href: accessibility/build/ARIA-and-UI-Automation.md
-        - name: Test
-          href: accessibility/test.md
+# Card: DevTools ==============================================================
     - name: DevTools
       items:
         - name: DevTools overview
@@ -309,6 +297,7 @@
               href: devtools-protocol-chromium/index.md
             - name: Keyboard shortcuts
               href: devtools-guide-chromium/shortcuts/index.md
+# Card: Extensions ============================================================
     - name: Extensions
       items:
         - name: Overview of Microsoft Edge extensions
@@ -379,10 +368,7 @@
               href: extensions-chromium/enterprise/hosting-and-updating.md
             - name: Auto-update
               href: extensions-chromium/enterprise/auto-update.md
-    - name: Origin Trials overview
-      href: origin-trials/index.md
-    - name: Privacy whitepaper
-      href: privacy-whitepaper/index.md
+# Card: Progressive Web Apps ==================================================
     - name: Progressive Web Apps
       items:
         - name: Progressive Web Apps overview
@@ -401,44 +387,7 @@
           href: progressive-web-apps-chromium/experimental-features/index.md
         - name: Publish a PWA to the Microsoft Store
           href: progressive-web-apps-chromium/microsoft-store.md
-    - name: Playwright overview
-      href: playwright/index.md
-    - name: Puppeteer overview
-      href: puppeteer/index.md
-    - name: Visual Studio overview
-      href: visual-studio/index.md
-    - name: Visual Studio Code
-      items:
-        - name: Visual Studio Code overview
-          href: visual-studio-code/index.md
-        - name: Debugger for Edge
-          href: visual-studio-code/debugger-for-edge.md
-        - name: Microsoft Edge DevTools extension
-          href: visual-studio-code/microsoft-edge-devtools-extension.md
-        - name: webhint extension
-          href: visual-studio-code/webhint.md
-    - name: Web platform
-      items:
-        - name: Site compatibility-impacting changes coming to Microsoft Edge
-          href: web-platform/site-impacting-changes.md
-        - name: Moving users to Microsoft Edge from IE
-          href: web-platform/ie-to-microsoft-edge-redirection.md
-        - name: Tracking prevention in Microsoft Edge
-          href: web-platform/tracking-prevention.md
-        - name: Detecting Microsoft Edge from your website
-          href: web-platform/user-agent-guidance.md
-        - name: Customize the password reveal button
-          href: web-platform/password-reveal.md
-    - name: Web We Want overview
-      href: web-we-want/index.md
-    - name: WebDriver
-      items:
-        - name: WebDriver overview
-          href: webdriver-chromium/index.md
-        - name: Capabilities and EdgeOptions
-          href: webdriver-chromium/capabilities-edge-options.md
-        - name: Verifying downloads of Selenium Tools for Microsoft Edge
-          href: webdriver-chromium/verify-selenium-tools.md
+# Card: WebView2 ==============================================================
     - name: WebView2
       items:
         - name: WebView2 overview
@@ -516,3 +465,63 @@
                   href: /microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index
                 - name: COM Interop
                   href: /microsoft-edge/webview2/reference/winrt/interop/index
+# Card: Test & Automation =====================================================
+    - name: WebDriver
+      items:
+        - name: WebDriver overview
+          href: webdriver-chromium/index.md
+        - name: Capabilities and EdgeOptions
+          href: webdriver-chromium/capabilities-edge-options.md
+        - name: Verifying downloads of Selenium Tools for Microsoft Edge
+          href: webdriver-chromium/verify-selenium-tools.md
+    - name: Puppeteer overview
+      href: puppeteer/index.md
+# Card: Web platform ==========================================================
+    - name: Web platform
+      items:
+        - name: Site compatibility-impacting changes coming to Microsoft Edge
+          href: web-platform/site-impacting-changes.md
+        - name: Moving users to Microsoft Edge from IE
+          href: web-platform/ie-to-microsoft-edge-redirection.md
+        - name: Tracking prevention in Microsoft Edge
+          href: web-platform/tracking-prevention.md
+        - name: Detecting Microsoft Edge from your website
+          href: web-platform/user-agent-guidance.md
+        - name: Customize the password reveal button
+          href: web-platform/password-reveal.md
+# Card: Microsoft Edge IDE integration ========================================
+    - name: Visual Studio overview
+      href: visual-studio/index.md
+    - name: Visual Studio Code
+      items:
+        - name: Visual Studio Code overview
+          href: visual-studio-code/index.md
+        - name: Debugger for Edge
+          href: visual-studio-code/debugger-for-edge.md
+        - name: Microsoft Edge DevTools extension
+          href: visual-studio-code/microsoft-edge-devtools-extension.md
+        - name: webhint extension
+          href: visual-studio-code/webhint.md
+# Card: Accessibility =========================================================
+    - name: Accessibility
+      items:
+        - name: Accessibility overview
+          href: accessibility/index.md
+        - name: Design
+          href: accessibility/design.md
+        - name: Build
+          href: accessibility/build/index.md
+          items:
+            - name: ARIA and UI automation
+              href: accessibility/build/ARIA-and-UI-Automation.md
+        - name: Test
+          href: accessibility/test.md
+# SORT into the above card sections ===========================================
+    - name: Origin Trials overview
+      href: origin-trials/index.md
+    - name: Privacy whitepaper
+      href: privacy-whitepaper/index.md
+    - name: Playwright overview
+      href: playwright/index.md
+    - name: Web We Want overview
+      href: web-we-want/index.md


### PR DESCRIPTION
* With the Content & Learning / Information Architecture team, figured out how to properly tag the "Microsoft Edge for Developers" section of the hub page.
* The "Microsoft Edge for Developers" section of the hub page now has the same, gray background color as the "Enterprise" section.
* The "Microsoft Edge for Developers" section of the hub page is now 1" closer, vertically, to the "Enterprise" section, bringing more content into view and more integrating the two doc-sets.
* Replaced the cards, which has an unbalanced emphasis on Microsoft Edge Extensions, by the cards from the landing page, which have even coverage of the TOC feature areas.
* *  The tagging correction places icons by the links in the "Microsoft Edge for Developers" section of the hub page, matching the Enterprise section.
*  The tagging correction places the "Microsoft Edge for Developers" section of the hub page in the "conceptualContent: " section (immediately following the "Microsoft Edge for Enterprise" section) instead of the asymmetrical/inconsistent fallback tagging approach of "additionalContent:" that was previously used.
* The TOC buckets match the [landing page](https://review.docs.microsoft.com/en-us/microsoft-edge/developer/?branch=user%2Fv-mhoffman%2Fhub-page) cards.
* Individual articles about testing and automation, that had unclear titles in the TOC, now are gathered in an explicitly labelled "Test and automation" bucket.

[Before](https://docs.microsoft.com/en-us/microsoft-edge/)/[After](https://review.docs.microsoft.com/en-us/microsoft-edge/?branch=user/v-mhoffman/hub-page)