### PR TITLE
Updated "Add-ons API Ref" as private preview

### DIFF
--- a/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
+++ b/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
@@ -7,7 +7,7 @@ ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.date: 08/19/2021
 ---
-# Microsoft Edge Add-ons API Reference (under development)
+# Microsoft Edge Add-ons API Reference (in private preview)
 
 > [!NOTE]
 > This article is a Request for Comments.  The Microsoft Edge Add-ons API is currently in private preview, and the Publish APIs page is not yet available at Partner Center for everyone.  The Microsoft Edge Add-ons API is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.

--- a/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
+++ b/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
@@ -10,7 +10,7 @@ ms.date: 08/19/2021
 # Microsoft Edge Add-ons API Reference (in private preview)
 
 > [!NOTE]
-> This article is a Request for Comments.  The Microsoft Edge Add-ons API is currently in private preview, and the Publish APIs page is not yet available at Partner Center for everyone.  The Microsoft Edge Add-ons API is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.
+> This article is a Request for Comments.  The Microsoft Edge Add-ons API is currently in private preview. The **Publish API** page is present at Partner Center only for participants of the private preview. The Microsoft Edge Add-ons API is under active development, and the roadmap continues to evolve based on market changes and customer feedback. The plans outlined here aren't exhaustive, and are subject to change.
 
 This is the REST endpoint reference for the Microsoft Edge Add-ons API.  This API automates publishing updates to add-ons that have been submitted to the Microsoft Edge Add-ons website.
 

--- a/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
+++ b/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
@@ -10,7 +10,7 @@ ms.date: 08/19/2021
 # Microsoft Edge Add-ons API Reference (in private preview)
 
 > [!NOTE]
-> This article is a Request for Comments.  The Microsoft Edge Add-ons API is currently in private preview. The **Publish API** page is present at Partner Center only for participants of the private preview. The Microsoft Edge Add-ons API is under active development, and the roadmap continues to evolve based on market changes and customer feedback. The plans outlined here aren't exhaustive, and are subject to change.
+> The Microsoft Edge Add-ons API is currently in private preview.  The **Publish API** page is present at Partner Center only for participants of the private preview.  The Microsoft Edge Add-ons API is under active development, and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here aren't exhaustive, and are subject to change.
 
 This is the REST endpoint reference for the Microsoft Edge Add-ons API.  This API automates publishing updates to add-ons that have been submitted to the Microsoft Edge Add-ons website.
 

--- a/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
+++ b/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
@@ -1,5 +1,5 @@
 ---
-title: Microsoft Edge Add-ons API Reference (under development)
+title: Microsoft Edge Add-ons API Reference (in private preview)
 description: The Add-ons API Reference, for REST endpoints to automate publishing updates to add-ons that are submitted to the Microsoft Edge Add-ons website.
 author: MSEdgeTeam
 ms.author: msedgedevrel
@@ -10,7 +10,7 @@ ms.date: 08/19/2021
 # Microsoft Edge Add-ons API Reference (under development)
 
 > [!NOTE]
-> This article is a Request for Comments.  The Microsoft Edge Add-ons API is not yet available for testing, and the Publish APIs page is not yet available at Partner Center.  The Microsoft Edge Add-ons API is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.
+> This article is a Request for Comments.  The Microsoft Edge Add-ons API is currently in private preview, and the Publish APIs page is not yet available at Partner Center for everyone.  The Microsoft Edge Add-ons API is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.
 
 This is the REST endpoint reference for the Microsoft Edge Add-ons API.  This API automates publishing updates to add-ons that have been submitted to the Microsoft Edge Add-ons website.
 

--- a/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
+++ b/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
@@ -12,6 +12,7 @@ ms.date: 08/19/2021
 > [!NOTE]
 > This article is a Request for Comments.  The Microsoft Edge Add-ons API is not yet available for testing, and the Publish APIs page is not yet available at Partner Center.  The Microsoft Edge Add-ons API is under active development and the roadmap continues to evolve based on market changes and customer feedback.  The plans outlined here are not exhaustive and are subject to change.
 
+<!-- shortened title ok in mid-sentence link -->
 This article, along with the [Microsoft Edge Add-ons API Reference](addons-api-reference.md), provides an overview of the proposed Microsoft Edge Add-ons API.  We look forward to your suggestions and feedback on the proposed API contracts.  Please submit your feedback as an [Issue about the Add-ons API](https://github.com/MicrosoftDocs/edge-developer/issues/new?title=[Add-ons%20API]).
 
 The Microsoft Edge Add-ons API provides a set of REST endpoints for programmatically publishing updates to add-ons submitted to the Microsoft Edge Add-ons website.  You can use these REST endpoints to automate the process of uploading and publishing add-ons into the Microsoft Edge Add-ons website.

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -713,7 +713,7 @@
               items:
                 - name: Using the Add-ons API
                   href: extensions-chromium/publish/api/using-addons-api.md
-                - name: Add-ons API Reference
+                - name: Microsoft Edge Add-ons API Reference (in private preview)
                   href: extensions-chromium/publish/api/addons-api-reference.md
         - name: Extensions for enterprise
           items:


### PR DESCRIPTION
**Rendered article for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/addons-api-reference?branch=pr-en-us-1705

Made a few changes to indicate that this API is available in private preview hence not be visible to everyone.  

Writer/Editor pass:
vchapel