### PR TITLE
Update WebDriver recommendations for Selenium 3 to 4 migration

### DIFF
--- a/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
+++ b/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
@@ -25,7 +25,6 @@ Create an instance of `EdgeOptions`, which provides convenience methods to set M
 
 ```csharp
 var options = new EdgeOptions();
-options.UseChromium = true;
 options.AddExtensions("/path/to/extension.crx");
 var driver = new EdgeDriver(options);
 ```

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -6,12 +6,11 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: devtools
-keywords: microsoft edge, web development, html, css, javascript, developer, webdriver, selenium, testing, tools, automation, test
-ms.date: 08/24/2021
+ms.date: 01/20/2022
 ---
 # Use WebDriver to automate Microsoft Edge
 
-WebDriver allows developers to automate Microsoft Edge by simulating user interaction.  WebDriver tests and simulations differ from JavaScript unit tests in the following ways:
+WebDriver allows you to automate Microsoft Edge by simulating user interaction.  WebDriver tests and simulations differ from JavaScript unit tests in the following ways:
 
 *   WebDriver accesses functionality and information that's not available to JavaScript running in browsers.
 *   WebDriver simulates user events or OS-level events more accurately than JavaScript unit tests.
@@ -61,22 +60,27 @@ To begin writing automated tests, make sure the Microsoft Edge Driver version yo
 <!-- ====================================================================== -->
 ## Choose a WebDriver testing framework
 
