### PR TITLE
Added Browse NuGet steps in "Get started with WebView2 in Win32 apps"

### DIFF
--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -55,7 +55,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
     :::image-end:::
 
 1.  Install the Windows Implementation Library.
-    1.  In the **Nuget** window click the **Browse** tab.
+    1.  In the **NuGet** window click the **Browse** tab.
     1.  In the search bar, type `Microsoft.Windows.ImplementationLibrary` > choose **Microsoft.Windows.ImplementationLibrary**.
     1.  In the right-hand side window, choose **Install**.  NuGet downloads the library to your machine.
 
@@ -67,7 +67,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
         :::image-end:::
 
 1.  Install the WebView2 SDK.
-    1.  In the **Nuget** window click the **Browse** tab.
+    1.  In the **NuGet** window click the **Browse** tab.
     1.  In the search bar, type `Microsoft.Web.WebView2` and choose **Microsoft.Web.WebView2**.
     1.  In the right-hand side window, click **Install**.  NuGet downloads the SDK to your machine.
 

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -1,9 +1,9 @@
 ---
-description: Get started guide with WebView2 for Win32 apps
 title: Get started with WebView2 in Win32 apps
+description: Get started building WebView2 for Win32 by working with sample apps and the WebView2 SDK.
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: 11/05/2021
+ms.date: 12/09/2021
 ms.topic: tutorial
 ms.prod: microsoft-edge
 ms.technology: webview
@@ -55,6 +55,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
     :::image-end:::
 
 1.  Install the Windows Implementation Library.
+    1.  In the **Nuget** window click the **Browse** tab.
     1.  In the search bar, type `Microsoft.Windows.ImplementationLibrary` > choose **Microsoft.Windows.ImplementationLibrary**.
     1.  In the right-hand side window, choose **Install**.  NuGet downloads the library to your machine.
 
@@ -66,6 +67,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
         :::image-end:::
 
 1.  Install the WebView2 SDK.
+    1.  In the **Nuget** window click the **Browse** tab.
     1.  In the search bar, type `Microsoft.Web.WebView2` and choose **Microsoft.Web.WebView2**.
     1.  In the right-hand side window, click **Install**.  NuGet downloads the SDK to your machine.
 

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -55,7 +55,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
     :::image-end:::
 
     > [!WARNING]
-    > If you do not see the expected search results in the following steps, check the NuGet source location. Click **Tools** > **Options** > **NuGet Package Manager** > **Package Sources**. Make sure that in **Package sources** there is a **nuget.com** route pointing to https://api.nuget.org/v3/index.json. If not, enter `nuget.com` in the **Name** text box and `https://api.nuget.org/v3/index.json` in the **Source** text box. Then click **Update** and **OK**.
+    > If you don't see the expected search results in the following steps, check the NuGet source location. Click **Tools** > **Options** > **NuGet Package Manager** > **Package Sources**. Make sure that in **Package sources** there is a **nuget.com** route pointing to `https://api.nuget.org/v3/index.json`. If **Package sources** doesn't contain that route, enter `nuget.com` in the **Name** text box and `https://api.nuget.org/v3/index.json` in the **Source** text box. Then click **Update** and **OK**.
 
 1.  Install the Windows Implementation Library.
     1.  In the **NuGet** window, click the **Browse** tab.

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -3,7 +3,7 @@ title: Get started with WebView2 in Win32 apps
 description: Get started building WebView2 for Win32 by working with sample apps and the WebView2 SDK.
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: 12/09/2021
+ms.date: 12/13/2021
 ms.topic: tutorial
 ms.prod: microsoft-edge
 ms.technology: webview
@@ -53,6 +53,9 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
     :::image type="complex" source="../media/manage-nuget-packages.png" alt-text="Manage NuGet packages" lightbox="../media/manage-nuget-packages.png":::
        Manage NuGet packages
     :::image-end:::
+
+    > [!WARNING]
+    > If you do not see the expected search results in the following steps, check the NuGet source location. Click **Tools** > **Options** > **NuGet Package Manager** > **Package Sources**. Make sure that in **Package sources** there is a **nuget.com** route pointing to https://api.nuget.org/v3/index.json. If not, enter `nuget.com` in the **Name** text box and `https://api.nuget.org/v3/index.json` in the **Source** text box. Then click **Update** and **OK**.
 
 1.  Install the Windows Implementation Library.
     1.  In the **NuGet** window, click the **Browse** tab.

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -55,7 +55,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
     :::image-end:::
 
 1.  Install the Windows Implementation Library.
-    1.  In the **NuGet** window click the **Browse** tab.
+    1.  In the **NuGet** window, click the **Browse** tab.
     1.  In the search bar, type `Microsoft.Windows.ImplementationLibrary` > choose **Microsoft.Windows.ImplementationLibrary**.
     1.  In the right-hand side window, choose **Install**.  NuGet downloads the library to your machine.
 
@@ -67,7 +67,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
         :::image-end:::
 
 1.  Install the WebView2 SDK.
-    1.  In the **NuGet** window click the **Browse** tab.
+    1.  In the **NuGet** window, click the **Browse** tab.
     1.  In the search bar, type `Microsoft.Web.WebView2` and choose **Microsoft.Web.WebView2**.
     1.  In the right-hand side window, click **Install**.  NuGet downloads the SDK to your machine.
 

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -55,7 +55,7 @@ Add the WebView2 SDK into the project.  Use NuGet to install the Win32 SDK.
     :::image-end:::
 
     > [!WARNING]
-    > If you don't see the expected search results in the following steps, check the NuGet source location. Click **Tools** > **Options** > **NuGet Package Manager** > **Package Sources**. Make sure that in **Package sources** there is a **nuget.com** route pointing to `https://api.nuget.org/v3/index.json`. If **Package sources** doesn't contain that route, enter `nuget.com` in the **Name** text box and `https://api.nuget.org/v3/index.json` in the **Source** text box. Then click **Update** and **OK**.
+    > If you don't see the expected search results in the following steps, check the NuGet source location. Click **Tools** > **Options** > **NuGet Package Manager** > **Package Sources**. Make sure that in **Package sources** there is a **nuget.com** source pointing to `https://api.nuget.org/v3/index.json`. If **Package sources** doesn't contain that source, enter `nuget.com` in the **Name** text box and `https://api.nuget.org/v3/index.json` in the **Source** text box. Then click **Update** and **OK**.
 
 1.  Install the Windows Implementation Library.
     1.  In the **NuGet** window, click the **Browse** tab.


### PR DESCRIPTION
Added steps to view Browse tab in NuGet window.

Note that all other WebView2 Get Started Guides include steps to open the Browse tab and select Prerelease checkbox.

This PR fixes [Issue 1618](https://github.com/MicrosoftDocs/edge-developer/issues/1618).

**Rendered article for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/get-started/win32?branch=pr-en-us-1622
Find nuget