### PR TITLE
Ignore experimental features page when checking for old versions

### DIFF
--- a/scripts/find-references-to-old-versions.js
+++ b/scripts/find-references-to-old-versions.js
@@ -5,9 +5,12 @@ const fetch = require('node-fetch');
 
 const FILES_TO_INCLUDE = '../microsoft-edge/**/*.md';
 const FILES_TO_IGNORE = [
+    // What's new/release notes articles are bound to always have version numbers in them. That's ok.
     '../microsoft-edge/devtools-guide-chromium/whats-new/**/*.md',
     '../microsoft-edge/webview2/release-notes.md',
-    '../microsoft-edge/progressive-web-apps-chromium/whats-new/*.md'
+    '../microsoft-edge/progressive-web-apps-chromium/whats-new/*.md',
+    // Experimental features also often have version numbers in them. Let's ignore them too.
+    '../microsoft-edge/devtools-guide-chromium/experimental-features/index.md'
 ];
 // This script attempts to find the current edge release version by looking at this page and finding the first version header occurrence.
 const RELEASE_NOTES_PAGE = 'https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel';


### PR DESCRIPTION
The script we use to check for old versions of Edge should ignore the experimental features page, since we're bound to mention version numbers in it.

This fixes #1653.