### PR TITLE
Adding a link to the protocol handling blog post

### DIFF
--- a/microsoft-edge/progressive-web-apps-chromium/how-to/handle-protocols.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/handle-protocols.md
@@ -44,4 +44,5 @@ In the above example, the app is registered to handle the `mailto` protocol.  Wh
 <!-- ====================================================================== -->
 ## See also
 
+*  [Getting started with Protocol Handlers for your web app](https://blogs.windows.com/msedgedev/2022/01/20/getting-started-url-protocol-handlers-microsoft-edge/)
 *  [URL protocol handler registration for PWAs](https://web.dev/url-protocol-handler/)


### PR DESCRIPTION
@diekus wrote this awesome [announcement blog post](https://blogs.windows.com/msedgedev/2022/01/20/getting-started-url-protocol-handlers-microsoft-edge/) about protocol_handlers for PWA. It's a great resource to add to [our PWA docs](https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/handle-protocols).