### PR TITLE
Old version bot ignores PWA what's new

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "markdownlint.config": {
-        "MD028": false,
-        "MD025": {
-            "front_matter_title": ""
-        }
-    }
-}


### PR DESCRIPTION
The What's New page in the PWA section will always contain version numbers.
So, we don't need for the old-version-reference bot to check this page. So I'm adding it to the list of ignored pages. We were already ignoring the what's new content for devtools and webview.

For info, the bot recently created this issue: https://github.com/MicrosoftDocs/edge-developer/issues/1490 which contains 3 references of old versions in the PWA what's new.

This change will make sure that next time this won't happen.