### PR TITLE
Add some missing install and run instructions to the EdgeDriver page

### DIFF
--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -1,13 +1,13 @@
 ---
-description: Learn how to test your website or app in Microsoft Edge or automate the browser with WebDriver
 title: Use WebDriver to automate Microsoft Edge
+description: Learn how to test your website or app in Microsoft Edge, and how to automate the browser with WebDriver.
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: 08/24/2021
 ms.topic: article
 ms.prod: microsoft-edge
 ms.technology: devtools
 keywords: microsoft edge, web development, html, css, javascript, developer, webdriver, selenium, testing, tools, automation, test
+ms.date: 08/24/2021
 ---
 # Use WebDriver to automate Microsoft Edge
 
@@ -162,21 +162,21 @@ EdgeDriver driver = new EdgeDriver();
 
 #### [JavaScript](#tab/javascript/)
 
-For Selenium 3.
+For Selenium 4:
+
+```javascript
+const edge = require('selenium-webdriver/edge');
+
+let driver = edge.Driver.createSession(options);
+```
+
+For Selenium 3:
 
 ```javascript
 const edge = require("@microsoft/edge-selenium-tools");
 
 let options = new edge.Options();
 options.setEdgeChromium(true);
-
-let driver = edge.Driver.createSession(options);
-```
-
-For Selenium 4.
-
-```
-const edge = require('selenium-webdriver/edge');
 
 let driver = edge.Driver.createSession(options);
 ```

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -162,16 +162,20 @@ EdgeDriver driver = new EdgeDriver();
 
 #### [JavaScript](#tab/javascript/)
 
+For Selenium 3.
+
 ```javascript
-// For Selenium 3
 const edge = require("@microsoft/edge-selenium-tools");
 
 let options = new edge.Options();
 options.setEdgeChromium(true);
 
 let driver = edge.Driver.createSession(options);
+```
 
-// For Selenium 4
+For Selenium 4.
+
+```
 const edge = require('selenium-webdriver/edge');
 
 let driver = edge.Driver.createSession(options);

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -55,6 +55,8 @@ To begin automating tests, make sure the WebDriver version you install matches y
 
     :::image type="content" source="./media/microsoft-edge-driver-install.msft.png" alt-text="The `Get the latest version` section of the Microsoft Edge Driver webpage." lightbox="./media/microsoft-edge-driver-install.msft.png":::
 
+1.  After the download completes, extract the `msedgedriver` executable to your preferred location. Add the folder where the executable is located to your `PATH` environment variable.
+
 
 <!-- ====================================================================== -->
 ## Choose a WebDriver testing framework
@@ -161,8 +163,16 @@ EdgeDriver driver = new EdgeDriver();
 #### [JavaScript](#tab/javascript/)
 
 ```javascript
+// For Selenium 3
+const edge = require("@microsoft/edge-selenium-tools");
+
 let options = new edge.Options();
 options.setEdgeChromium(true);
+
+let driver = edge.Driver.createSession(options);
+
+// For Selenium 4
+const edge = require('selenium-webdriver/edge');
 
 let driver = edge.Driver.createSession(options);
 ```


### PR DESCRIPTION
Trying to follow the steps on [this page](https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/), it's clear that some steps are missing.

You need to have the msedgedriver.exe in your path for the code to work, and when using JavaScript, you first need to `require` or `import` the library before being able to use it.

**Rendered article sections for review:**
* Added the final step in section [Download Microsoft Edge Driver](https://review.docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/?branch=pr-en-us-1632&tabs=c-sharp#download-microsoft-edge-driver).
* Expanded the code in the **JavaScript** tab in section [Automate Microsoft Edge](https://review.docs.microsoft.com/microsoft-edge/webdriver-chromium/?branch=pr-en-us-1632&tabs=javascript#automate-microsoft-edge).  [before](https://docs.microsoft.com/microsoft-edge/webdriver-chromium/?tabs=javascript#automate-microsoft-edge)