### PR TITLE
Added missing value for 21H2

### DIFF
--- a/microsoft-edge/web-platform/how-to-detect-win11.md
+++ b/microsoft-edge/web-platform/how-to-detect-win11.md
@@ -116,4 +116,5 @@ To detect specific versions of Windows, use the following values for `platformVe
 | Win10 2004 | 10 |
 | Win10 20H2 | 10 |
 | Win10 21H1 | 10 |
+| Win10 21H2 | 10 |
 | Win11 | 13+ |


### PR DESCRIPTION
To verify, I ran

```javascript
navigator.userAgentData.getHighEntropyValues(["platformVersion"]).then(data => {
    alert(data.platformVersion)
})
```

in a secure context (localhost) on Windows 10 21H2 (verified using `winver`) and it displayed "10.0.0".

**Revised section for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/web-platform/how-to-detect-win11?branch=pr-en-us-1682#detecting-specific-windows-versions - added row "Win10 21H2" at bottom.