### PR TITLE
Removed "a" tag from tabs, separated HTML comment from tab heading

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/open/index.md
+++ b/microsoft-edge/devtools-guide-chromium/open/index.md
@@ -75,15 +75,11 @@ To auto-open DevTools on every new tab, open Microsoft Edge from the command lin
 
 ### [CMD (Windows)](#tab/cmd-Windows/)
 
-<a id="auto-open-devtools-command-line"></a>
-
 ```cmd
 start msedge --auto-open-devtools-for-tabs
 ```
 
 ### [PowerShell (Windows)](#tab/powershell-Windows/)
-
-<a id="auto-open-devtools-command-line"></a>
 
 ```powershell
 Start-Process -FilePath "msedge" -ArgumentList "--auto-open-devtools-for-tabs"
@@ -91,15 +87,11 @@ Start-Process -FilePath "msedge" -ArgumentList "--auto-open-devtools-for-tabs"
 
 ### [bash (macOS)](#tab/bash-macos/)
 
-<a id="auto-open-devtools-command-line"></a>
-
 ```bash
 /Applications/Microsoft\ Edge\ Beta.app/Contents/MacOS/Microsoft\ Edge\ Beta --auto-open-devtools-for-tabs
 ```
 
 ### [bash (Linux)](#tab/bash-linux/)
-
-<a id="auto-open-devtools-command-line"></a>
 
 ```bash
 microsoft-edge-dev --auto-open-devtools-for-tabs

--- a/microsoft-edge/extensions-chromium/developer-guide/native-messaging.md
+++ b/microsoft-edge/extensions-chromium/developer-guide/native-messaging.md
@@ -173,8 +173,6 @@ The final step involves copying the native messaging host manifest file to your 
 
 ### [Windows](#tab/windows/)
 
-<a id="copy-manifest-file"></a>
-
 The manifest file may be located anywhere in the file system.  The app installer must create a registry key and set the default value of the key to the full path of the manifest file.  The following locations are examples of registry keys.
 
 ```output
@@ -230,8 +228,6 @@ HKEY_LOCAL_MACHINE\SOFTWARE\Google\Chrome\NativeMessagingHosts\
 
 ### [macOS](#tab/macos/)
 
-<a id="copy-manifest-file"></a>
-
 To store the manifest file, complete one of the following actions.
 
 *   System-wide native messaging hosts, which are available to all users, are stored in a fixed location.  For example, the manifest file must be stored in following location.
@@ -255,8 +251,6 @@ To store the manifest file, complete one of the following actions.
     When using the Stable channel, ` {Channel_Name}` isn't required.
 
 ### [Linux](#tab/linux/)
-
-<a id="copy-manifest-file"></a>
 
 To store the manifest file, complete one of the following actions.
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -83,13 +83,9 @@ If you're using Selenium 3, use the following steps to add the [Selenium Tools f
 
 #### [C#](#tab/c-sharp/)
 
-<a id="selenium-tools-install"></a>
-
 Add the [Microsoft.Edge.SeleniumTools](https://www.nuget.org/packages/Microsoft.Edge.SeleniumTools) and [Selenium.WebDriver](https://www.nuget.org/packages/Selenium.WebDriver/3.141.0) packages to your .NET project using the [NuGet CLI](https://www.nuget.org/packages/NuGet.CommandLine/) or [Visual Studio](https://visualstudio.microsoft.com/).
 
 #### [Python](#tab/python/)
-
-<a id="selenium-tools-install"></a>
 
 Use [pip](https://pypi.org/project/pip/) to install the [msedge-selenium-tools](https://pypi.org/project/msedge-selenium-tools/) and [selenium](https://pypi.org/project/selenium/) packages.
 
@@ -98,8 +94,6 @@ pip install msedge-selenium-tools selenium==3.141
 ```
 
 #### [Java](#tab/java/)
