### PR TITLE
Fix example in ExecuteScript JSON encoded results

### DIFF
--- a/microsoft-edge/webview2/how-to/javascript.md
+++ b/microsoft-edge/webview2/how-to/javascript.md
@@ -37,7 +37,7 @@ Use the following functions to begin embedding JavaScript in your WebView app.
 
 Because the result of `ExecuteScriptAsync` is JSON-encoded, if the result of evaluating the JavaScript is a string, you will receive a JSON-encoded string and not the value of the string. For example, the following code executes script that results in a string.  The resulting string includes a quote at the start, a quote at the end, and escaping slashes:
 
-```c#
+```csharp
 string result = await coreWebView2.ExecuteScriptAsync(@"'example'");
 Debug.Assert(result == "\"example\"");
 ```

--- a/microsoft-edge/webview2/how-to/javascript.md
+++ b/microsoft-edge/webview2/how-to/javascript.md
@@ -35,10 +35,12 @@ Use the following functions to begin embedding JavaScript in your WebView app.
 ## Scenario: ExecuteScript JSON-encoded results
 
 
-Because the result of `ExecuteScriptAsync` is JSON-encoded, if the result of evaluating the JavaScript is a string, you will receive a JSON-encoded string and not the value of the string. For example, the following script results in a string with the following value, including the quotes at the start and end, and the escaping slashes:
+Because the result of `ExecuteScriptAsync` is JSON-encoded, if the result of evaluating the JavaScript is a string, you will receive a JSON-encoded string and not the value of the string. For example, the following code executes script that results in a string including the quotes at the start and end and the escaping slashes:
 
- * Script: ```var result = await webView22.CoreWebView2.ExecuteScriptAsync(@"'example'");``` 
- * Result: ```"\"example\"";```
+```c#
+string result = await coreWebView2.ExecuteScriptAsync(@"'example'");
+Debug.Assert(result == "\"example\"");
+```
 
 The script returns a string that `ExecuteScript` JSON-encodes for you. If you call `JSON.stringify` from your script, then the result is doubly encoded as a JSON string the value of which is a JSON string.
 

--- a/microsoft-edge/webview2/how-to/javascript.md
+++ b/microsoft-edge/webview2/how-to/javascript.md
@@ -35,7 +35,7 @@ Use the following functions to begin embedding JavaScript in your WebView app.
 ## Scenario: ExecuteScript JSON-encoded results
 
 
-Because the result of `ExecuteScriptAsync` is JSON-encoded, if the result of evaluating the JavaScript is a string, you will receive a JSON-encoded string and not the value of the string. For example, the following code executes script that results in a string including the quotes at the start and end and the escaping slashes:
+Because the result of `ExecuteScriptAsync` is JSON-encoded, if the result of evaluating the JavaScript is a string, you will receive a JSON-encoded string and not the value of the string. For example, the following code executes script that results in a string.  The resulting string includes a quote at the start, a quote at the end, and escaping slashes:
 
 ```c#
 string result = await coreWebView2.ExecuteScriptAsync(@"'example'");


### PR DESCRIPTION
The previous PR had a mixup between what was script and a suggestion to use C# and used the C# as script. Instead moving to just C# to make it easier to understand how to interpret the quotes and escaped quotes.

**Rendered section for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/how-to/javascript?branch=pr-en-us-1662#scenario-executescript-json-encoded-results

Writer/Editor pass: Victor