### PR TITLE
Make the 'Files to ship' section separate from 'Fixed Version'

### DIFF
--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -274,7 +274,8 @@ To use the Fixed Version distribution mode:
             Permission for PlayReady
         :::image-end:::
 
-### Files to ship with the app
+<!-- ====================================================================== -->
+## Files to ship with the app
 
 The `WebView2Loader` code needs to be shipped with the app.  This can be done by [statically linking](../how-to/static.md) `WebView2Loader.lib` into the app binaries, or by including the `WebView2Loader.dll` that matches the app's architecture.
 


### PR DESCRIPTION
The 'Files to Ship' section is separate from the 'Fixed Version' section, and should also show up in the 'ToC' of the page. Update to make it a higher level section.

**Rendered article section for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution?branch=pr-en-us-1658#files-to-ship-with-the-app