### PR TITLE
node-fetch 3 was migrated to ESM, so updating import

### DIFF
--- a/scripts/find-references-to-old-versions.js
+++ b/scripts/find-references-to-old-versions.js
@@ -1,7 +1,6 @@
 const glob = require('glob');
 const fs = require('fs').promises;
 const path = require('path');
-const fetch = require('node-fetch');
 
 const FILES_TO_INCLUDE = '../microsoft-edge/**/*.md';
 const FILES_TO_IGNORE = [
@@ -21,6 +20,8 @@ const PATTERNS_TO_LOOK_FOR = [
     /Edge ([0-9]{2,3}) /g,
     / ([0-9]{2,3}) or later/g,
 ];
+
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 
 function getAllSourceFiles() {
     return new Promise(resolve => {


### PR DESCRIPTION
The dependency bot updated our version of node-fetch to version 3+. This version was converted to ESM only package, so we can't use `require` anymore to import it.
We can, however, dynamically import it with the `import()` function.

Doing this will fix the `scripts/find-references-to-old-versions.js` script which would otherwise fail.