-After downloading Microsoft Edge Driver, the last component you must download is a WebDriver testing framework.  Test authors use WebDriver testing frameworks to write end-to-end tests and automate browsers.  The framework provides a language-specific interface that translates your code (such as Python, Java, C#, Ruby, or JavaScript) into commands that Microsoft Edge Driver runs in Microsoft Edge.  WebDriver testing frameworks exist for all major platforms and languages.
+After downloading Microsoft Edge Driver, the last component you must download is a WebDriver testing framework.  Test authors use WebDriver testing frameworks to write end-to-end tests and automate browsers.  A WebDriver testing framework provides a language-specific interface that translates your code into commands that Microsoft Edge Driver runs in Microsoft Edge.  WebDriver testing frameworks exist for all major platforms and languages, such as Python, Java, C#, Ruby, and JavaScript.
 
 This article provides instructions for using the Selenium framework, but you can use any library, framework, and programming language that supports WebDriver.  To accomplish the same tasks using a WebDriver testing framework other than Selenium, consult the official documentation for your framework of choice.
 
 ### Using Selenium 4
 
-Selenium WebDriver is an open-source testing framework that can be used on any platform, and provides language bindings for Java, Python, C#, Ruby, and JavaScript.  The Microsoft Edge team recommends [Selenium 4](https://www.nuget.org/packages/Selenium.WebDriver) because Selenium 4 has built-in support for Microsoft Edge (Chromium).  To install Selenium 4, see [Installing Selenium libraries](https://www.selenium.dev/documentation/en/selenium_installation/installing_selenium_libraries).
+Selenium WebDriver is an open-source testing framework that can be used on any platform, and provides language bindings for Java, Python, C#, Ruby, and JavaScript.
 
+The Microsoft Edge team recommends [Selenium 4](https://www.nuget.org/packages/Selenium.WebDriver), because Selenium 4 has built-in support for Microsoft Edge (Chromium).  To install Selenium 4, see [Installing Selenium libraries](https://www.selenium.dev/documentation/en/selenium_installation/installing_selenium_libraries).
 
 ### Upgrading from Selenium 3
 
-The Microsoft Edge team recommends upgrading existing Selenium 3 tests to Selenium 4 because the Selenium project no longer maintains Selenium 3.  To learn more about upgrading to Selenium 4, navigate to [Upgrade to Selenium 4](https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/).  If you are using [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) to add Microsoft Edge (Chromium) support to your Selenium 3 browser tests, update your tests as follows:
+The Microsoft Edge team recommends upgrading existing Selenium 3 tests to Selenium 4, because the Selenium project no longer maintains Selenium 3.  To learn more about upgrading to Selenium 4, navigate to [Upgrade to Selenium 4](https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/).
 
-1. Remove [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) from your project.  It isn't necessary to use Selenium Tools for Microsoft Edge with Selenium 4 because Selenium 4 already has built-in support for Microsoft Edge.
+If you're using [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) to add Microsoft Edge (Chromium) support to your Selenium 3 browser tests, update your tests as follows:
+
+1. Remove [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) from your project.  It isn't necessary to use Selenium Tools for Microsoft Edge with Selenium 4, because Selenium 4 already has built-in support for Microsoft Edge.
+
 1. Update your tests to use the built-in `EdgeDriver` and related classes that Selenium 4 provides instead.
-1. Remove all usages of the `EdgeOptions.UseChromium` property.  This property no longer exists in Selenium 4 because Selenium 4 supports Chromium-based Microsoft Edge only.
+
+1. Remove all usages of the `EdgeOptions.UseChromium` property.  This property no longer exists in Selenium 4, because Selenium 4 supports Chromium-based Microsoft Edge only.
 
 * * *
 
@@ -84,16 +88,24 @@ The Microsoft Edge team recommends upgrading existing Selenium 3 tests to Seleni
 <!-- ====================================================================== -->
 ## Automate Microsoft Edge with WebDriver
 
-To automate a browser using WebDriver, you must first start a WebDriver session using your preferred WebDriver testing framework.  A session is a single running instance of a browser controlled using WebDriver commands.  Start a WebDriver session to launch a new browser instance.  The launched browser instance remains open until you close the WebDriver session.
+To automate a browser using WebDriver, you must first start a WebDriver session by using a WebDriver testing framework.  A WebDriver _session_ is a single running instance of a browser that's controlled through WebDriver commands.
 
-The following content walks you through using Selenium 4 to start a WebDriver session with Microsoft Edge.
+Start a WebDriver session to launch a new browser instance.  The launched browser instance remains open until you close the WebDriver session.
+
+The following section walks you through using Selenium 4 to start a WebDriver session with Microsoft Edge.
 
 > [!NOTE]
 > This article provides instructions for using the Selenium framework, but you can use any library, framework, and programming language that supports WebDriver.  To accomplish the same tasks using another framework, consult the documentation for your framework of choice.
 
 ### Automate Microsoft Edge
 
-Selenium uses the `EdgeDriver` class to manage a Microsoft Edge session.  The code snippets below will start a Microsoft Edge session, instruct Microsoft Edge to navigate to Bing, and then search for "WebDriver".  It sleeps for a few seconds so the user can see the results. Copy and paste the code snippet for your preferred language to get started automating Microsoft Edge with WebDriver.
+Selenium uses the `EdgeDriver` class to manage a Microsoft Edge session.  The following code:
+1. Starts a Microsoft Edge session.
+1. Instructs Microsoft Edge to navigate to Bing.
+1. Searches for "WebDriver".
+1. Sleeps for a few seconds so you can see the results.
+
+To get started automating Microsoft Edge with WebDriver, copy and paste the code snippet for your preferred language:
 
 #### [C#](#tab/c-sharp/)
 
@@ -197,11 +209,11 @@ const { Builder, By } = require('selenium-webdriver');
 
 ### Manage and Configure the Microsoft Edge Driver Service
 
-When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  This can be inefficient if you have many tests because each test will create its own driver process and wait for the driver process to launch.
+When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  This can be inefficient if you have many tests, because each test creates its own driver process and waits for the driver process to launch.  Instead, you can create a single Microsoft Edge Driver process and reuse it for multiple tests.
 
-Instead, you can create a single Microsoft Edge Driver process and reuse it for multiple tests.  Selenium uses the `EdgeDriverService` class to manage a Microsoft Edge Driver process.  You can create an `EdgeDriverService` once before running your tests, and pass the `EdgeDriverService` object to the `EdgeDriver` constructor when creating a new `EdgeDriver` object.  When you pass an `EdgeDriverService` to the `EdgeDriver` constructor, the `EdgeDriver` object will use this `EdgeDriverService` instead of creating a new one.
+Selenium uses the `EdgeDriverService` class to manage a Microsoft Edge Driver process.  You can create an `EdgeDriverService` once before running your tests, and pass the `EdgeDriverService` object to the `EdgeDriver` constructor when creating a new `EdgeDriver` object.  When you pass an `EdgeDriverService` to the `EdgeDriver` constructor, the `EdgeDriver` object will use this `EdgeDriverService` instead of creating a new one.  You can also use `EdgeDriverService` to configure command-line options for the Microsoft Edge Driver process, as shown below.
 
-You can also use `EdgeDriverService` to configure command-line options for the Microsoft Edge Driver process. The following snippet creates a new `EdgeDriverService` and enables verbose log output:
+The following snippet creates a new `EdgeDriverService` and enables verbose log output:
 
 #### [C#](#tab/c-sharp/)
 
@@ -247,11 +259,11 @@ const driver = edge.Driver.createSession(options, service);
 
 ### Configure Microsoft Edge Options
 
-You can pass an `EdgeOptions` object to the `EdgeDriver` constructor to configure extra options for the Microsoft Edge browser process.  The following section shows how to use `EdgeOptions` for some common scenarios.  For a full list of options that are supported, navigate to [Capabilities and EdgeOptions](capabilities-edge-options.md).
+You can pass an `EdgeOptions` object to the `EdgeDriver` constructor to configure extra options for the Microsoft Edge browser process.  The following section shows how to use `EdgeOptions` for some common scenarios.  For a full list of options that are supported, see [Capabilities and EdgeOptions](capabilities-edge-options.md).
 
 #### Choose Specific Browser Binaries
 
-You can start a WebDriver session with specific Microsoft Edge binaries.  For example, you can run tests using the [Microsoft Edge preview channels](https://www.microsoftedgeinsider.com/download) such as Microsoft Edge Beta.
+You can start a WebDriver session with specific Microsoft Edge binaries.  For example, you can run tests using the [Microsoft Edge preview channels](https://www.microsoftedgeinsider.com/download), such as Microsoft Edge Beta, Dev, or Canary.
 
 ##### [C#](#tab/c-sharp/)
 
@@ -296,9 +308,9 @@ let driver = edge.Driver.createSession(options);
 
 * * *
 
-#### Pass Extra Command-Line Arguments
+#### Pass extra command-line arguments
 
-You can use `EdgeOptions` to configure command-line arguments that will be passed to the Microsoft Edge browser process when a session is created. For example, you can configure the browser to run in headless mode.
+You can use `EdgeOptions` to configure command-line arguments that will be passed to the Microsoft Edge browser process when a session is created.  For example, you can configure the browser to run in headless mode.
 
 ##### [C#](#tab/c-sharp/)
 
@@ -349,7 +361,7 @@ let driver = edge.Driver.createSession(options);
 
 ### Docker
 
-If you use [Docker](https://hub.docker.com), run the following command to download a pre-configured image with Microsoft Edge and [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver) pre-installed.
+If you use [Docker](https://hub.docker.com), run the following command to download a pre-configured image that has Microsoft Edge and [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver) pre-installed.
 
 ```console
 docker run -d -p 9515:9515 mcr.microsoft.com/msedge/msedgedriver
@@ -361,11 +373,11 @@ For more information, see the [msedgedriver container on Docker Hub](https://hub
 <!-- ====================================================================== -->
 ## Application Guard
 
-Trusted sites that use Microsoft Defender Application Guard (Application Guard) can be automated using Microsoft Edge Driver.
+Trusted sites that use Microsoft Defender Application Guard can be automated using Microsoft Edge Driver.  Microsoft Defender Application Guard is also called _Application Guard_, for short.
 
 Untrusted sites that use Application Guard cannot be automated or manipulated using Microsoft Edge Driver.  Application Guard launches untrusted sites in a container, and this container doesn't expose the remote debugging port that Microsoft Edge Driver needs to communicate with the site.
 
-Your enterprise administrator defines what are trusted sites, including cloud resources and internal networks.  Sites that aren't in the trusted sites list are considered untrusted.  Microsoft Edge Driver can automate both InPrivate windows, and sites in the trusted sites list.
+Your enterprise administrator defines what are trusted sites, including cloud resources and internal networks.  Sites that aren't in the trusted sites list are considered _untrusted_.  Microsoft Edge Driver can automate both InPrivate windows, and sites in the trusted sites list.
 
 For more information about Application Guard, see:
 
@@ -376,7 +388,7 @@ For more information about Application Guard, see:
 <!-- ====================================================================== -->
 ## Opt out of diagnostic data collection
 
-By default, Microsoft Edge Driver sends diagnostic data such as the status of the [New Session WebDriver command](https://www.w3.org/TR/webdriver2/#new-session) to Microsoft.  To turn off the diagnostic data collection for Microsoft Edge Driver, set the `MSEDGEDRIVER_TELEMETRY_OPTOUT` environment variable to `1`.  For more information about the data that Microsoft Edge Driver collects, see the [Microsoft Edge Privacy Whitepaper](/microsoft-edge/privacy-whitepaper#microsoft-edge-driver).
+By default, Microsoft Edge Driver sends diagnostic data such as the status of the [New Session WebDriver command](https://www.w3.org/TR/webdriver2/#new-session) to Microsoft.  To turn off diagnostic data collection for Microsoft Edge Driver, set the `MSEDGEDRIVER_TELEMETRY_OPTOUT` environment variable to `1`.  For more information about the data that Microsoft Edge Driver collects, see the [Microsoft Edge Privacy Whitepaper](/microsoft-edge/privacy-whitepaper#microsoft-edge-driver).
 
 
 <!-- ====================================================================== -->
@@ -384,7 +396,7 @@ By default, Microsoft Edge Driver sends diagnostic data such as the status of th
 
 ### Developer Tools Availability
 
-If your IT admin has set the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy to `2`,  [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver) is blocked from driving Microsoft Edge, because the driver uses the [Microsoft Edge DevTools](../devtools-guide-chromium/index.md).  Ensure the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy is set to `0` or `1` to automate Microsoft Edge.
+If your IT admin has set the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy to `2`,  [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver) is blocked from driving Microsoft Edge, because the driver uses [Microsoft Edge DevTools](../devtools-guide-chromium/index.md).  To automate Microsoft Edge, make sure the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy is set to `0` or `1`.
 
 ### Upgrading from Selenium 3 to Selenium 4
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -394,9 +394,11 @@ By default, Microsoft Edge Driver sends diagnostic data such as the status of th
 
 
 <!-- ====================================================================== -->
-## Known Issues
+## Known issues
 
-### Developer Tools Availability
+These are known issues with using WebDriver to automate Microsoft Edge.
+
+### Developer Tools Availability policy
 
 If your IT admin has set the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy to `2`,  [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver) is blocked from driving Microsoft Edge, because the driver uses [Microsoft Edge DevTools](../devtools-guide-chromium/index.md).  To automate Microsoft Edge, make sure the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy is set to `0` or `1`.
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -209,7 +209,7 @@ const { Builder, By } = require('selenium-webdriver');
 
 ### Manage and configure the Microsoft Edge Driver service
 
-When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  Letting each `EdgeDriver` object manage its own driver process can be inneficient if you have many tests, because each test must wait for a new driver process to launch.  Instead, you can create a single Microsoft Edge Driver process and then reuse it for multiple tests.
+When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  Letting each `EdgeDriver` object manage its own driver process can be inefficient if you have many tests, because each test must wait for a new driver process to launch.  Instead, you can create a single Microsoft Edge Driver process and then reuse it for multiple tests.
 
 Selenium uses the `EdgeDriverService` class to manage a Microsoft Edge Driver process.  You can create an `EdgeDriverService` once before running your tests, and then pass this `EdgeDriverService` object to the `EdgeDriver` constructor when creating a new `EdgeDriver` object.  When you pass an `EdgeDriverService` to the `EdgeDriver` constructor, the `EdgeDriver` object will use this `EdgeDriverService`, instead of creating a new one.
 
@@ -396,7 +396,7 @@ By default, Microsoft Edge Driver sends diagnostic data such as the status of th
 <!-- ====================================================================== -->
 ## Troubleshooting
 
-These are known troubleshooting considerations when using WebDriver to automate Microsoft Edge.
+These are troubleshooting considerations when using WebDriver to automate Microsoft Edge.
 
 ### Developer Tools Availability policy
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -394,9 +394,9 @@ By default, Microsoft Edge Driver sends diagnostic data such as the status of th
 
 
 <!-- ====================================================================== -->
-## Known issues
+## Troubleshooting
 
-These are known issues with using WebDriver to automate Microsoft Edge.
+These are known troubleshooting considerations when using WebDriver to automate Microsoft Edge.
 
 ### Developer Tools Availability policy
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -207,11 +207,13 @@ const { Builder, By } = require('selenium-webdriver');
 
 * * *
 
-### Manage and Configure the Microsoft Edge Driver Service
+### Manage and configure the Microsoft Edge Driver service
 
-When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  This can be inefficient if you have many tests, because each test creates its own driver process and waits for the driver process to launch.  Instead, you can create a single Microsoft Edge Driver process and reuse it for multiple tests.
+When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  Calling the `Quit` method in each test can be inefficient if you have many tests, because each test creates its own driver process and then waits for the driver process to launch.  Instead, you can create a single Microsoft Edge Driver process and then reuse it for multiple tests.
 
-Selenium uses the `EdgeDriverService` class to manage a Microsoft Edge Driver process.  You can create an `EdgeDriverService` once before running your tests, and pass the `EdgeDriverService` object to the `EdgeDriver` constructor when creating a new `EdgeDriver` object.  When you pass an `EdgeDriverService` to the `EdgeDriver` constructor, the `EdgeDriver` object will use this `EdgeDriverService` instead of creating a new one.  You can also use `EdgeDriverService` to configure command-line options for the Microsoft Edge Driver process, as shown below.
+Selenium uses the `EdgeDriverService` class to manage a Microsoft Edge Driver process.  You can create an `EdgeDriverService` once before running your tests, and then pass this `EdgeDriverService` object to the `EdgeDriver` constructor when creating a new `EdgeDriver` object.  When you pass an `EdgeDriverService` to the `EdgeDriver` constructor, the `EdgeDriver` object will use this `EdgeDriverService`, instead of creating a new one.
+
+You can also use `EdgeDriverService` to configure command-line options for the Microsoft Edge Driver process, as shown below.
 
 The following snippet creates a new `EdgeDriverService` and enables verbose log output:
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -209,7 +209,7 @@ const { Builder, By } = require('selenium-webdriver');
 
 ### Manage and configure the Microsoft Edge Driver service
 
-When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  Calling the `Quit` method in each test can be inefficient if you have many tests, because each test creates its own driver process and then waits for the driver process to launch.  Instead, you can create a single Microsoft Edge Driver process and then reuse it for multiple tests.
+When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  Letting each `EdgeDriver` object manage its own driver process can be inneficient if you have many tests, because each test must wait for a new driver process to launch.  Instead, you can create a single Microsoft Edge Driver process and then reuse it for multiple tests.
 
 Selenium uses the `EdgeDriverService` class to manage a Microsoft Edge Driver process.  You can create an `EdgeDriverService` once before running your tests, and then pass this `EdgeDriverService` object to the `EdgeDriver` constructor when creating a new `EdgeDriver` object.  When you pass an `EdgeDriverService` to the `EdgeDriver` constructor, the `EdgeDriver` object will use this `EdgeDriverService`, instead of creating a new one.
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -34,8 +34,8 @@ The functional relationship between these components is as follows:
 |---|---|
 | WebDriver | A W3C standard for a platform- and language-neutral wire protocol.  This protocol allows out-of-process programs to remotely instruct the behavior of web browsers. |
 | Microsoft Edge Driver | Microsoft's implementation of the WebDriver protocol specifically for Microsoft Edge.  Test authors write tests that use WebDriver commands that Microsoft Edge Driver receives.  Microsoft Edge Driver is then responsible for communicating that command to the browser. |
-| A WebDriver testing framework | Test authors use a testing framework to write end-to-end tests and automate browsers.  Provides a language-specific interface that translates your code into commands that Microsoft Edge Driver runs in Microsoft Edge.  WebDriver testing frameworks exist for all major platforms and languages.  One such framework is Selenium. |
-| Internet Explorer Driver | An implementation of the WebDriver protocol specifically for Internet Explorer.  To run legacy end-to-end tests for Internet Explorer, we recommend using Internet Explorer Driver. |
+| A WebDriver testing framework | Test authors use a testing framework to write end-to-end tests and automate browsers.  Provides a language-specific interface that translates your code into commands that are sent to Microsoft Edge Driver.  WebDriver testing frameworks exist for all major platforms and languages.  One such framework is Selenium. |
+| Internet Explorer Driver | An open-source implementation of the WebDriver protocol specifically for Internet Explorer.  To run legacy end-to-end tests for Internet Explorer Mode, we recommend using Internet Explorer Driver. |
 
 The following sections describe how to get started with WebDriver for Microsoft Edge.
 
@@ -43,7 +43,7 @@ The following sections describe how to get started with WebDriver for Microsoft 
 <!-- ====================================================================== -->
 ## Download Microsoft Edge Driver
 
-To begin automating tests, make sure the WebDriver version you install matches your browser version, as follows:
+To begin writing automated tests, make sure the Microsoft Edge Driver version you install matches your browser version, as follows:
 
 1.  Go to `edge://settings/help` and note your version of Microsoft Edge.
 
@@ -51,7 +51,7 @@ To begin automating tests, make sure the WebDriver version you install matches y
 
 1.  Go to [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver).
 
-1.  In the **Get the latest version** section of the page, click a platform in the channel that matches your version number of Microsoft Edge.
+1.  In the **Get the latest version** section of the page, select a platform in the channel that matches your version number of Microsoft Edge.
 
     :::image type="content" source="./media/microsoft-edge-driver-install.msft.png" alt-text="The `Get the latest version` section of the Microsoft Edge Driver webpage." lightbox="./media/microsoft-edge-driver-install.msft.png":::
 
@@ -65,57 +65,18 @@ After downloading Microsoft Edge Driver, the last component you must download is
 
 This article provides instructions for using the Selenium framework, but you can use any library, framework, and programming language that supports WebDriver.  To accomplish the same tasks using a WebDriver testing framework other than Selenium, consult the official documentation for your framework of choice.
 
-If you're using Selenium, the Microsoft Edge team recommends [Selenium 4](https://www.nuget.org/packages/Selenium.WebDriver) or later, because that version of Selenium supports Microsoft Edge.  However, you can control Microsoft Edge in all older versions of Selenium, including Selenium 3.
-
 ### Using Selenium 4
 
-The Selenium WebDriver testing framework can be used on any platform, and is available for Java, Python, C#, Ruby, and JavaScript.
+Selenium WebDriver is an open-source testing framework that can be used on any platform, and provides language bindings for Java, Python, C#, Ruby, and JavaScript.  The Microsoft Edge team recommends [Selenium 4](https://www.nuget.org/packages/Selenium.WebDriver) because Selenium 4 has built-in support for Microsoft Edge (Chromium).  To install Selenium 4, see [Installing Selenium libraries](https://www.selenium.dev/documentation/en/selenium_installation/installing_selenium_libraries).
 
-Selenium 4 has built-in support for Microsoft Edge.  To install Selenium 4, see [Installing Selenium libraries](https://www.selenium.dev/documentation/en/selenium_installation/installing_selenium_libraries).
 
-If you use Selenium 4, you don't need to use Selenium Tools for Microsoft Edge.  Selenium Tools for Microsoft Edge are for Selenium 3 only.  If you try to use Selenium 4 with Selenium Tools for Microsoft Edge and try to create a new `EdgeDriver` instance, you get the following error: `System.MissingMethodException: 'Method not found: 'OpenQA.Selenium.Remote.DesiredCapabilities OpenQA.Selenium.DriverOptions.GenerateDesiredCapabilities(Boolean)'`.
+### Upgrading from Selenium 3
 
-If you're using Selenium 4 and get this error, remove `Microsoft.Edge.SeleniumTools` from your project, and make sure you're using the official `EdgeOptions` and `EdgeDriver` classes from the `OpenQA.Selenium.Edge` namespace.
+The Microsoft Edge team recommends upgrading existing Selenium 3 tests to Selenium 4 because the Selenium project no longer maintains Selenium 3.  To learn more about upgrading to Selenium 4, navigate to [Upgrade to Selenium 4](https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/).  If you are using [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) to add Microsoft Edge (Chromium) support to your Selenium 3 browser tests, update your tests as follows:
 
-### Using Selenium 3
-
-If you already use [Selenium 3](https://www.selenium.dev), you may have existing browser tests and want to add coverage for Microsoft Edge without changing your version of Selenium.  To use [Selenium 3](https://www.selenium.dev) to write automated tests for both legacy EdgeHTML and Microsoft Edge, install the [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) package to use the updated driver.  The `EdgeDriver` and `EdgeDriverService` classes included in the tools are fully compatible with the built-in equivalents in Selenium 4.
-
-If you're using Selenium 3, use the following steps to add the [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) and [Selenium 3](https://www.selenium.dev) to your project.
-
-#### [C#](#tab/c-sharp/)
-
-Add the [Microsoft.Edge.SeleniumTools](https://www.nuget.org/packages/Microsoft.Edge.SeleniumTools) and [Selenium.WebDriver](https://www.nuget.org/packages/Selenium.WebDriver/3.141.0) packages to your .NET project using the [NuGet CLI](https://www.nuget.org/packages/NuGet.CommandLine/) or [Visual Studio](https://visualstudio.microsoft.com/).
-
-#### [Python](#tab/python/)
-
-Use [pip](https://pypi.org/project/pip/) to install the [msedge-selenium-tools](https://pypi.org/project/msedge-selenium-tools/) and [selenium](https://pypi.org/project/selenium/) packages.
-
-```python
-pip install msedge-selenium-tools selenium==3.141
-```
-
-#### [Java](#tab/java/)
-
-If your Java project uses Maven, copy and paste the following dependency to your `pom.xml` file to add [msedge-selenium-tools-java](https://search.maven.org/artifact/com.microsoft.edge/msedge-selenium-tools-java/3.141.0/jar).
-
-```xml
-<dependency>
-    <groupId>com.microsoft.edge</groupId>
-    <artifactId>msedge-selenium-tools-java</artifactId>
-    <version>[3.141.0,)</version>
-</dependency>
-```
-
-The Java package is also available to download directly on the [Selenium Tools for Microsoft Edge Releases page](https://github.com/microsoft/edge-selenium-tools/releases).
-
-#### [JavaScript](#tab/javascript/)
-
-Use [npm](https://www.npmjs.com/) to install the [edge-selenium-tools](https://www.npmjs.com/package/@microsoft/edge-selenium-tools) and [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver) packages.
-
-```javascript
-npm install @microsoft/edge-selenium-tools selenium-webdriver
-```
+1. Remove [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) from your project.  It isn't necessary to use Selenium Tools for Microsoft Edge with Selenium 4 because Selenium 4 already has built-in support for Microsoft Edge.
+1. Update your tests to use the built-in `EdgeDriver` and related classes that Selenium 4 provides instead.
+1. Remove all usages of the `EdgeOptions.UseChromium` property.  This property no longer exists in Selenium 4 because Selenium 4 supports Chromium-based Microsoft Edge only.
 
 * * *
 
@@ -125,92 +86,195 @@ npm install @microsoft/edge-selenium-tools selenium-webdriver
 
 To automate a browser using WebDriver, you must first start a WebDriver session using your preferred WebDriver testing framework.  A session is a single running instance of a browser controlled using WebDriver commands.  Start a WebDriver session to launch a new browser instance.  The launched browser instance remains open until you close the WebDriver session.
 
-The following content walks you through using Selenium to start a WebDriver session with Microsoft Edge.  You can run these examples using either Selenium 3 or 4.  To use WebDriver with Selenium 3, the [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) package must be installed.
+The following content walks you through using Selenium 4 to start a WebDriver session with Microsoft Edge.
 
 > [!NOTE]
 > This article provides instructions for using the Selenium framework, but you can use any library, framework, and programming language that supports WebDriver.  To accomplish the same tasks using another framework, consult the documentation for your framework of choice.
 
 ### Automate Microsoft Edge
 
-Selenium uses the `EdgeDriver` class to manage a Microsoft Edge session.  To start a session and automate Microsoft Edge, create a new `EdgeDriver` object and pass it an `EdgeOptions` object with the `UseChromium` property set to `true`.
+Selenium uses the `EdgeDriver` class to manage a Microsoft Edge session.  The code snippets below will start a Microsoft Edge session, instruct Microsoft Edge to navigate to Bing, and then search for "WebDriver".  It sleeps for a few seconds so the user can see the results. Copy and paste the code snippet for your preferred language to get started automating Microsoft Edge with WebDriver.
 
 #### [C#](#tab/c-sharp/)
 
 ```csharp
-var options = new EdgeOptions();
-options.UseChromium = true;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Edge;
+using System.Threading;
 
-var driver = new EdgeDriver(options);
+namespace EdgeDriverSample
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var driver = new EdgeDriver();
+            try
+            {
+                driver.Url = "https://bing.com";
+
+                var element = driver.FindElement(By.Id("sb_form_q"));
+                element.SendKeys("WebDriver");
+                element.Submit();
+
+                Thread.Sleep(5000);
+            }
+            finally
+            {
+                driver.Quit();
+            }
+        }
+    }
+}
 ```
 
 #### [Python](#tab/python/)
 
 ```python
-options = EdgeOptions()
-options.use_chromium = True
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+import time
 
-driver = Edge(options = options)
+driver = webdriver.Edge()
+
+driver.get('https://bing.com')
+
+element = driver.find_element(By.ID, 'sb_form_q')
+element.send_keys('WebDriver')
+element.submit()
+
+time.sleep(5)
+driver.quit()
 ```
 
 #### [Java](#tab/java/)
 
-The `EdgeDriver` class only supports Microsoft Edge (Chromium), and doesn't support Microsoft Edge (EdgeHTML).  For basic usage, you can create an `EdgeDriver` without providing `EdgeOptions`.
-
 ```java
-EdgeDriver driver = new EdgeDriver();
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.edge.EdgeDriver;
+
+public class EdgeDriverSample {
+    public static void main(String[] args) throws Exception {
+        EdgeDriver driver = new EdgeDriver();
+        try {
+            driver.navigate().to("https://bing.com");
+
+            WebElement element = driver.findElement(By.id("sb_form_q"));
+            element.sendKeys("WebDriver");
+            element.submit();
+
+            Thread.sleep(5000);
+        } finally {
+            driver.quit();
+        }
+    }
+}
 ```
 
 #### [JavaScript](#tab/javascript/)
 
-For Selenium 4:
-
 ```javascript
-const edge = require('selenium-webdriver/edge');
+const { Builder, By } = require('selenium-webdriver');
 
-let driver = edge.Driver.createSession(options);
-```
+(async () => {
+    const driver = await new Builder().forBrowser('MicrosoftEdge').build();
+    try {
+        await driver.get('https://bing.com');
 
-For Selenium 3:
+        const element = await driver.findElement(By.id('sb_form_q'));
+        await element.sendKeys('WebDriver');
+        await element.submit();
 
-```javascript
-const edge = require("@microsoft/edge-selenium-tools");
-
-let options = new edge.Options();
-options.setEdgeChromium(true);
-
-let driver = edge.Driver.createSession(options);
+        await driver.sleep(5000);
+    } finally {
+        await driver.quit();
+    }
+})();
 ```
 
 * * *
 
-> [!NOTE]
-> If your IT admin has set the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy to `2`,  [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver) is blocked from driving Microsoft Edge, because the driver uses the [Microsoft Edge DevTools](../devtools-guide-chromium/index.md).  Ensure the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy is set to `0` or `1` to automate Microsoft Edge.
+### Manage and Configure the Microsoft Edge Driver Service
 
-### Choose Specific Browser Binaries (Chromium-Only)
+When you create a new `EdgeDriver` object to start a Microsoft Edge session, Selenium launches a new Microsoft Edge Driver process that the `EdgeDriver` object communicates with.  The Microsoft Edge Driver process is closed when you call the `EdgeDriver` object's `Quit` method.  This can be inefficient if you have many tests because each test will create its own driver process and wait for the driver process to launch.
 
-You can start a WebDriver session with specific Microsoft Edge binaries.  For example, you can run tests using the [Microsoft Edge preview channels](https://www.microsoftedgeinsider.com/download) such as Microsoft Edge Beta.
+Instead, you can create a single Microsoft Edge Driver process and reuse it for multiple tests.  Selenium uses the `EdgeDriverService` class to manage a Microsoft Edge Driver process.  You can create an `EdgeDriverService` once before running your tests, and pass the `EdgeDriverService` object to the `EdgeDriver` constructor when creating a new `EdgeDriver` object.  When you pass an `EdgeDriverService` to the `EdgeDriver` constructor, the `EdgeDriver` object will use this `EdgeDriverService` instead of creating a new one.
+
+You can also use `EdgeDriverService` to configure command-line options for the Microsoft Edge Driver process. The following snippet creates a new `EdgeDriverService` and enables verbose log output:
 
 #### [C#](#tab/c-sharp/)
 
 ```csharp
+var service = EdgeDriverService.CreateDefaultService();
+service.UseVerboseLogging = true;
+
+var driver = new EdgeDriver(service);
+```
+
+#### [Python](#tab/python/)
+
+```python
+from selenium import webdriver
+from selenium.webdriver.edge.service import Service
+
+service = Service(verbose = True)
+
+driver = webdriver.Edge(service = service)
+```
+
+#### [Java](#tab/java/)
+
+```java
+System.setProperty("webdriver.edge.verboseLogging", "true");
+EdgeDriverService service = EdgeDriverService.createDefaultService();
+
+EdgeDriver driver = new EdgeDriver(service);
+```
+
+#### [JavaScript](#tab/javascript/)
+
+```javascript
+const edge = require('selenium-webdriver/edge');
+
+const service = new edge.ServiceBuilder().enableVerboseLogging().build();
+
+const options = new edge.Options();
+const driver = edge.Driver.createSession(options, service);
+```
+
+* * *
+
+### Configure Microsoft Edge Options
+
+You can pass an `EdgeOptions` object to the `EdgeDriver` constructor to configure extra options for the Microsoft Edge browser process.  The following section shows how to use `EdgeOptions` for some common scenarios.  For a full list of options that are supported, navigate to [Capabilities and EdgeOptions](capabilities-edge-options.md).
+
+#### Choose Specific Browser Binaries
+
+You can start a WebDriver session with specific Microsoft Edge binaries.  For example, you can run tests using the [Microsoft Edge preview channels](https://www.microsoftedgeinsider.com/download) such as Microsoft Edge Beta.
+
+##### [C#](#tab/c-sharp/)
+
+```csharp
 var options = new EdgeOptions();
-options.UseChromium = true;
 options.BinaryLocation = @"C:\Program Files (x86)\Microsoft\Edge Beta\Application\msedge.exe";
 
 var driver = new EdgeDriver(options);
 ```
 
-#### [Python](#tab/python/)
+##### [Python](#tab/python/)
 
 ```python
-options = EdgeOptions()
-options.use_chromium = True
+from selenium import webdriver
+from selenium.webdriver.edge.options import Options
+
+options = Options()
 options.binary_location = r"C:\Program Files (x86)\Microsoft\Edge Beta\Application\msedge.exe"
 
-driver = Edge(options = options)
+driver = webdriver.Edge(options = options)
 ```
 
-#### [Java](#tab/java/)
+##### [Java](#tab/java/)
 
 ```java
 EdgeOptions options = new EdgeOptions();
@@ -219,11 +283,12 @@ options.setBinary("C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\m
 EdgeDriver driver = new EdgeDriver(options);
 ```
 
-#### [JavaScript](#tab/javascript/)
+##### [JavaScript](#tab/javascript/)
 
 ```javascript
+const edge = require('selenium-webdriver/edge');
+
 let options = new edge.Options();
-options.setEdgeChromium(true);
 options.setBinaryPath("C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\msedge.exe");
 
 let driver = edge.Driver.createSession(options);
@@ -231,101 +296,52 @@ let driver = edge.Driver.createSession(options);
 
 * * *
 
-### Customize the Microsoft Edge Driver Service
+#### Pass Extra Command-Line Arguments
 
-#### [C#](#tab/c-sharp/)
+You can use `EdgeOptions` to configure command-line arguments that will be passed to the Microsoft Edge browser process when a session is created. For example, you can configure the browser to run in headless mode.
 
-When you use the `EdgeOptions` class to create an `EdgeDriver` class instance, it creates and launches the appropriate `EdgeDriverService` class for either legacy EdgeHTML or Microsoft Edge (Chromium).
-
-If you want to create an `EdgeDriverService`, use the `CreateChromiumService()` method to create one configured for Microsoft Edge.  The `CreateChromiumService()` method is useful when you need to add customizations.  For example, the following code starts verbose log output:
-
-```csharp
-using (var service = EdgeDriverService.CreateChromiumService())
-{
-    service.UseVerboseLogging = true;
-
-    var driver = new EdgeDriver(service);
-}
-```
-
-> [!NOTE]
->You don't need to provide the `EdgeOptions` object when you pass `EdgeDriverService` to the `EdgeDriver` instance.  The `EdgeDriver` class uses the default options for either legacy EdgeHTML or Microsoft Edge (Chromium), based on the service you provide.
-> However, if you want to provide both `EdgeDriverService` and `EdgeOptions` classes, make sure that both are configured for the same version of Microsoft Edge.  For example, suppose you use a default legacy EdgeHTML `EdgeDriverService` class but use Microsoft Edge (Chromium) properties in the `EdgeOptions` class.  The `EdgeDriver` class would throw an error to prevent using different versions of Microsoft Edge.
-
-#### [Python](#tab/python/)
-
-When you use Python, the `Edge` object creates and manages the `EdgeService`.  To configure the `EdgeService`, pass extra arguments to the `Edge` object as shown in the following code:
-
-```python
-service_args = ['--verbose']
-driver = Edge(service_args = service_args)
-```
-
-#### [Java](#tab/java/)
-
-Use the `createDefaultService()` method to create an `EdgeDriverService` configured for Microsoft Edge.  Use Java system properties to customize driver services in Java.  For example, the following code uses the `"webdriver.edge.verboseLogging"` property to turn on verbose log output:
-
-```java
-System.setProperty("webdriver.edge.verboseLogging", "true");
-EdgeDriverService service = EdgeDriverService.createDefaultService();
-EdgeOptions options = new EdgeOptions();
-EdgeDriver driver = new EdgeDriver(service, options);
-```
-
-#### [JavaScript](#tab/javascript/)
-
-When you use JavaScript, create and configure a `Service` with the `ServiceBuilder` class.  Optionally, you can pass the `Service` object to the `Driver` object, which starts (and stops) the service for you.  To configure the `Service`, run another method in the `ServiceBuilder` class before you use the `build()` method.  Then pass the `service` as a parameter in the `Driver.createSession()` method:
-
-```javascript
-let service = new edge.ServiceBuilder().enableVerboseLogging().build();
-let driver = edge.Driver.createSession(options, service);
-```
-
-* * *
-
-### Use Chromium-Specific Options
-
-If you set the `UseChromium` property to `true`, you can use the `EdgeOptions` class to access the same [Chromium-specific properties and methods](capabilities-edge-options.md) that are used when you automate other Chromium browsers.
-
-#### [C#](#tab/c-sharp/)
+##### [C#](#tab/c-sharp/)
 
 ```csharp
 var options = new EdgeOptions();
-options.UseChromium = true;
 options.AddArgument("headless");
-options.AddArgument("disable-gpu");
+
+var driver = new EdgeDriver(options);
 ```
 
-#### [Python](#tab/python/)
+##### [Python](#tab/python/)
 
 ```python
-options = EdgeOptions()
-options.use_chromium = True
+from selenium import webdriver
+from selenium.webdriver.edge.options import Options
+
+options = Options()
 options.add_argument("headless")
-options.add_argument("disable-gpu")
+
+driver = webdriver.Edge(options = options)
 ```
 
-#### [Java](#tab/java/)
+##### [Java](#tab/java/)
 
 ```java
 EdgeOptions options = new EdgeOptions();
 options.addArguments("headless");
-options.addArguments("disable-gpu");
+
+EdgeDriver driver = new EdgeDriver(options);
 ```
 
-#### [JavaScript](#tab/javascript/)
+##### [JavaScript](#tab/javascript/)
 
 ```javascript
+const edge = require('selenium-webdriver/edge');
+
 let options = new edge.Options();
-options.setEdgeChromium(true);
 options.addArguments("headless");
-options.addArguments("disable-gpu");
+
+let driver = edge.Driver.createSession(options);
 ```
 
 * * *
-
-> [!NOTE]
-> If the `UseChromium` property is set to `true`, you can't use properties and methods for Microsoft Edge (EdgeHTML).
 
 
 <!-- ====================================================================== -->
@@ -361,6 +377,20 @@ For more information about Application Guard, see:
 ## Opt out of diagnostic data collection
 
 By default, Microsoft Edge Driver sends diagnostic data such as the status of the [New Session WebDriver command](https://www.w3.org/TR/webdriver2/#new-session) to Microsoft.  To turn off the diagnostic data collection for Microsoft Edge Driver, set the `MSEDGEDRIVER_TELEMETRY_OPTOUT` environment variable to `1`.  For more information about the data that Microsoft Edge Driver collects, see the [Microsoft Edge Privacy Whitepaper](/microsoft-edge/privacy-whitepaper#microsoft-edge-driver).
+
+
+<!-- ====================================================================== -->
+## Known Issues
+
+### Developer Tools Availability
+
+If your IT admin has set the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy to `2`,  [Microsoft Edge Driver](https://developer.microsoft.com/microsoft-edge/tools/webdriver) is blocked from driving Microsoft Edge, because the driver uses the [Microsoft Edge DevTools](../devtools-guide-chromium/index.md).  Ensure the [DeveloperToolsAvailability](/deployedge/microsoft-edge-policies#developertoolsavailability) policy is set to `0` or `1` to automate Microsoft Edge.
+
+### Upgrading from Selenium 3 to Selenium 4
+
+If you use Selenium 4, you don't need to use Selenium Tools for Microsoft Edge.  Selenium Tools for Microsoft Edge are for Selenium 3 only.  If you try to use Selenium 4 with Selenium Tools for Microsoft Edge and try to create a new `EdgeDriver` instance, you get the following error: `System.MissingMethodException: 'Method not found: 'OpenQA.Selenium.Remote.DesiredCapabilities OpenQA.Selenium.DriverOptions.GenerateDesiredCapabilities(Boolean)'`.
+
+If you're using Selenium 4 and get this error, remove `Microsoft.Edge.SeleniumTools` from your project, and make sure you're using the official `EdgeOptions` and `EdgeDriver` classes from the `OpenQA.Selenium.Edge` namespace.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -80,7 +80,7 @@ If you're using [Selenium Tools for Microsoft Edge](https://github.com/microsoft
 
 1. Update your tests to use the built-in `EdgeDriver` and related classes that Selenium 4 provides instead.
 
-1. Remove all usages of the `EdgeOptions.UseChromium` property.  This property no longer exists in Selenium 4, because Selenium 4 supports Chromium-based Microsoft Edge only.
+1. Remove all usages of the `EdgeOptions.UseChromium` property.  This property no longer exists in Selenium 4, because Selenium 4 supports only Microsoft Edge (Chromium).
 
 * * *
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -76,7 +76,7 @@ The Microsoft Edge team recommends upgrading existing Selenium 3 tests to Seleni
 
 If you're using [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) to add Microsoft Edge (Chromium) support to your Selenium 3 browser tests, update your tests as follows:
 
-1. Remove [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) from your project.  It isn't necessary to use Selenium Tools for Microsoft Edge with Selenium 4, because Selenium 4 already has built-in support for Microsoft Edge.
+1. Remove [Selenium Tools for Microsoft Edge](https://github.com/microsoft/edge-selenium-tools) from your project.  You don't need to use Selenium Tools for Microsoft Edge with Selenium 4, because Selenium 4 already has built-in support for Microsoft Edge (Chromium).
 
 1. Update your tests to use the built-in `EdgeDriver` and related classes that Selenium 4 provides instead.
 


### PR DESCRIPTION
**Rendered article for review:**
[Use WebDriver to automate Microsoft Edge](https://review.docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium/index?branch=pr-en-us-1685)

This change updates our WebDriver docs to recommend Selenium 4 exclusively and help users migrate any remaining Selenium 3 browser tests:

- The "Using Selenium 3" section has been replaced with a "Upgrading from Selenium 3" section.
- Instructions for installing Selenium Tools for Microsoft Edge have been removed as our goal is to deprecate this library and help users upgrade instead.
- Removed instances of `UseChromium`, mentions of EdgeHTML, and anything else that is no longer needed in the Chromium-only world.
- Code samples are for Selenium 4 only now.

Also did an edit pass:

- The starter code samples for all languages are now complete and runnable as-is, including import statements, etc.
- Other code samples are still snippets only, but I've added appropriate `import` and `require` statements to python and JavaScript respectively because we've heard feedback that some of these examples are incomplete/unclear. I left this out intentionally for C# and Java because importing types in these languages is far less ambiguous and users often have IDE help.
- Moved the section on configuring the EdgeDriverService above the section on EdgeOptions and expanded a bit on why users might want to do this and how.
- Gathered notes and issues into a single "Known Issues" section at the end of the doc.
- Other minor edits.