### PR TITLE
Adding linux to the wv2 roadmap page

### DIFF
--- a/microsoft-edge/webview2/roadmap.md
+++ b/microsoft-edge/webview2/roadmap.md
@@ -1,5 +1,5 @@
 ---
-title: Roadmap for Microsoft Edge WebView2
+title: WebView2 roadmap
 description: Learn about what's coming next for WebView2
 author: MSEdgeTeam
 ms.author: msedgedevrel
@@ -9,11 +9,11 @@ ms.technology: webview
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Host, browser control, edge html
 ms.date: 01/07/2021
 ---
-# Roadmap for Microsoft Edge WebView2
+# WebView2 roadmap
 
 Last Updated: July 2021
 
-The WebView2 control allows you to embed web technologies in your native applications.  This article outlines the prospective roadmap for WebView2.
+The Microsoft Edge WebView2 control allows you to embed web technologies in your native applications.  This article outlines the prospective roadmap for WebView2.
 
 WebView2 is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.
 

--- a/microsoft-edge/webview2/roadmap.md
+++ b/microsoft-edge/webview2/roadmap.md
@@ -1,27 +1,25 @@
 ---
+title: Roadmap for Microsoft Edge WebView2
 description: Learn about what's coming next for WebView2
-title: Roadmap for Microsoft Edge WebView 2
 author: MSEdgeTeam
 ms.author: msedgedevrel
-ms.date: 01/07/2021
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
 keywords: IWebView2, IWebView2WebView, webview2, webview, win32 apps, win32, edge, ICoreWebView2, ICoreWebView2Host, browser control, edge html
+ms.date: 01/07/2021
 ---
-# Microsoft Edge WebView2 roadmap
+# Roadmap for Microsoft Edge WebView2
 
-> [!NOTE]
-> Last Updated:  July 2021
+Last Updated: July 2021
 
-The WebView2 control allows developers to embed web technologies in their native applications.  The following page outlines the prospective roadmap for WebView2.
+The WebView2 control allows you to embed web technologies in your native applications.  This article outlines the prospective roadmap for WebView2.
 
-> [!NOTE]
-> WebView2 is under active development and the roadmap continues to evolve based on market changes and customer feedback, so please note that the plans outlined here are not exhaustive and are subject to change.
+WebView2 is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.
 
 If you have concerns or questions about the Roadmap, provide your feedback in the [feedback repo](https://github.com/MicrosoftEdge/WebViewFeedback).
 
-The WebView2 team is planning the following major efforts for future updates.
+The WebView2 team is planning the following major efforts for future updates:
 
 * UWP Preview
 * MacOS Preview
@@ -33,17 +31,19 @@ The WebView2 team is planning the following major efforts for future updates.
 <!-- ====================================================================== -->
 ## WebView2 Runtime and Installer
 
-Evergreen distribution mode allows you to target or chain-install the WebView2 Runtime onto your user's machine.  The Evergreen WebView2 Runtime and installer has reached General Availability (GA).  For more information, navigate to [Distribute a WebView2 app and the WebView2 Runtime](./concepts/distribution.md).
+Evergreen distribution mode allows you to target or chain-install the WebView2 Runtime onto your users' machines.  The Evergreen WebView2 Runtime and installer has reached General Availability (GA).  For more information, see [Distribute a WebView2 app and the WebView2 Runtime](./concepts/distribution.md).
 
 
 <!-- ====================================================================== -->
 ## Fixed version
 
-Fixed version distribution mode allows you to package the Microsoft Edge binaries <!--(a specific version of the WebView2 Runtime)--> inside your native application.  The Fixed Version has reached General Availability (GA).  For more information, navigate to [Distribute a WebView2 app and the WebView2 Runtime](./concepts/distribution.md).
+Fixed version distribution mode allows you to package the Microsoft Edge binaries <!--(a specific version of the WebView2 Runtime)--> inside your native application.  The Fixed Version has reached General Availability (GA).  For more information, see [Distribute a WebView2 app and the WebView2 Runtime](./concepts/distribution.md).
 
 
 <!-- ====================================================================== -->
-## General availability
+## General Availability
+
+The following technologies have reached General Availability (GA).
 
 ### Win32 C/C++
 
@@ -55,4 +55,4 @@ The .NET SDK has reached GA.
 
 ### Windows UI Library 3
 
-You can access WebView2 controls in your applications using [Windows UI Library 3 (WinUI3)](/uwp/toolkits/winui3/index) with the Windows App SDK. This is currently in preview. For more information, navigate to the [Windows App SDK roadmap](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/roadmap.md).
+You can access WebView2 controls in your applications using [Windows UI Library 3 (WinUI3)](/uwp/toolkits/winui3/index) with the Windows App SDK.  This is currently in preview. For more information, see [Windows App SDK roadmap](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/roadmap.md).

--- a/microsoft-edge/webview2/roadmap.md
+++ b/microsoft-edge/webview2/roadmap.md
@@ -25,6 +25,7 @@ The WebView2 team is planning the following major efforts for future updates.
 
 * UWP Preview
 * MacOS Preview
+* Linux Preview
 * Xbox Preview
 * HoloLens Preview
 

--- a/microsoft-edge/webview2/roadmap.md
+++ b/microsoft-edge/webview2/roadmap.md
@@ -21,9 +21,9 @@ The WebView2 team is planning the following major efforts for future updates:
 
 * UWP Preview
 * MacOS Preview
-* Linux Preview
 * Xbox Preview
 * HoloLens Preview
+* Linux Preview
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/roadmap.md
+++ b/microsoft-edge/webview2/roadmap.md
@@ -11,8 +11,6 @@ ms.date: 01/07/2021
 ---
 # WebView2 roadmap
 
-Last Updated: July 2021
-
 The Microsoft Edge WebView2 control allows you to embed web technologies in your native applications.  This article outlines the prospective roadmap for WebView2.
 
 WebView2 is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.


### PR DESCRIPTION
The WebView2 team is planning to work on Linux support sometime next year. This is being tracked here: https://github.com/MicrosoftEdge/WebView2Feedback/issues/645

However the roadmap doc does not mention it, and people have been asking about it.

Fixes #1638.

**Rendered article for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/roadmap?branch=pr-en-us-1642
Added the Linux list item in intro section.
Docs team added a full Writer/Editor pass on the article.