### PR TITLE
WebView2 Release Notes for Edge 95 & prerelease

### DIFF
--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -15,9 +15,10 @@ The WebView2 team updates the [WebView2 SDK][NuGetGallery] on a six-week cadence
 
 > [!NOTE]
 > Make sure to re-compile your WebView2 app after updating the WebView2 SDK NuGet package.  The WebView2 team recommends the following:
-> *  Use the Canary preview channel of Microsoft Edge when you develop using a prerelease version of the WebView2 SDK package.
+> *  Use the Canary preview channel of Microsoft Edge when you develop using a prerelease version of the WebView2 SDK package.  Canary is the recommended preview channel because it ships at the fastest cadence and has the newest APIs.
 > *  Use the Evergreen WebView2 Runtime when you use a release version of the WebView2 SDK package.
-> Canary is the recommended preview channel because it ships at the fastest cadence and has the newest APIs.  For more information, see [Matching the Runtime version with the SDK version][Webview2ConceptsVersioningMatchingWebview2RuntimeVersions].
+>
+> For more information, see [Matching the Runtime version with the SDK version][Webview2ConceptsVersioningMatchingWebview2RuntimeVersions].
 
 > [!NOTE]
 > WebView2 bug fixes are either Runtime-specific or SDK-specific.


### PR DESCRIPTION
**Article section rendered for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/release-notes?branch=pr-en-us-1529#10102030
1 visible section; the prerelease section is commented out.