### PR TITLE
Deferrals in C# using block

### DIFF
--- a/microsoft-edge/webview2/concepts/threading-model.md
+++ b/microsoft-edge/webview2/concepts/threading-model.md
@@ -81,9 +81,9 @@ For instance, you can use the `NewWindowRequested` event to provide a `CoreWebVi
 
 ### Deferrals in C#
 
-When using a `Deferral` in C# the best practice is to use it with a `using` block. The `using` block will ensure that the `Deferral` is completed even if an exception is thrown in the middle of the `using` block. If instead you have code to explicitly call `Complete`, but an exception is thrown before your `Complete` call occurs then the deferral isn't completed until some time later when the garbage collector eventually collects and disposes of the deferral. In the interim the WebView2 will be waiting for the app code to handle the event.
+When using a `Deferral` in C#, the best practice is to use it with a `using` block. The `using` block ensures that the `Deferral` is completed even if an exception is thrown in the middle of the `using` block. If instead, you have code to explicitly call `Complete`, but an exception is thrown before your `Complete` call occurs, then the deferral isn't completed until some time later, when the garbage collector eventually collects and disposes of the deferral. In the interim, the WebView2 waits for the app code to handle the event.
 
-For example, don't do the following because if there's an exception before calling `Complete` the WebResourceRequested event won't be considered handled and will block WebView2 from rendering that web content.
+For example, don't do the following, because if there's an exception before calling `Complete`, the `WebResourceRequested` event isn't considered "handled", and blocks WebView2 from rendering that web content.
 
 ```csharp
 private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs eventArgs)
@@ -97,7 +97,7 @@ private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, Core
 }
 ```
 
-Instead use a `using` block as in the following example. The `using` block will ensure the `Deferral` is completed whether or not there's an exception.
+Instead, use a `using` block, as in the following example. The `using` block ensures that the `Deferral` is completed, whether or not there's an exception.
 
 ```csharp
 private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs eventArgs)

--- a/microsoft-edge/webview2/concepts/threading-model.md
+++ b/microsoft-edge/webview2/concepts/threading-model.md
@@ -3,7 +3,7 @@ description: In the WebView2 threading model, the WebView2 must be created on a 
 title: Threading model for WebView2
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: 07/28/2021
+ms.date: 09/21/2021
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview

--- a/microsoft-edge/webview2/concepts/threading-model.md
+++ b/microsoft-edge/webview2/concepts/threading-model.md
@@ -86,13 +86,15 @@ When using a `Deferral` in C#, the best practice is to use it with a `using` blo
 For example, don't do the following, because if there's an exception before calling `Complete`, the `WebResourceRequested` event isn't considered "handled", and blocks WebView2 from rendering that web content.
 
 ```csharp
-private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs eventArgs)
+private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, 
+                           CoreWebView2WebResourceRequestedEventArgs eventArgs)
 {
    var deferral = eventArgs.GetDeferral();
 
    args.Response = await CreateResponse(eventArgs);
 
-   // NOT recommended. If CreateResponse throws the deferral isn't completed.
+   // Calling Complete is not recommended, because if CreateResponse
+   // throws an exception, the deferral isn't completed.
    deferral.Complete();
 }
 ```
@@ -100,15 +102,18 @@ private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, Core
 Instead, use a `using` block, as in the following example. The `using` block ensures that the `Deferral` is completed, whether or not there's an exception.
 
 ```csharp
-private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, CoreWebView2WebResourceRequestedEventArgs eventArgs)
+private async void WebView2WebResourceRequestedHandler(CoreWebView2 sender, 
+                           CoreWebView2WebResourceRequestedEventArgs eventArgs)
 {
-   // Using block ensures the deferral is completed regardless of exception.
+   // The using block ensures that the deferral is completed, regardless of
+   // whether there's an exception.
    using (eventArgs.GetDeferral())
    {
       args.Response = await CreateResponse(eventArgs);
    }
 }
 ```
+
 
 ## Block the UI thread  
 


### PR DESCRIPTION
Update the threading model doc to note that when using deferrals in C# the best practice is to use them with a using block.