### PR TITLE
Update new event name and add link to ALA article

### DIFF
--- a/microsoft-edge/progressive-web-apps-chromium/how-to/window-controls-overlay.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/window-controls-overlay.md
@@ -147,7 +147,7 @@ if ('windowControlsOverlay' in navigator) {
         // Detect if the Window Controls Overlay is visible.
         const isOverlayVisible = navigator.windowControlsOverlay.visible;
         // Get the size and position of the title bar area.
-        const titleBarRect = e.boundingRect;
+        const titleBarRect = e.titlebarAreaRect;
 
         console.log(`The overlay is ${isOverlayVisible ? 'visible' : 'hidden'}, the title bar width is ${titleBarRect.width}px`);
     }, 200));
@@ -184,3 +184,4 @@ The source code for this app is in the [My Tracks](https://github.com/captainbro
 
 *   [Window Controls Overlay video tutorial](https://www.youtube.com/watch?v=NvClp35dFVI)
 *   [Customize the window controls overlay of your PWA's title bar](https://web.dev/window-controls-overlay/)
+*   [Breaking Out of the Box](https://alistapart.com/article/breaking-out-of-the-box/)


### PR DESCRIPTION
There was a recent spec and implementation change in the Window Controls Overlay feature.
One method name changed, and one event name changed. Our docs refer to the latter, so it needs to be updated.

I'm also taking this opportunity to link the Window Controls Overlay docs to the new third-party blog post I wrote, since it's a good tutorial on this topic.

**Rendered article for review:**
Article: Display content in the title bar
https://review.docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/window-controls-overlay?branch=pr-en-us-1640
Find:
* titlebarAreaRect
* See Also link: Breaking Out of the Box