### PR TITLE
Updating URLs of demos that moved from the DevToolsSamples to the Demos repo

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/3d-view/index.md
+++ b/microsoft-edge/devtools-guide-chromium/3d-view/index.md
@@ -16,8 +16,6 @@ Use the **3D View** to debug your web app by navigating through the [Document Ob
 *   [Clear some of the clutter on the DOM pane](#changing-your-view) or the [z-index pane](#change-the-scope-of-your-exploration).
 *   [Pick the color scheme to best debug your DOM problems](#dom-color-type) or [z-index problems](#z-index-color-type).
 
-To explore an early prototype for the 3D View project and run the code yourself, go to [3D View Sample](https://github.com/MicrosoftEdge/DevToolsSamples/tree/master/3DView).
-
 On the left side, there are three panes that you can use for your debugging experience:
 *   The [Z-index](#z-index) pane.  Navigate through the different elements in the web app with the z-index context in mind.  The **Z-index** pane is the default pane.
 *   The [3D DOM](#3d-dom) pane.  Explore the DOM as a whole with all the elements easily accessible.  To access the pane, select the **DOM** pane next to the **Z-index** pane.

--- a/microsoft-edge/devtools-guide-chromium/accessibility/accessibility-testing-in-devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/accessibility-testing-in-devtools.md
@@ -9,7 +9,7 @@ ms.date: 06/07/2021
 ---
 # Overview of accessibility testing using DevTools
 
-In this article, we cover some of the features you can use in DevTools to test for accessibility problems.  We go through using different features of DevTools to detect the accessibility problems in a demo page, and we discuss how to fix them.  Open the [demo page](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab to try it out yourself and you can test along.
+In this article, we cover some of the features you can use in DevTools to test for accessibility problems.  We go through using different features of DevTools to detect the accessibility problems in a demo page, and we discuss how to fix them.  Open the [demo page](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab to try it out yourself and you can test along.
 
 :::image type="content" source="../media/a11y-testing-basics-demopage.msft.png" alt-text="The demo page used in this article with a few accessibility issues." lightbox="../media/a11y-testing-basics-demopage.msft.png":::
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-accessibility-tree.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-accessibility-tree.md
@@ -17,7 +17,7 @@ The **Accessibility Tree** is a subset of the DOM tree, which contains elements 
 
 To explore using the Accessibility Tree with the demo page:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab.  Then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab.  Then select **F12** to open DevTools.
 
 1.  Select the **Inspect** (![the Inspect icon.](../media/inspect-icon.msft.png)) button in the top-left corner of DevTools so that the button is highlighted (blue).
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-analyze-no-focus-indicator.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-analyze-no-focus-indicator.md
@@ -19,7 +19,7 @@ This analysis finds that the lack of indication of keyboard focus in the links o
 
 To navigate to the CSS, we'll use the **Inspect** tool to highlight a blue link on the page's sidebar navigation menu, and then view the DOM tree and CSS for the `a` element that defines that link.
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select the **Inspect** (![Inspect icon.](../media/inspect-icon.msft.png)) button in the top-left corner of DevTools so that the button is highlighted (blue).
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-analyze-no-keyboard-support.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-analyze-no-keyboard-support.md
@@ -17,7 +17,7 @@ To use the Inspect tool and Event Listeners tab to analyze the lack of keyboard 
 
 <!-- 1. Inspect tool: Accessibility section: keyboard-focusable row -->
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select the **Inspect** (![Inspect icon.](../media/inspect-icon.msft.png)) button in the top-left corner of DevTools so that the button is highlighted (blue).
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-blurred-vision.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-blurred-vision.md
@@ -15,7 +15,7 @@ To simulate blurred vision, in the **Rendering** tool, use the **Emulate vision 
 
 To check whether a webpage is usable with blurred vision:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select **Esc** to open the Drawer at the bottom of DevTools.  Select the **+** icon at the top of the Drawer to display the list of tools, and then select **Rendering**.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-color-blindness.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-color-blindness.md
@@ -23,7 +23,7 @@ But you can't expect all of your users to experience these colors as intended.  
 
 To check whether a webpage is usable by people with color blindness:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select **Esc** to open the Drawer at the bottom of DevTools.  Select the **+** icon at the top of the Drawer to see the list of tools, and then select **Rendering**.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-dark-mode.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-dark-mode.md
@@ -20,7 +20,7 @@ As an example, the accessibility-testing demo page includes a light theme and a 
 
 To emulate a user's selection of preferred color theme:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select **Esc** to open the Drawer at the bottom of DevTools.  Select the **+** icon at the top of the Drawer to see the list of tools, and then select **Rendering**.  The Rendering tool appears.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-inspect-states.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-inspect-states.md
@@ -35,7 +35,7 @@ The green **Dogs** list item in the **Donation status** section doesn't have eno
 
 The **Inspect** tool's information overlay only represents a single state.  Elements on the page can have different states, all of which need to be tested.  For example, when you hover the mouse pointer over the menu of the accessibility-testing demo page, you get an animation that changes the colors. Perform the following steps.
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab.
 
 1.  Hover over the blue menu items in the sidebar navigation menu.  Notice that each item has an animation.
 
@@ -61,7 +61,7 @@ When the **Inspect** tool is active, instead of hovering over an animated elemen
 
 To turn on the hover state while using the Inspect tool:
 
-1.  If it's not open already, open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab.  Then select **F12** to open DevTools.
+1.  If it's not open already, open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab.  Then select **F12** to open DevTools.
 
 1.  Select the **Inspect** (![Inspect tool button.](../media/inspect-icon.msft.png)) button in the top-left corner of DevTools so that the icon is highlighted (blue).
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-inspect-text-contrast.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-inspect-text-contrast.md
@@ -25,7 +25,7 @@ In some cases, contrast is affected by setting the browser to light theme or dar
 
 As an example, on the demo page, the blue links of the sidebar navigation menu have enough contrast, but the green **Dogs** link in the **Donation status** section does not have enough contrast.  Review those elements using the **Inspect** tool, as follows:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab.  Then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab.  Then select **F12** to open DevTools.
 
 1.  Select the **Inspect** (![Inspect button.](../media/inspect-icon.msft.png)) button in the top-left corner of DevTools so that the icon is highlighted (blue).
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-inspect-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-inspect-tool.md
@@ -28,7 +28,7 @@ The main article about the Inspect tool is [Analyze HTML pages using the Inspect
 
 <!-- Inspect tool: Accessibility section of overlay -->
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select the **Inspect** (![Inspect.](../media/inspect-icon.msft.png)) button in the top-left corner of DevTools so that the icon is highlighted (blue).
 
@@ -77,7 +77,7 @@ The top part of the **Inspect** overlay, which is above the **Accessibility** se
 
 In addition to the information overlay, the **Inspect** tool also provides region-coloring that's similar to hovering in the DOM tree in the **Elements** tool.
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select the **Inspect** button (![Inspect tool icon.](../media/inspect-icon.msft.png)) in the top-left corner of DevTools, so that the button is highlighted (blue).
 
@@ -95,7 +95,7 @@ To configure the grid overlay or flexbox overlay, in the **Elements** tool, sele
 
 <!-- general info about the Inspect tool, not particularly focused on accessibility -->
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  Select the **Inspect** button (![the Inspect tool.](../media/inspect-icon.msft.png)) in the top-left corner of DevTools, so that the button is highlighted (blue).
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-issues-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-issues-tool.md
@@ -20,7 +20,7 @@ There are several ways to open the **Issues** tool, such as:
 <!-- ====================================================================== -->
 ## View the Accessibility section of the Issues tool
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.  In the upper right, the **Issues counter** (![Issues counter.](../media/issues-counter-icon.msft.png)) appears.  The **Issues counter** is a speech-bubble icon along with the number of automatically detected issues.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.  In the upper right, the **Issues counter** (![Issues counter.](../media/issues-counter-icon.msft.png)) appears.  The **Issues counter** is a speech-bubble icon along with the number of automatically detected issues.
 
     :::image type="complex" source="../media/a11y-testing-issues-tracker.msft.png" alt-text="The Issues counter in DevTools, indicating how many problems there are in the current document" lightbox="../media/a11y-testing-issues-tracker.msft.png":::
         The **Issues counter** in DevTools, indicating how many problems there are in the current document
@@ -42,7 +42,7 @@ There are several ways to open the **Issues** tool, such as:
 
 To check whether input fields have labels connected to them, use the **Issues** tool, which automatically checks the entire webpage and reports this issue in the **Accessibility** section.
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  In the upper right, select the **Issues counter** (![Issues counter.](../media/issues-counter-icon.msft.png)).  The **Issues** tool opens, in the **Drawer** at the bottom of DevTools.
 
@@ -86,7 +86,7 @@ Basic accessibility testing requires making sure alternative text (also called _
 
 To automatically check whether alt text is provided for images, use the **Issues** tool, which has an **Accessibility** section.  The **Issues** tool is located in the **Drawer** at the bottom of DevTools.
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  To open the **Issues** tool, select the **Issues** counter in the upper right of DevTools.
 
@@ -104,7 +104,7 @@ For more information, navigate to [Images must have alternate text](https://dequ
 
 To automatically check whether text colors have enough contrast, use the **Issues** tool, which has an **Accessibility** section.  The **Issues** tool is located in the **Drawer** at the bottom of DevTools.
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  To open the **Issues** tool, select the **Issues** counter in the upper right of DevTools.  You may receive warnings that two elements on the demo webpage don't have enough contrast.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-reduced-ui-motion.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-reduced-ui-motion.md
@@ -17,7 +17,7 @@ In the accessibility-testing demo webpage, when you turn off animations in the o
 
 To check whether the page is usable with animations turned off:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser, and then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser, and then select **F12** to open DevTools.
 
 1.  At the top of DevTools, select the **Sources** tool, and then in the **Navigation** pane on the left, select `styles.css`.  The CSS file appears in the **Editor** pane.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-tab-enter-keys.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-tab-enter-keys.md
@@ -18,7 +18,7 @@ You can test the usability of a webpage for keyboard users in several ways:
 
 To check the demo page for accessibility issues by using a keyboard rather than a mouse, perform the following steps:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab of the browser.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab of the browser.
 
 1.  Use a keyboard to navigate the demo document, using the `Tab` and `Shift`+`Tab` keys to jump from element to element.  On the demo webpage, the `Tab` key first moves focus to the search form in the `header` section.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer.md
@@ -17,7 +17,7 @@ To ensure that the document has a logical order, you can use the **Source Order 
 <!-- ====================================================================== -->
 ## Analyzing the order of keyboard access through sections of the page
 
-The [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) has a counterintuitive tabbing order, where keyboard users access the sidebar navigation menu only after tabbing through all the **More** links.  The sidebar navigation menu is meant to be a shortcut to reach deep into the page content.  But because you need to go through the entire page before you reach the sidebar navigation menu, that navigation menu is ineffective for keyboard users.
+The [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) has a counterintuitive tabbing order, where keyboard users access the sidebar navigation menu only after tabbing through all the **More** links.  The sidebar navigation menu is meant to be a shortcut to reach deep into the page content.  But because you need to go through the entire page before you reach the sidebar navigation menu, that navigation menu is ineffective for keyboard users.
 
 The `Tab` key order on the demo page is:
 1. The **Search** field, then the **go** button for the **Search** field.
@@ -48,7 +48,7 @@ To turn on the Source Order Viewer:
 
 To activate and use the Source Order Viewer, with the demo page:
 
-1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab.  Then select **F12** to open DevTools.
+1.  Open the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab.  Then select **F12** to open DevTools.
 
 1.  In the **Elements** tool, to the right of the **Styles** tab, select the **Accessibility** tab.
 

--- a/microsoft-edge/devtools-guide-chromium/console/console-debug-javascript.md
+++ b/microsoft-edge/devtools-guide-chromium/console/console-debug-javascript.md
@@ -15,7 +15,7 @@ This article is about resolving JavaScript errors that are reported in the Conso
 <!-- ====================================================================== -->
 ## Fix JavaScript errors
 
-The first experience you have with the **Console** is probably an error in a script.  To try it, see [JavaScript error reported in the Console tool](https://microsoftedge.github.io/DevToolsSamples/console/error.html).
+The first experience you have with the **Console** is probably an error in a script.  To try it, see [JavaScript error reported in the Console tool](https://microsoftedge.github.io/Demos/devtools-console/error.html).
 
 Open DevTools in the browser.  The **Open Console to view errors** button on the top right displays an error about the webpage.  Select the button to take you to the **Console** and give you more information about the error:
 
@@ -33,7 +33,7 @@ The script tries to get the first `h2` element in the document and paint a red b
 <!-- ====================================================================== -->
 ## Find and debug network issues
 
-Other errors that the **Console** reports are network errors.  To display it in action, see the [Network error reported in Console](https://microsoftedge.github.io/DevToolsSamples/console/network-error.html).
+Other errors that the **Console** reports are network errors.  To display it in action, see the [Network error reported in Console](https://microsoftedge.github.io/Demos/devtools-console/network-error.html).
 
 :::image type="content" source="../media/console-debug-network-error.msft.png" alt-text="Console displays a Network and a JavaScript error." lightbox="../media/console-debug-network-error.msft.png":::
 
@@ -73,13 +73,13 @@ The **Sources** tool displays the line of code with the error:
 
 :::image type="content" source="../media/console-debug-network-error-code-error.msft.png" alt-text="The Sources tool displays the line of code with the error." lightbox="../media/console-debug-network-error-code-error.msft.png":::
 
-To see the resulting page when there are no errors in the **Console**, see [Fixed network error reported in Console](https://microsoftedge.github.io/DevToolsSamples/console/network-error-fixed.html).
+To see the resulting page when there are no errors in the **Console**, see [Fixed network error reported in Console](https://microsoftedge.github.io/Demos/devtools-console/network-error-fixed.html).
 
 The example without any errors loads information from GitHub and displays it:
 
 :::image type="content" source="../media/console-debug-network-error-fixed.msft.png" alt-text="The example without any errors loads information from GitHub and displays it." lightbox="../media/console-debug-network-error-fixed.msft.png":::
 
-Use defensive coding techniques to avoid the previous user experiences.  Make sure your code catches errors and displays each error in the **Console**.  see [Network error reporting in Console and UI](https://microsoftedge.github.io/DevToolsSamples/console/network-error-reported.html) and review the following items.
+Use defensive coding techniques to avoid the previous user experiences.  Make sure your code catches errors and displays each error in the **Console**.  see [Network error reporting in Console and UI](https://microsoftedge.github.io/Demos/devtools-console/network-error-reported.html) and review the following items.
 
 *   Provide UI to the user to indicate that something went wrong.
 *   In the **Console**, provide helpful information about the **Network** error from your code.
@@ -108,7 +108,7 @@ const handleErrors = (response) => {
 ## Create errors and traces in the Console
 
 Besides the `throw Error` example in the previous section, you can also create different errors and trace problems in the **Console**.
-To display two created error messages in the **Console**, see [Creating error reports and assertions in Console](https://microsoftedge.github.io/DevToolsSamples/console/error-assert.html).
+To display two created error messages in the **Console**, see [Creating error reports and assertions in Console](https://microsoftedge.github.io/Demos/devtools-console/error-assert.html).
 
 Error messages created from **Console**:
 
@@ -157,7 +157,7 @@ console.assert(x >= 40, `${x} is too small`)
 > [!IMPORTANT]
 > The second and third lines of the code perform the same test.  Because the assertion needs to record a negative result, you test for `x < 40` in the `if` case and `x >= 40` for the assertion.
 
-If you aren't sure which function requests another function, use the `console.trace()` method to track which functions are requested to get to the current one.  To display the trace in the **Console**, see [Creating traces in Console](https://microsoftedge.github.io/DevToolsSamples/console/trace.html).
+If you aren't sure which function requests another function, use the `console.trace()` method to track which functions are requested to get to the current one.  To display the trace in the **Console**, see [Creating traces in Console](https://microsoftedge.github.io/Demos/devtools-console/trace.html).
 
 ```javascript
 function here() {there()}

--- a/microsoft-edge/devtools-guide-chromium/console/console-log.md
+++ b/microsoft-edge/devtools-guide-chromium/console/console-log.md
@@ -26,7 +26,7 @@ console.error('This is an error')
 console.warn('This is a warning')
 ```
 
-Copy and paste the previous code into the **Console**, or see [Console messages examples: log, info, error, and warn](https://microsoftedge.github.io/DevToolsSamples/console/logging-examples.html).  When you try any method in the **Console**, the `log()` and `info()` methods seem to do the same thing, while the `error()` and `warn()` methods display an icon next to the message and a way to inspect the [stack trace](https://en.wikipedia.org/wiki/Stack_trace) of the message.
+Copy and paste the previous code into the **Console**, or see [Console messages examples: log, info, error, and warn](https://microsoftedge.github.io/Demos/devtools-console/logging-examples.html).  When you try any method in the **Console**, the `log()` and `info()` methods seem to do the same thing, while the `error()` and `warn()` methods display an icon next to the message and a way to inspect the [stack trace](https://en.wikipedia.org/wiki/Stack_trace) of the message.
 
 The **Console** displays the messages from different log APIs:
 
@@ -38,7 +38,7 @@ It is, however, still a good idea to use `info()` and `log()` for different log 
 <!-- ====================================================================== -->
 ## Different types of logs
 
-Instead of log text, you can send any valid JavaScript or DOM references to the **Console**.  The **Console** is elegant and it determines the type that you send it.  It then gives you the best possible representation.  Copy and paste the following code into the **Console**.  Or, to display formatted results, see [Console messages examples: logging different types](https://microsoftedge.github.io/DevToolsSamples/console/logging-types.html).
+Instead of log text, you can send any valid JavaScript or DOM references to the **Console**.  The **Console** is elegant and it determines the type that you send it.  It then gives you the best possible representation.  Copy and paste the following code into the **Console**.  Or, to display formatted results, see [Console messages examples: logging different types](https://microsoftedge.github.io/Demos/devtools-console/logging-types.html).
 
 ```javascript
 let x = 2;
@@ -93,7 +93,7 @@ console.log('%O', document.body);
 console.log('%cImportant message follows','color:red;font-size:40px');
 ```
 
-The first example displays that the order of replacement of specifiers is the parameter order following the string.  To display the results, copy and paste the previous code in the **Console** or see [Console messages examples: Logging with specifiers](https://microsoftedge.github.io/DevToolsSamples/console/logging-with-specifiers.html).
+The first example displays that the order of replacement of specifiers is the parameter order following the string.  To display the results, copy and paste the previous code in the **Console** or see [Console messages examples: Logging with specifiers](https://microsoftedge.github.io/Demos/devtools-console/logging-with-specifiers.html).
 
 Use specifiers to log and convert values:
 
@@ -132,7 +132,7 @@ for (tech in technologies) {
 }
 ```
 
-Also in the second example, the group names can be optionally generated.  To display the results, copy and paste the previous code in the **Console** or see [Console messages examples: grouping logs](https://microsoftedge.github.io/DevToolsSamples/console/logging-with-groups.html).  You can expand and collapse each of the sections.
+Also in the second example, the group names can be optionally generated.  To display the results, copy and paste the previous code in the **Console** or see [Console messages examples: grouping logs](https://microsoftedge.github.io/Demos/devtools-console/logging-with-groups.html).  You can expand and collapse each of the sections.
 
 Log lots of values as groups:
 
@@ -146,7 +146,7 @@ Each group can be expanded and collapsed:
 <!-- ====================================================================== -->
 ## Display complex data as tables
 
-The `console.table()` method logs complex data not as a collapsible and expandable object, but as a table that you can sort using different headers.  A sorted table makes it much easier for people to review the information.  To display it in an example, see [Console messages examples: Using table](https://microsoftedge.github.io/DevToolsSamples/console/logging-with-table.html).
+The `console.table()` method logs complex data not as a collapsible and expandable object, but as a table that you can sort using different headers.  A sorted table makes it much easier for people to review the information.  To display it in an example, see [Console messages examples: Using table](https://microsoftedge.github.io/Demos/devtools-console/logging-with-table.html).
 
 ```javascript
 let technologies = {

--- a/microsoft-edge/devtools-guide-chromium/console/index.md
+++ b/microsoft-edge/devtools-guide-chromium/console/index.md
@@ -76,7 +76,7 @@ DevTools with a **Console** full of messages:
 The most popular use case for the **Console** is logging information from your scripts using the `console.log()` method or other similar methods.  To try it:
 
 1.  To open the **Console**, select `Control`+`Shift`+`J` (Windows, Linux) or `Command`+`Option`+`J` (macOS).
-1.  See [Console messages examples: log, info, error and warn](https://microsoftedge.github.io/DevToolsSamples/console/logging-demo.html), or copy and run the following code in the **Console**.
+1.  See [Console messages examples: log, info, error and warn](https://microsoftedge.github.io/Demos/devtools-console/logging-demo.html), or copy and run the following code in the **Console**.
 
     ```javascript
     console.log('This is a log message');

--- a/microsoft-edge/devtools-guide-chromium/console/live-expressions.md
+++ b/microsoft-edge/devtools-guide-chromium/console/live-expressions.md
@@ -66,7 +66,7 @@ A **Live Expression** is available as long as you keep it active.  To get rid of
 
 You may create as many expressions as you want and persist each across browser sessions and windows.  **Live Expressions** are a way to cut down on noise in your debugging workflow.
 
-For example, you want to monitor the mouse movement in the current webpage.  Navigate to [Logging Mouse Movement demo](https://microsoftedge.github.io/DevToolsSamples/console/mousemove.html), open the **Console**, and move your mouse around to display the logs with a lot of information.
+For example, you want to monitor the mouse movement in the current webpage.  Navigate to [Logging Mouse Movement demo](https://microsoftedge.github.io/Demos/devtools-console/mousemove.html), open the **Console**, and move your mouse around to display the logs with a lot of information.
 
 :::image type="complex" source="../media/console-live-expression-mouse-logging.msft.png" alt-text="Console displays much information on mouse position." lightbox="../media/console-live-expression-mouse-logging.msft.png":::
     **Console** displays much information on mouse position
@@ -76,7 +76,7 @@ The large amount of information not only slows your debug process, but also make
 
 To try **Live Expressions** as an alternative, complete the following actions.
 
-1.  Navigate to the [Mouse movement without logging demo](https://microsoftedge.github.io/DevToolsSamples/console/mousemove-no-log.html).
+1.  Navigate to the [Mouse movement without logging demo](https://microsoftedge.github.io/Demos/devtools-console/mousemove-no-log.html).
 1.  Create **Live Expressions** for `x` and `y`.
 
 When you use **Live Expressions**, you always get the information on the same part of your screen and keep **Console** logs for values that don't change as much.

--- a/microsoft-edge/devtools-guide-chromium/css/inspect.md
+++ b/microsoft-edge/devtools-guide-chromium/css/inspect.md
@@ -9,7 +9,7 @@ ms.date: 12/16/2021
 ---
 # Analyze pages using the Inspect tool
 
-This article shows how to use the **Inspect** tool to preview information about an element, and how to select an element in the current document.  To try out the **Inspect** tool now, open the [Inspect Demo](https://microsoftedge.github.io/DevToolsSamples/inspector/inspector-demo.html) page in a different tab or window while reading this article.
+This article shows how to use the **Inspect** tool to preview information about an element, and how to select an element in the current document.  To try out the **Inspect** tool now, open the [Inspect Demo](https://microsoftedge.github.io/Demos/devtools-inspect) page in a different tab or window while reading this article.
 
 
 <!-- ====================================================================== -->
@@ -49,7 +49,7 @@ The **Accessibility** section of the **Inspect** overlay displays information ab
 * The name and the role of the element that's reported to assistive technology.
 * Whether the element is keyboard focusable.
 
-For example, in the [Inspect Demo](https://microsoftedge.github.io/DevToolsSamples/inspector/inspector-demo.html) page, for the `Bad Contrast` button, the **Inspect** overlay has a warning icon next to the contrast value of 1.77.  The **Inspect** overlay also shows that the button isn't focusable via keyboard.  The button can't be navigated to via keyboard, because the button is implemented as a `<div>` element with a class of `button`, instead of being implemented as a `<button>` element.
+For example, in the [Inspect Demo](https://microsoftedge.github.io/Demos/devtools-inspect) page, for the `Bad Contrast` button, the **Inspect** overlay has a warning icon next to the contrast value of 1.77.  The **Inspect** overlay also shows that the button isn't focusable via keyboard.  The button can't be navigated to via keyboard, because the button is implemented as a `<div>` element with a class of `button`, instead of being implemented as a `<button>` element.
 
 ![Elements that lack sufficient contrast have a warning icon.](images/inspect-tool-bad-contrast.msft.png)
 
@@ -57,7 +57,7 @@ For example, in the [Inspect Demo](https://microsoftedge.github.io/DevToolsSampl
 <!-- ====================================================================== -->
 ## Inspecting non-accessible elements
 
-Elements that have the CSS property of `pointer-events: none` aren't available to the **Inspect** tool.  In the [Inspect Demo](https://microsoftedge.github.io/DevToolsSamples/inspector/inspector-demo.html) page, hover over the `Overlay Button` and you will see that the parent element (`div.wrapper`) is shown instead of the `Overlay Button`.
+Elements that have the CSS property of `pointer-events: none` aren't available to the **Inspect** tool.  In the [Inspect Demo](https://microsoftedge.github.io/Demos/devtools-inspect) page, hover over the `Overlay Button` and you will see that the parent element (`div.wrapper`) is shown instead of the `Overlay Button`.
 
 ![An element that has a CSS property of 'pointer events: none' can't be selected.](images/inspect-tool-element-element-without-pointer-events.msft.png)
 

--- a/microsoft-edge/devtools-guide-chromium/issues/index.md
+++ b/microsoft-edge/devtools-guide-chromium/issues/index.md
@@ -42,7 +42,7 @@ Feedback in the **Issues** tool is provided by several sources, including the Ch
 <!-- ====================================================================== -->
 ## Opening the Issues tool
 
-1.  Navigate to a webpage that contains issues to fix.  For example, open the [accessibility-testing demo page](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new tab or window.
+1.  Navigate to a webpage that contains issues to fix.  For example, open the [accessibility-testing demo page](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new tab or window.
 
 1.  Open DevTools.  After a few seconds, the **Issues counter** (![Issues counter.](../media/issues-counter-icon.msft.png)) appears in the upper right corner of DevTools.
 
@@ -79,7 +79,7 @@ To include issues that are caused by third-party sites, at the top of the **Issu
 
 The **Issues** tool presents additional documentation and recommended fixes to apply to each issue.  To expand an issue to get this additional information, select an issue, as follows.
 
-1.  Open the [demo page](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new window or tab, and then open DevTools.
+1.  Open the [demo page](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new window or tab, and then open DevTools.
 
 1.  Open the **Issues** tool by selecting the **Issues counter** (![Issues counter.](../media/issues-counter-icon.msft.png)).
 
@@ -123,7 +123,7 @@ If an element has an associated issue, the DOM tree in the **Elements** tool sho
 
 To display an issue for elements with wavy underlines in the DOM tree, perform the following steps.
 
-1.  Open a page, such as the [demo page](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html), in a new tab or window.
+1.  Open a page, such as the [demo page](https://microsoftedge.github.io/Demos/devtools-a11y-testing/), in a new tab or window.
 
 1.  Open DevTools and then select the **Elements** tab.
 

--- a/microsoft-edge/devtools-guide-chromium/sample-code/sample-code.md
+++ b/microsoft-edge/devtools-guide-chromium/sample-code/sample-code.md
@@ -9,17 +9,9 @@ ms.date: 02/01/2022
 ---
 # Sample code for DevTools
 
-Most of the sample code that's used by the DevTools documentation is stored in the following GitHub repos.
+Most of the sample code that's used by the DevTools documentation is stored in the [MicrosoftEdge/Demos](https://github.com/MicrosoftEdge/Demos) GitHub repository.
 
-
-<!-- ====================================================================== -->
-## GitHub repos for samples
-
-The [MicrosoftEdge/Demos](https://github.com/MicrosoftEdge/Demos) repo contains most of the demo pages or sample code that's used by the documentation.
-
-The [MicrosoftEdge/DevToolsSamples](https://github.com/MicrosoftEdge/DevToolsSamples) repo contains several demos that are used by the documentation, including for **3D View**, **Inspect tool**, **Console**, and accessibility testing.
-
-The demo pages below are stored in those repos, and are useful for exploring tools such as **Elements** and **Sources**.
+The demo pages below are stored in this repos, and are useful for exploring tools such as **Elements** and **Sources**.
 
 
 <!-- ====================================================================== -->
@@ -27,7 +19,7 @@ The demo pages below are stored in those repos, and are useful for exploring too
 
 This demo webpage is useful for exploring various DevTools features, such as the **Elements** and **Sources** tools.
 
-* Open the [Demo page with accessibility issues](https://microsoftedge.github.io/DevToolsSamples/a11y-testing/page-with-errors.html) in a new window or tab.  Right-click any item in the rendered webpage, and then select **Inspect**.  Or, press `F12`.  DevTools opens next to the demo webpage.
+* Open the [Demo page with accessibility issues](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new window or tab.  Right-click any item in the rendered webpage, and then select **Inspect**.  Or, press `F12`.  DevTools opens next to the demo webpage.
 
 ![The 'Demo page with accessibility issues'.](../media/demo-page-with-accessibility-issues.png)
 
@@ -45,9 +37,9 @@ These articles walk you through using this demo page:
 
 This is the source code repo and its directory which stores the files for this demo webpage:
 
-* [MicrosoftEdge/DevToolsSamples > a11y-testing](https://github.com/MicrosoftEdge/DevToolsSamples/tree/master/docs/a11y-testing) - Contains files including:
+* [MicrosoftEdge/Demos > devtools-a11y-testing](https://github.com/MicrosoftEdge/Demos/tree/main/devtools-a11y-testing) - Contains files including:
 
-   * `page-with-errors.html` - The demo webpage, including page sections and input forms that send data to the `buttons.js` JavaScript file.  To view the rendered webpage, use the demo webpage link above.
+   * `index.html` - The demo webpage, including page sections and input forms that send data to the `buttons.js` JavaScript file.  To view the rendered webpage, use the demo webpage link above.
 
    * `buttons.js` - Contains the JavaScript code that's used by the demo webpage.
 

--- a/microsoft-edge/devtools-guide-chromium/sample-code/sample-code.md
+++ b/microsoft-edge/devtools-guide-chromium/sample-code/sample-code.md
@@ -5,33 +5,39 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
-ms.date: 02/01/2022
+ms.date: 02/03/2022
 ---
 # Sample code for DevTools
 
-Most of the sample code that's used by the DevTools documentation is stored in the [MicrosoftEdge/Demos](https://github.com/MicrosoftEdge/Demos) GitHub repository.
+The sample code that's used by the DevTools documentation is mainly in the [MicrosoftEdge/Demos](https://github.com/MicrosoftEdge/Demos) repo at GitHub.
 
-The demo pages below are stored in this repos, and are useful for exploring tools such as **Elements** and **Sources**.
+<!-- A few demos are at other locations, such as Glitch. -->
 
 
 <!-- ====================================================================== -->
 ## Demo webpage with accessibility issues
 
-This demo webpage is useful for exploring various DevTools features, such as the **Elements** and **Sources** tools.
+This demo webpage is useful for exploring various DevTools features, such as the **Elements** tool.
 
-* Open the [Demo page with accessibility issues](https://microsoftedge.github.io/Demos/devtools-a11y-testing/) in a new window or tab.  Right-click any item in the rendered webpage, and then select **Inspect**.  Or, press `F12`.  DevTools opens next to the demo webpage.
+1. Open the [Demo webpage with accessibility issues](https://MicrosoftEdge.github.io/Demos/devtools-a11y-testing/) in a new window or tab.
 
-![The 'Demo page with accessibility issues'.](../media/demo-page-with-accessibility-issues.png)
+1. Right-click anywhere in the rendered webpage and then select **Inspect**.  DevTools opens next to the demo webpage.
+
+   <!-- Or, press `F12`, `Ctrl`+`Shift`+`I` (on Windows/Linux), or `Command`+`Option`+`I` (on macOS). -->
+
+![The 'Demo webpage with accessibility issues'.](../media/demo-page-with-accessibility-issues.png)
+
 
 ### Articles
 
-These articles walk you through using this demo page:
+These articles walk you through using this demo webpage:
 
-* [Overview of accessibility testing using DevTools](../accessibility/accessibility-testing-in-devtools.md) - Long article with sections that demonstrate using various DevTools features to do accessibility testing, by using the "Demo page with accessibility issues".
+* [Overview of accessibility testing using DevTools](../accessibility/accessibility-testing-in-devtools.md) - Long article with sections that demonstrate using various DevTools features to do accessibility testing, by using the "Demo webpage with accessibility issues".
 
 * [Use the Inspect tool to detect accessibility issues by hovering over the webpage](../accessibility/test-inspect-tool.md) - One of several short articles that are derived from sections of the above article.
 
-* [Accessibility-testing features](../accessibility/reference.md) - A list of accessibility testing features of DevTools, with links to several articles that use the "Demo page with accessibility issues".
+* [Accessibility-testing features](../accessibility/reference.md) - A list of accessibility testing features of DevTools, with links to several articles that use the "Demo webpage with accessibility issues".
+
 
 ### Source code repo
 
@@ -53,17 +59,23 @@ This is the source code repo and its directory which stores the files for this d
 
 This demo webpage is useful for exploring the **Sources** tool, especially the JavaScript debugger.
 
-* Open the demo page [Get started Debugging JavaScript with DevTools](https://microsoftedge.github.io/Demos/devtools-js-get-started/) in a new window or tab.  Right-click anywhere in the rendered webpage and then select **Inspect**.  Or, press `F12`.  DevTools opens next to the demo webpage.
+1. Open the demo webpage [Get started Debugging JavaScript with DevTools](https://MicrosoftEdge.github.io/Demos/devtools-js-get-started/) in a new window or tab.
 
-![The 'Get started Debugging JavaScript with DevTools' demo page.](../media/using-debug-js-demo-page.png)
+1. Right-click anywhere in the rendered webpage and then select **Inspect**.  DevTools opens next to the demo webpage.
+
+   <!-- Or, press `F12`, `Ctrl`+`Shift`+`I` (on Windows/Linux), or `Command`+`Option`+`I` (on macOS). -->
+
+![The 'Get started Debugging JavaScript with DevTools' demo webpage.](../media/using-debug-js-demo-page.png)
+
 
 ### Articles
 
-These articles or article sections walk you through using this demo page:
+These articles or article sections walk you through using this demo webpage:
 
-* [The basic approach to using a debugger](../sources/index.md#the-basic-approach-to-using-a-debugger) in _Sources tool overview_.  This article section briefly walks you through the steps to use the JavaScript debugger in the **Sources** tool, to find the bug in the demo page.  To fix the bug, you convert the input strings to numbers before adding them.
+* [The basic approach to using a debugger](../sources/index.md#the-basic-approach-to-using-a-debugger) in _Sources tool overview_.  This article section briefly walks you through the steps to use the JavaScript debugger in the **Sources** tool, to find the bug in the demo webpage.  To fix the bug, you convert the input strings to numbers before adding them.
 
-* [Get started debugging JavaScript](../javascript/index.md) - A more in-depth walkthrough of using the demo page along with the debugger, demonstrating various features of the debugger, and setting different kinds of breakpoints.
+* [Get started debugging JavaScript](../javascript/index.md) - A more in-depth walkthrough of using the demo webpage along with the debugger, demonstrating various features of the debugger, and setting different kinds of breakpoints.
+
 
 ### Source code repo
 
@@ -76,3 +88,29 @@ This is the source code repo and its directory which stores the files for this d
    *  `index.html` - The webpage with an input form that sends data to the JavaScript file, and that displays the result of the JavaScript.
 
    *  `get-started.js` - The JavaScript file that's used by the form in the demo webpage.
+
+
+<!-- ====================================================================== -->
+## URL patterns for rendered demo webpages and source code
+
+To convert between the URL for a rendered demo webpage and the URL for the source code at GitHub, the patterns are as follows.
+
+
+### Pattern
+
+*  URL for the rendered demo webpage: `https://[org].github.io/[repo]/[path]`
+
+*  URL for the webpage's source code: `https://github.com/[org]/[repo]/tree/main/[path]`
+
+Not case-sensitive.
+
+
+### Example
+
+*  URL for the rendered demo webpage: `https://MicrosoftEdge.github.io/Demos/devtools-a11y-testing/`
+
+*  URL for the webpage's source code: `https://github.com/MicrosoftEdge/Demos/tree/main/devtools-a11y-testing/`
+
+*  Org = `MicrosoftEdge`
+*  Repo = `Demos`
+*  Path = `/devtools-a11y-testing/`

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2021/01/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2021/01/devtools.md
@@ -194,7 +194,7 @@ In Microsoft Edge version 89, node screenshots are more accurate, capturing the 
 
 #### Support forcing the :target CSS state
 
-You may now use DevTools to force the [:target](https://developer.mozilla.org/docs/web/css/:target) CSS pseudo-class.  The `:target` pseudo-class is triggered when a unique element (the target element) has an `id` that matches a fragment of the URL.  For example, the `http://www.example.com/index.html#section1` URL triggers the `:target` pseudo-class on an HTML element with `id="section1"`.  To try a demo with section 1 highlighted, navigate to [CSS :target demo](https://microsoftedge.github.io/DevToolsSamples/whats-new/89/target-css-demo.html#section-1).  To review the history of this feature in the Chromium open-source project, navigate to Issue [1156628](https://crbug.com/1156628).
+You may now use DevTools to force the [:target](https://developer.mozilla.org/docs/web/css/:target) CSS pseudo-class.  The `:target` pseudo-class is triggered when a unique element (the target element) has an `id` that matches a fragment of the URL.  For example, the `http://www.example.com/index.html#section1` URL triggers the `:target` pseudo-class on an HTML element with `id="section1"`.  To try a demo with section 1 highlighted, navigate to [CSS :target demo](https://microsoftedge.github.io/Demos/devtools-target-pseudo/#section-1).  To review the history of this feature in the Chromium open-source project, navigate to Issue [1156628](https://crbug.com/1156628).
 
 Webpage highlighted with no forced CSS:
 


### PR DESCRIPTION
The new [Demos](https://github.com/MicrosoftEdge/Demos) repository is meant to replace the older [DevToolsSamples](https://github.com/MicrosoftEdge/DevToolsSamples) repository (and is more general too since it has demos from not just devtools).

Earlier, I moved all of the demos that we references in our docs out of DevToolsSamples and into Demos.
Because of this, I'm now making this change to update the URLs to these demos so they point to the new location.

**Rendered Samples article:**
https://review.docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/sample-code/sample-code?branch=pr-en-us-1717