### PR TITLE
Change "first-class" with something more inclusive

### DIFF
--- a/microsoft-edge/progressive-web-apps-chromium/index.md
+++ b/microsoft-edge/progressive-web-apps-chromium/index.md
@@ -17,7 +17,7 @@ PWAs are websites that are **[progressively enhanced][AListApartUnderstandingPro
 
 The qualities of a PWA combine **the best of the web and compiled apps**. PWAs run in browsers, like websites, but have access to app features like the ability to work offline, be installed on the operating system, support push notifications and periodic updates, access hardware features, and more.
 
-**PWAs are first-class citizens on Windows**. When installed, they behave like other apps. They can be added to the Start Menu, pinned to the Taskbar, handle files, run on user login, and more.
+When installed, **PWAs are just like other apps on Windows**. They can be added to the Start Menu, pinned to the Taskbar, handle files, run on user login, and more.
 
 PWAs can also be **submitted to the Microsoft Store** where millions of Windows users can discover and easily install them alongside other Windows apps.
 
@@ -120,7 +120,7 @@ Check out [Myth Busting PWAs][Davrous20191018MythBustingPwasNewEdgeEdition] for 
 <!-- ====================================================================== -->
 ## The Microsoft Store
 
-Because PWAs are first-class citizens in the [Microsoft Store][PwaMicrosoftStore], users can fully engage with them, from discovery, to installation, to execution, without ever opening the browser.
+Because PWAs are just like other apps in the [Microsoft Store][PwaMicrosoftStore], users can fully engage with them, from discovery, to installation, to execution, without ever opening the browser.
 
 As the most used app on PCs, the Microsoft Store provides a trustworthy and familiar experience for your users to install your app. Additionally, you can view detailed usage statistics and charts that let you know how your apps in the Microsoft Store are doing.
 

--- a/microsoft-edge/progressive-web-apps-chromium/ux.md
+++ b/microsoft-edge/progressive-web-apps-chromium/ux.md
@@ -10,7 +10,7 @@ keywords: progressive web apps, PWA, Edge, Windows, desktop, installation, integ
 ---
 # The user experience of PWAs
 
-On Windows, PWAs are first-class app citizens.  Any device running Microsoft Edge gets full access to the technologies and characteristics of Progressive Web Apps.
+On Windows, PWAs are just like other apps.  Any device running Microsoft Edge gets full access to the technologies and characteristics of Progressive Web Apps.
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
This changes 3 places in the PWA docs where we use the phrase "first-class citizen apps" to be more inclusive.