-
-<a id="selenium-tools-install"></a>
 
 If your Java project uses Maven, copy and paste the following dependency to your `pom.xml` file to add [msedge-selenium-tools-java](https://search.maven.org/artifact/com.microsoft.edge/msedge-selenium-tools-java/3.141.0/jar).
 
@@ -114,8 +108,6 @@ If your Java project uses Maven, copy and paste the following dependency to your
 The Java package is also available to download directly on the [Selenium Tools for Microsoft Edge Releases page](https://github.com/microsoft/edge-selenium-tools/releases).
 
 #### [JavaScript](#tab/javascript/)
-
-<a id="selenium-tools-install"></a>
 
 Use [npm](https://www.npmjs.com/) to install the [edge-selenium-tools](https://www.npmjs.com/package/@microsoft/edge-selenium-tools) and [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver) packages.
 
@@ -142,8 +134,6 @@ Selenium uses the `EdgeDriver` class to manage a Microsoft Edge session.  To sta
 
 #### [C#](#tab/c-sharp/)
 
-<a id="drive-microsoft-edge-chromium-code"></a>
-
 ```csharp
 var options = new EdgeOptions();
 options.UseChromium = true;
@@ -152,8 +142,6 @@ var driver = new EdgeDriver(options);
 ```
 
 #### [Python](#tab/python/)
-
-<a id="drive-microsoft-edge-chromium-code"></a>
 
 ```python
 options = EdgeOptions()
@@ -164,8 +152,6 @@ driver = Edge(options = options)
 
 #### [Java](#tab/java/)
 
-<a id="drive-microsoft-edge-chromium-code"></a>
-
 The `EdgeDriver` class only supports Microsoft Edge (Chromium), and doesn't support Microsoft Edge (EdgeHTML).  For basic usage, you can create an `EdgeDriver` without providing `EdgeOptions`.
 
 ```java
@@ -173,8 +159,6 @@ EdgeDriver driver = new EdgeDriver();
 ```
 
 #### [JavaScript](#tab/javascript/)
-
-<a id="drive-microsoft-edge-chromium-code"></a>
 
 ```javascript
 let options = new edge.Options();
@@ -194,8 +178,6 @@ You can start a WebDriver session with specific Microsoft Edge binaries.  For ex
 
 #### [C#](#tab/c-sharp/)
 
-<a id="choose-specific-browser-binaries-chrome-only-code"></a>
-
 ```csharp
 var options = new EdgeOptions();
 options.UseChromium = true;
@@ -205,8 +187,6 @@ var driver = new EdgeDriver(options);
 ```
 
 #### [Python](#tab/python/)
-
-<a id="choose-specific-browser-binaries-chrome-only-code"></a>
 
 ```python
 options = EdgeOptions()
@@ -218,8 +198,6 @@ driver = Edge(options = options)
 
 #### [Java](#tab/java/)
 
-<a id="choose-specific-browser-binaries-chrome-only-code"></a>
-
 ```java
 EdgeOptions options = new EdgeOptions();
 options.setBinary("C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\msedge.exe");
@@ -228,8 +206,6 @@ EdgeDriver driver = new EdgeDriver(options);
 ```
 
 #### [JavaScript](#tab/javascript/)
-
-<a id="choose-specific-browser-binaries-chrome-only-code"></a>
 
 ```javascript
 let options = new edge.Options();
@@ -244,8 +220,6 @@ let driver = edge.Driver.createSession(options);
 ### Customize the Microsoft Edge Driver Service
 
 #### [C#](#tab/c-sharp/)
-
-<a id="customize-microsoft-edge-driver-services-code"></a>
 
 When you use the `EdgeOptions` class to create an `EdgeDriver` class instance, it creates and launches the appropriate `EdgeDriverService` class for either legacy EdgeHTML or Microsoft Edge (Chromium).
 
@@ -266,8 +240,6 @@ using (var service = EdgeDriverService.CreateChromiumService())
 
 #### [Python](#tab/python/)
 
-<a id="customize-microsoft-edge-driver-services-code"></a>
-
 When you use Python, the `Edge` object creates and manages the `EdgeService`.  To configure the `EdgeService`, pass extra arguments to the `Edge` object as shown in the following code:
 
 ```python
@@ -276,8 +248,6 @@ driver = Edge(service_args = service_args)
 ```
 
 #### [Java](#tab/java/)
-
-<a id="customize-microsoft-edge-driver-services-code"></a>
 
 Use the `createDefaultService()` method to create an `EdgeDriverService` configured for Microsoft Edge.  Use Java system properties to customize driver services in Java.  For example, the following code uses the `"webdriver.edge.verboseLogging"` property to turn on verbose log output:
 
@@ -289,8 +259,6 @@ EdgeDriver driver = new EdgeDriver(service, options);
 ```
 
 #### [JavaScript](#tab/javascript/)
-
-<a id="customize-microsoft-edge-driver-services-code"></a>
 
 When you use JavaScript, create and configure a `Service` with the `ServiceBuilder` class.  Optionally, you can pass the `Service` object to the `Driver` object, which starts (and stops) the service for you.  To configure the `Service`, run another method in the `ServiceBuilder` class before you use the `build()` method.  Then pass the `service` as a parameter in the `Driver.createSession()` method:
 
@@ -307,8 +275,6 @@ If you set the `UseChromium` property to `true`, you can use the `EdgeOptions` c
 
 #### [C#](#tab/c-sharp/)
 
-<a id="use-chromium-specific-options-code"></a>
-
 ```csharp
 var options = new EdgeOptions();
 options.UseChromium = true;
@@ -317,8 +283,6 @@ options.AddArgument("disable-gpu");
 ```
 
 #### [Python](#tab/python/)
-
-<a id="use-chromium-specific-options-code"></a>
 
 ```python
 options = EdgeOptions()
@@ -329,8 +293,6 @@ options.add_argument("disable-gpu")
 
 #### [Java](#tab/java/)
 
-<a id="use-chromium-specific-options-code"></a>
-
 ```java
 EdgeOptions options = new EdgeOptions();
 options.addArguments("headless");
@@ -338,8 +300,6 @@ options.addArguments("disable-gpu");
 ```
 
 #### [JavaScript](#tab/javascript/)
-
-<a id="use-chromium-specific-options-code"></a>
 
 ```javascript
 let options = new edge.Options();

--- a/microsoft-edge/webview2/how-to/debug.md
+++ b/microsoft-edge/webview2/how-to/debug.md
@@ -15,6 +15,7 @@ The goal of the Microsoft Edge WebView2 control is to combine the best of both t
 
 
 <!-- ====================================================================== -->
+
 ## [Microsoft Edge DevTools](#tab/devtools)
 
 Use [Microsoft Edge Developer Tools](../index.md) to debug web content displayed in WebView2 controls, in the same way that you may debug for another webpage displayed in Microsoft Edge.  To open the DevTools, set focus on the WebView control and then use one of the following actions.
@@ -31,6 +32,7 @@ For more information, navigate to [DevTools overview](../index.md).
 
 
 <!-- ====================================================================== -->
+
 ## [Visual Studio](#tab/visualstudio)
 
 Visual Studio provides various debugging tools for web and native code in WebView2 apps.  In the Visual Studio section, the primary focus is debugging WebView controls, however the other methods of debugging in Visual Studio are available as usual.  Use the following process to debug web and native code in Win32 apps or Office Add-ins only.
@@ -99,6 +101,7 @@ Complete the following actions to debug your WebView2 app.
 
 
 <!-- ====================================================================== -->
+
 ## [Visual Studio Code](#tab/visualstudiocode)
 
 Use Microsoft Visual Studio Code to debug scripts that run in WebView2 controls.  <!--Ensure that you're using Visual Studio Code version [insert build here] or later.  -->


### PR DESCRIPTION
This PR fixes [Issue 1376](https://github.com/MicrosoftDocs/edge-developer/issues/1376), "Tab control is broken (ja-jp)".
TODO: Close that issue after publish & test this fix.

This PR fixes [Issue 5121](https://github.com/MicrosoftDocs/docs-help-pr/issues/5121); the above issue was subsequently logged also in Docs Contributor Guide Issues, as https://github.com/MicrosoftDocs/docs-help-pr/issues/5121 "Tabs not working in ja-jp or zh-cn (to switch between programming language listings)".
TODO: Close that issue after publish & test this fix.

**To test this PR's fix:**
In these rendered PR articles, click the tabs to make sure they work:

"Open Microsoft Edge DevTools"
Live: https://docs.microsoft.com/ja-jp/microsoft-edge/devtools-guide-chromium/open/
PR: https://review.docs.microsoft.com/ja-jp/microsoft-edge/devtools-guide-chromium/open/index?branch=pr-en-us-1579

"Native messaging"
Live: https://docs.microsoft.com/ja-jp/microsoft-edge/extensions-chromium/developer-guide/native-messaging
PR: https://review.docs.microsoft.com/ja-jp/microsoft-edge/extensions-chromium/developer-guide/native-messaging?branch=pr-en-us-1579

"Use WebDriver (Chromium) for test automation"
Live: https://docs.microsoft.com/ja-jp/microsoft-edge/webdriver-chromium/
PR: https://review.docs.microsoft.com/ja-jp/microsoft-edge/webdriver-chromium/index?branch=pr-en-us-1579

"Get started debugging WebView2 apps"
Live: https://docs.microsoft.com/ja-jp/microsoft-edge/webview2/how-to/debug
PR: https://review.docs.microsoft.com/ja-jp/microsoft-edge/webview2/how-to/debug?branch=pr-en-us-1579