### PR TITLE
Minor corrections to PUSH notifications section

### DIFF
--- a/microsoft-edge/progressive-web-apps-chromium/how-to/notifications-badges.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/notifications-badges.md
@@ -205,8 +205,6 @@ To create a PWA that supports push notifications:
 
 Like Service Workers, the push notification APIs are standards-based APIs.  The push notification APIs work across browsers, so your code should work everywhere that PWAs are supported.  For more information about delivering push messages to different browsers on your server, see [Web-Push](https://www.npmjs.com/package/web-push).
 
-The following steps have been adapted from the Push Rich Demo in the [Service Worker Cookbook](https://serviceworke.rs/push-rich_demo.html) provided by Mozilla.  This Cookbook has many useful Web Push and Service Worker recipes.
-
 
 <!-- ====================================================================== -->
 ### Step 1 - Generate VAPID keys
@@ -223,7 +221,7 @@ For information about VAPID and WebPush, see [Sending VAPID identified WebPush N
 
 Service workers handle push events and toast notification interactions in your PWA.  To subscribe the PWA to server push notifications:
 
-*   Make sure your PWA is installed, active, and registered.
+*   Make sure your service worker is installed, active, and registered.
 *   Make sure your code for completing the subscription task is on the main UI thread of the PWA.
 *   Make sure you have network connectivity.
 


### PR DESCRIPTION
The mozilla demo page that is mentioned in the docs does not exist anymore.
So, removing the mention.

Also, step 2 said that the PWA should be installed, active, and registered.
This is incorrect, the service worker should be all of those things, not the PWA.

Before: https://docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/notifications-badges#add-push-notifications-to-your-pwa
After: https://review.docs.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/notifications-badges?branch=pr-en-us-1760#add-push-notifications-to-your-pwa