### PR TITLE
Automatically label new issues with the 'triage-needed' label

### DIFF
--- a/.github/workflows/label-new-issues.yaml
+++ b/.github/workflows/label-new-issues.yaml
@@ -1,4 +1,4 @@
-# This workflow is used to add the 'triage' label to newly opened issues.
+# This workflow is used to add the 'triage-needed' label to newly opened issues.
 
 name: Label new issues
 on:
@@ -15,5 +15,5 @@ jobs:
       - name: Label issues
         uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
         with:
-          add-labels: "triage"
+          add-labels: "triage-needed"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-new-issues.yaml
+++ b/.github/workflows/label-new-issues.yaml
@@ -1,0 +1,19 @@
+# This workflow is used to add the 'triage' label to newly opened issues.
+
+name: Label new issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label issues
+        uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+        with:
+          add-labels: "triage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This introduces a new workflow that adds the `triage-needed` label to new (and re-opened) issues.
This way, we can easily filter issues with this label and go through a regular triage meeting to handle requests to change/fix docs.

I tested this workflow on my forked version of the repo:

* here is an example of an issue I opened: https://github.com/captainbrosset/edge-developer/issues/7
* here is the evidence that the workflow did run successfully: https://github.com/captainbrosset/edge-developer/actions/runs/1471041515