### PR TITLE
Adding the ADO label to stalebot config

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -11,6 +11,7 @@ daysUntilClose: 7
 exemptLabels:
   - triage-needed
   - never-stale
+  - ADO
 # Label to use when marking an issue as stale.
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable.


### PR DESCRIPTION
When we triage a new issue and we take a decision to fix the docs, we create a task on our internal backlog, add the label `ADO` to the issue, and remove the `triage-needed` label. Then, later, when we do fix the docs, we come back to the issue and close it.

In the meantime, we should make sure that the issue doesn't accidentally get closed by our stalebot, just because it took us more than 30 days to fix the docs.

This PR prevents ADO-labelled issues to get closed.