### PR TITLE
Removed version 97 reference in dom-leaks article

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -12,12 +12,12 @@ ms.date: 11/30/2021
 
 <!-- 
 Policies for maintaining this page:
-Cover the latest Canary version.
+Cover the latest Canary version.  But also check for coherence against Edge Stable; if needed, address both extremes (Stable v[n] and Canary v[n+3]) explicitly.
 Keep h2 sections in same order as Microsoft Edge DevTools > Experiments page.
 In the heading and UI steps, keep the checkbox label UI string as-is.
 Include an h2 section for every checkbox that's in public-facing Microsoft Edge DevTools > Experiments page.
 If no info is an an h2 section, comment out the h2 heading & section.
-When a checkbox is removed from all the preview channels, move its section down to "Previously Experimental features which are now regular features" and comment it out.
+When a checkbox is removed from all the preview channels, move its section down to "Previously Experimental features which are now regular features" and comment it out.  Same w/ "on by default" list item if any.
 -->
 
 Microsoft Edge DevTools provide access to experimental features that are still in development.  This article lists and describes most of the experimental features which are in the latest version of the Canary preview channel of Microsoft Edge.
@@ -34,33 +34,28 @@ These experiments could be unstable or unreliable and may require you to restart
 The following experimental features are turned on by default. You can use these features right away, without changing any settings. You can turn off these default experimental features, if needed.
 
 <!-- listed in order of the Settings > Experiments pane -->
-*  Source order viewer.
-*  Enable back-forward cache debugging support.
-*  [Emulation: Support dual screen mode](../device-mode/dual-screen-and-foldables.md).
-*  Enable experimental hide issues menu.
-*  Enable webhint.
-*  Show issues in Elements.
-*  Enable Composited Layers in 3D View.
-*  DevTools Tooltips.
-*  Detached Elements.
-*  VS Code themes for the DevTools. <!-- preserve literal UI string, including "VS" & "the" -->
-*  Open source files in Visual Studio Code.
-*  Enable keyboard shortcut editor - [Edit keyboard shortcuts for any action in DevTools](../customize/shortcuts.md#edit-the-keyboard-shortcut-for-a-devtools-action).
-*  Enable dynamic Welcome content, off by default now but on by default in Microsoft Edge version 97.
+
+**Turned on by default in v100:**
+* [Enable Reporting API panel in the Application panel](#enable-reporting-api-panel-in-the-application-panel)
+* [Display more precise changes in the Changes tab](#display-more-precise-changes-in-the-changes-tab)
+* [Enable webhint](#enable-webhint)
+* [Show issues in Elements](#show-issues-in-elements)
+* [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
+* [Automatically pretty print in the Microsoft Edge Sources Panel](#automatically-pretty-print-in-the-microsoft-edge-sources-panel)
+
+**Turned on by default in v98:**
+* [Source order viewer](#source-order-viewer)
+* [Emulation: Support dual screen mode](##emulation-support-dual-screen-mode)
+* [Enable webhint](#enable-webhint)
+* [Show issues in Elements](#show-issues-in-elements)
+* [Enable Composited Layers in 3D View](#enable-composited-layers-in-3d-view)
+* [DevTools Tooltips](#devtools-tooltips)
+* [Detached Elements](#detached-elements)
+* [VS Code themes for the DevTools](#vs-code-themes-for-the-devtools)<!-- preserve literal UI string, including "VS" & "the" -->
+* [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
+* [Enable keyboard shortcut editor](#enable-keyboard-shortcut-editor)
 
 <!-- don't place a comment line between list item lines, above; that would create a gap -->
-
-<!-- Don't list this checkbox in this article; it's being removed: -->
-<!-- *  Enable CSS \<length\> authoring tool in the Styles pane -->
-
-<!-- *  Detached Elements 
-Is the Detached Elements experiment checkbox intended to be present for external users?
-Is the Detached Elements experiment checkbox intended to be turned on by default, for external users?
-PM answered:
-"The Detached Elements checkbox is visible to all Edge users since Edge 93.
-The experiment was turned on by default in Edge 93 for all internal (so has a microsoft.com account in Edge) DevTools customers.
-Starting with Edge 97, the experiment will be turned on by default for all Edge users"
--->
 
 
 <!-- ====================================================================== -->
@@ -148,18 +143,6 @@ To capture JavaScript stack traces when DOM nodes are added to the DOM at runtim
 
 
 <!-- ====================================================================== -->
-## Automatically pretty print in the Sources Panel
-<!-- present in 96, 98 -->
-
-When this experiment is turned on, when you display a minified file in the Sources panel, the file is opened in a single tab in the Sources panel, pretty-printed.
-
-When this experiment is turned off, a UI prompt with a button asks you whether to pretty-print the file.  The file is opened in an additional tab which has an appended suffix of **:formatted**.
-
-*  A _minified_ file is concatenated into a single long line.
-*  In contrast, _pretty print_ presents the contents of a file in an indented, more human-readable format.
-
-
-<!-- ====================================================================== -->
 ## Protocol Monitor
 <!-- present in 96, 98 -->
 
@@ -185,24 +168,53 @@ To monitor the messages sent and received by DevTools to debug the inspected pag
 
 
 <!-- ====================================================================== -->
-<!-- ## Show CSP Violations view -->
+## Show CSP Violations view
 <!-- present in 96, 98 -->
 
-<!-- Needs content. -->
+Shows Content Security Policy (CSP) violations.
+<!-- needs content, 0 hits in fts in this repo - retry "csp" Find. -->
+
+See [Content Security Policy (CSP)](../../extensions-chromium/store-policies/csp.md).
 
 
 <!-- ====================================================================== -->
-<!-- ## Record coverage while performance tracing -->
+## Record coverage while performance tracing
 <!-- present in 96, 98 -->
 
-<!-- Needs content. -->
+Records coverage while performance tracing.
+<!-- needs content, 0 hits in fts in this repo -->
 
 
 <!-- ====================================================================== -->
-<!-- ## Show option to take heap snapshot where globals are treated as root -->
+## Show option to take heap snapshot where globals are treated as root
 <!-- present in 96, 98 -->
 
-<!-- Needs content. -->
+Shows the option to take a heap snapshot where globals are treated as root.
+<!-- needs content -->
+
+
+<!-- ====================================================================== -->
+## Show back/forward cache blocking reasons in the frame tree structure view
+<!-- present in v100 -->
+
+Whether to show back/forward cache blocking reasons in the frame tree structure view.
+<!-- needs content -->
+
+
+<!-- ====================================================================== -->
+## Timeline: event initiators
+<!-- present in v100 -->
+
+Whether to include event initiators in the Timeline.
+<!-- needs content -->
+
+
+<!-- ====================================================================== -->
+## Timeline: WebGL-based flamechart
+<!-- present in v100 -->
+
+Whether to use a WebGL-based flamechart in the Timeline.
+<!-- needs content -->
 
 
 <!-- ====================================================================== -->
@@ -225,24 +237,14 @@ To use the **Source Order Viewer**:
 
    ![Source Order Viewer in the Accessibility pane.](../media/experiments-source-order-viewer.msft.png)
 
-This experiment is turned on by default.
-
 For more information, see [Test keyboard support using the Source Order Viewer](../accessibility/test-tab-key-source-order-viewer.md)
 
 
 <!-- ====================================================================== -->
-## Enable back-forward cache debugging support
+## WebAssembly Debugging: Enable DWARF support
 <!-- present in 96, 98 -->
 
-Back-forward cache, or *bfcache*. Makes navigating through your browsing history faster by saving snapshots of visited web pages in memory.
-
-Certain web pages can't be cached. Enable this experiment to add the **Back-forward Cache** section to the **Application** panel.  Enabling back-forward cache debugging provides information about web pages that can't be stored in `bfcache`.
-
-
-<!-- ====================================================================== -->
-<!-- ## WebAssembly Debugging: Enable DWARF support -->
-<!-- present in 96, 98 -->
-
+Enables DWARF support for WebAssembly debugging.  See [Improved WebAssembly debugging](../whats-new/2019/12/devtools.md#improved-webassembly-debugging) in _What's new in DevTools (Microsoft Edge 80)_.
 <!-- Needs content. -->
 
 
@@ -250,27 +252,35 @@ Certain web pages can't be cached. Enable this experiment to add the **Back-forw
 ## Emulation: Support dual screen mode
 <!-- present in 96, 98 -->
 
-For more information, see [Emulation: Support dual screen mode](../device-mode/dual-screen-and-foldables.md).
+See [Emulation: Support dual screen mode](../device-mode/dual-screen-and-foldables.md).
 
 
 <!-- ====================================================================== -->
-<!-- ## Enable new Advanced Perceptual Contrast Algorithm (APCA) replacing previous contrast ratio and AA/AAA guidelines -->
-<!-- present in 96, 98 -->
+## Enable experimental hide issues menu
 
+Enables the experimental **Hide issues** menu.
+<!-- needs content -->
+
+
+<!-- ====================================================================== -->
+## Enable new Advanced Perceptual Contrast Algorithm (APCA) replacing previous contrast ratio and AA/AAA guidelines
+<!-- present in 96, 98, 100 -->
+
+Enables the new Advanced Perceptual Contrast Algorithm (APCA), replacing previous contrast ratio and AA/AAA guidelines.
 <!-- Needs content. -->
 
 
 <!-- ====================================================================== -->
-<!-- ## Enable full accessibility tree view in the Elements panel -->
-<!-- present in 96, 98 -->
+## Enable full accessibility tree view in the Elements panel
+<!-- present in 96, 98, 100 -->
 
+Enables the full accessibility tree view in the **Elements** tool.
 <!-- Needs content. -->
 
 
 <!-- ====================================================================== -->
 ## Enable the Font Editor tool within the Styles pane
-
-<!-- present in 96, 98 -->
+<!-- present in 96, 98, v100 -->
 
 You can use the visual [Font Editor](../inspect-styles/edit-fonts.md) to edit fonts.  Use it define fonts and font characteristics.  The visual **Font Editor** helps you do the following:
 
@@ -295,16 +305,18 @@ For more information, see [Edit CSS font styles and settings in the Styles pane]
 
 
 <!-- ====================================================================== -->
-<!-- ## Enable automatic contrast issue reporting via the Issues Panel -->
-<!-- present in 96, 98 -->
+## Enable automatic contrast issue reporting via the Issues Panel
+<!-- present in 96, 98, v100 -->
 
+Enables automatic contrast issue reporting in the **Issues** tool.
 <!-- Needs content. -->
 
 
 <!-- ====================================================================== -->
-<!-- ## Enable experimental cookie features -->
-<!-- present in 96, 98 -->
+## Enable experimental cookie features
+<!-- present in 96, 98, v100 -->
 
+Enables experimental cookie features.
 <!-- Needs content. -->
 
 
@@ -314,10 +326,35 @@ For more information, see [Edit CSS font styles and settings in the Styles pane]
 
 Use the Reporting API to catch certain errors such as security violations or deprecated API calls. These errors happen when users visit your site and are sent to a server endpoint. Enable this experiment to add the **Reporting API** section in the **Application** panel, which lists all of the reports sent to the endpoint.
 
-<!-- ====================================================================== -->
-<!-- ## Log DevTools uncaught exceptions to Console -->
-<!-- present in 96, 98 -->
 
+<!-- ====================================================================== -->
+## Display more precise changes in the Changes tab
+<!-- present in 100 -->
+
+See [More precise changes in the Changes tab](https://developer.chrome.com/blog/new-in-devtools-98/#changes).
+
+
+<!-- ====================================================================== -->
+## Sync CSS changes in the Styles pane
+<!-- present in 100 -->
+
+Whether to sync CSS changes in the **Styles** tab in the **Elements** tool.
+<!-- Needs content. -->
+
+
+<!-- ====================================================================== -->
+## Local overrides for response headers
+<!-- present in 100 -->
+
+Whether to use local overrides for response headers.
+<!-- Needs content. -->
+
+
+<!-- ====================================================================== -->
+## Log DevTools uncaught exceptions to Console
+<!-- present in 100 -->
+
+Controls whether to log DevTools uncaught exceptions in the **Console** tool.
 <!-- Needs content. -->
 
 
@@ -338,19 +375,19 @@ The [webhint](https://webhint.io) experiment displays the webhint feedback in th
 
 ![webhint feedback in the Issues panel.](../media/experiments-webhint.msft.png)
 
-This experiment is turned on by default.
-
 
 <!-- ====================================================================== -->
-
 ## Show issues in Elements
 <!-- present in 96, 98 -->
 
 Enable this experiment to view syntax errors under HTML in the **DOM** view of the **Elements** tool. For more information, see [Wavy underlines highlight code issues and improvements in Elements tool](../whats-new/2021/04/devtools.md#wavy-underlines-highlight-code-issues-and-improvements-in-elements-tool).
 
+
 <!-- ====================================================================== -->
 ## Enable Composited Layers in 3D View
 <!-- present in 96, 98 -->
+
+Checkbox not present in v100.<!-- move down to hidden section, comment out? -->
 
 You can visualize Layers alongside z-indexes and the Document Object Model (DOM). For a comprehensive visual debugging experience, the 3D View and Composited Layers are now combined.
 
@@ -369,8 +406,6 @@ To use **Composited Layers**:
 1. All of the painted layers of the app are displayed.  Try this feature with your own web apps.
 
    ![Composited Layers pane.](../media/experiments-layers.msft.png)
-
-This experiment is turned on by default.
 
 See also [Navigate z-index, DOM, and layers using the 3D View tool](../3d-view/index.md).
 
@@ -441,14 +476,21 @@ See also:
 ## DevTools Tooltips
 <!-- present in 96, 98 -->
 
+Checkbox not present in Canary v100.
+
 Enable this experiment to view tooltips for all the different tools and panes in DevTools. For more information, see [Learn about DevTools with informative tooltips](../whats-new/2021/04/devtools.md#learn-about-devtools-with-informative-tooltips).
 
 
 <!-- ====================================================================== -->
 ## Detached Elements
-<!-- present in 96, 98.  Selected by default for all users since v97. -->
+<!-- present in 96, 98.  Selected by default for all users since v97.
+PM:
+"The Detached Elements checkbox is visible to all Edge users since Edge 93.
+The experiment was turned on by default in Edge 93 for all internal (so has a microsoft.com account in Edge) DevTools customers.
+Starting with Edge 97, the experiment will be turned on by default for all Edge users"
+-->
 
-<!-- maintainers: see notes about this experiment, in the list of experiments which are turned on by default, at top of article -->
+Checkbox not present in Canary v100.
 
 Memory leaks in web applications can be difficult to locate and repair.
 
@@ -461,8 +503,10 @@ For more information, see [Debug DOM memory leaks with the Detached Elements too
 
 <!-- ====================================================================== -->
 ## VS Code themes for the DevTools
-<!-- present in 96, 98 -->
 <!-- preserve literal UI string, including "VS" & "the" -->
+<!-- present in 96, 98 -->
+
+Checkbox not present in v100.
 
 To use Visual Studio themes in DevTools, enable the **VS Code themes for the DevTools** experiment. For more information, see [Apply color themes to DevTools](../customize/theme.md).
 
@@ -481,50 +525,101 @@ Any edits that you make in DevTools now change the file on the hard drive and sy
 
 
 <!-- ====================================================================== -->
+## Automatically pretty print in the Microsoft Edge Sources Panel
+<!-- present in 96, 98 -->
+
+When this experiment is turned on, when you display a minified file in the Sources panel, the file is opened in a single tab in the Sources panel, pretty-printed.
+
+When this experiment is turned off, a UI prompt with a button asks you whether to pretty-print the file.  The file is opened in an additional tab which has an appended suffix of **:formatted**.
+
+*  A _minified_ file is concatenated into a single long line.
+*  In contrast, _pretty print_ presents the contents of a file in an indented, more human-readable format.
+
+
+<!-- ====================================================================== -->
 <!-- >> [!WARNING]
 > These experiments are particularly unstable. Enable at your own risk. -->
 
 
 <!-- ====================================================================== -->
-<!-- ## Ignore List for JavaScript frames on Timeline
+## Ignore List for JavaScript frames on Timeline
 <!-- present in 96, 98 -->
 
+Whether to include the Ignore list for JavaScript frames on the Timeline.
 <!-- Needs content. -->
+
+This checkbox is present in Canary v100.
 
 
 <!-- ====================================================================== -->
-<!-- ## Input events on Timeline overview -->
+## Input events on Timeline overview
 <!-- present in 96, 98 -->
 
+Controls whether to include Input events on the Timeline overview.
 <!-- Needs content. -->
+
+This checkbox is present in Canary v100.
 
 
 <!-- ====================================================================== -->
-<!-- ## Live heap profile -->
+## Live heap profile
 <!-- present in 96, 98 -->
 
+Controls whether to live-update the heap profile.
 <!-- Needs content. -->
+
+This checkbox is present in Canary v100.
 
 
 <!-- ====================================================================== -->
-<!-- ## Sampling heap profiler timeline -->
+## Sampling heap profiler timeline
 <!-- present in 96, 98 -->
 
+Controls whether to show the Sampling heap profiler timeline.
 <!-- Needs content. -->
+
+This checkbox is present in Canary v100.
 
 
 <!-- ====================================================================== -->
-<!-- ## Enable keyboard shortcut editor -->
+## Enable keyboard shortcut editor
 <!-- present in 96, 98 -->
 
-<!-- Needs content. -->
+See [Edit the keyboard shortcut for a DevTools action](../customize/shortcuts.md#edit-the-keyboard-shortcut-for-a-devtools-action) in _Customize keyboard shortcuts_.
+
+This checkbox is not present in Canary v100.
 
 
 <!-- ====================================================================== -->
-<!-- ## Enable dynamic Welcome content -->
-<!-- present in 96, 98 -->
+## Timeline: Invalidation tracking
 
-<!-- Needs content. -->
+Controls whether to show invalidation tracking on the Timeline.
+
+This checkbox is present in Canary v100.
+
+
+<!-- ====================================================================== -->
+## Timeline: Show all events
+
+Controls whether to show all events on the Timeline.
+
+This checkbox is present in Canary v100.
+
+
+<!-- ====================================================================== -->
+## Timeline: V8 Runtime Call Stats on Timeline
+
+Controls whether to show v8 runtime call stats on the Timeline.
+
+This checkbox is present in Canary v100.
+
+
+<!-- ====================================================================== -->
+## Timeline: Replay input events
+
+Controls whether to replay input events on the Timeline.
+
+This checkbox is present in Canary v100.
 
 
 <!-- ====================================================================== -->
@@ -532,6 +627,31 @@ Any edits that you make in DevTools now change the file on the hard drive and sy
 ## Previously Experimental features which are now regular features
 
 These features have been promoted from experimental to regular features, and have been removed from **Settings** > **Experiments**.
+
+
+no such, as of v98:
+*  [Enable back-forward cache debugging support](#Enable back-forward cache debugging support).
+
+no such, as of v98:
+*  Enable experimental hide issues menu.
+
+
+
+======================================================================
+## Enable dynamic Welcome content
+present in 96, 98 - no, not present in 98 anymore
+
+
+======================================================================
+## Enable back-forward cache debugging support
+present in 96, 98
+
+Back-forward cache, or *bfcache*. Makes navigating through your browsing history faster by saving snapshots of visited web pages in memory.
+
+Certain web pages can't be cached. Enable this experiment to add the **Back-forward Cache** section to the **Application** panel.  Enabling back-forward cache debugging provides information about web pages that can't be stored in `bfcache`.
+
+
+======================================================================
 
 *  [Turn on new CSS grid debugging features](../css/grid.md) - removed from experimental status starting with Microsoft Edge 89.
 

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -45,7 +45,7 @@ The following experimental features are turned on by default. You can use these 
 
 **Turned on by default in v98:**
 * [Source order viewer](#source-order-viewer)
-* [Emulation: Support dual screen mode](##emulation-support-dual-screen-mode)
+* [Emulation: Support dual screen mode](#emulation-support-dual-screen-mode)
 * [Enable webhint](#enable-webhint)
 * [Show issues in Elements](#show-issues-in-elements)
 * [Enable Composited Layers in 3D View](#enable-composited-layers-in-3d-view)

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 no-loc: ["Enable webhint", "Enable Network Console", "Source Order Viewer", "Enable Composited Layers in 3D View", "Enable new Font Editor tool within the Styles pane", "Enable new CSS Flexbox debugging features", "Enable + button tab menus to open more tools", "Enable Welcome tab", "3D View", "Turn on support to move tabs between panels", "Match keyboard shortcuts in DevTools to Microsoft Visual Studio Code", "Edit keyboard shortcuts for any action in DevTools", "Turn on new CSS grid debugging features", "Emulation: Support dual screen mode"]
-ms.date: 11/30/2021
+ms.date: 03/01/2022
 ---
 # Experimental features
 
@@ -20,13 +20,17 @@ In the heading and UI steps, keep the checkbox label UI string as-is (don't revi
 Include a visible h2 section for every checkbox that's in public-facing Microsoft Edge DevTools > Experiments page.  If no info, write a tautology as a starting point.
 When a checkbox is removed from all the preview channels, move its section down to "Previously Experimental features which are now regular features" and comment it out.  Same w/ any "on by default" list item.
 
-Open Edge Stable > Settings > Experiments, go to edge://settings/help, update if needed, make sure the article has an h2 for each checkbox.
-In each h2 section, write visibly & explicitly, "This checkbox is|is not present in Microsoft Edge Stable v123."
-Update the Edge Stable list at top, re: On By Default checkboxes. Link down to the h2, do not link to other page, here.
+Do the following, monthly:
 
-Open Edge Canary > Settings > Experiments, go to edge://settings/help, update if needed, make sure the article has an h2 for each checkbox.
-In each h2 section, write visibly & explicitly, "This checkbox is|is not present in Microsoft Edge Canary v123."
-Update the Edge Canary list at top, re: On By Default checkboxes. Link down to the h2, do not link to other page, here.
+1. Open Edge Stable > Settings > Experiments, go to edge://settings/help, update if needed, make sure the article has an h2 for each checkbox.
+2. In each h2 section, write visibly & explicitly:
+This checkbox is|is not present in Microsoft Edge Stable v123.
+1. Update the Edge Stable list at top, re: On By Default checkboxes. Link down to the h2, do not link to other page, here.
+
+4. Open Edge Canary > Settings > Experiments, go to edge://settings/help, update if needed, make sure the article has an h2 for each checkbox.
+5. In each h2 section, write visibly & explicitly:
+This checkbox is|is not present in Microsoft Edge Canary v123.
+1. Update the Edge Canary list at top, re: On By Default checkboxes. Link down to the h2, do not link to other page, here.
 -->
 
 Microsoft Edge DevTools provide access to experimental features that are still in development.  This article lists and describes the experimental features which are in either:
@@ -46,14 +50,6 @@ The following experimental features are turned on by default. You can use these 
 
 <!-- listed in order of the Settings > Experiments pane -->
 
-**Turned on by default in Microsoft Edge Canary v100:**
-* [Enable Reporting API panel in the Application panel](#enable-reporting-api-panel-in-the-application-panel)
-* [Display more precise changes in the Changes tab](#display-more-precise-changes-in-the-changes-tab)
-* [Enable webhint](#enable-webhint)
-* [Show issues in Elements](#show-issues-in-elements)
-* [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
-* [Automatically pretty print in the Microsoft Edge Sources Panel](#automatically-pretty-print-in-the-microsoft-edge-sources-panel)
-
 **Turned on by default in Microsoft Edge Stable v98:**
 * [Source order viewer](#source-order-viewer)
 * [Emulation: Support dual screen mode](#emulation-support-dual-screen-mode)
@@ -65,6 +61,14 @@ The following experimental features are turned on by default. You can use these 
 * [VS Code themes for the DevTools](#vs-code-themes-for-the-devtools)<!-- preserve literal UI string, including "VS" & "the" -->
 * [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
 * [Enable keyboard shortcut editor](#enable-keyboard-shortcut-editor)
+
+**Turned on by default in Microsoft Edge Canary v100:**
+* [Enable Reporting API panel in the Application panel](#enable-reporting-api-panel-in-the-application-panel)
+* [Display more precise changes in the Changes tab](#display-more-precise-changes-in-the-changes-tab)
+* [Enable webhint](#enable-webhint)
+* [Show issues in Elements](#show-issues-in-elements)
+* [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
+* [Automatically pretty print in the Microsoft Edge Sources Panel](#automatically-pretty-print-in-the-microsoft-edge-sources-panel)
 
 <!-- don't place a comment line between list item lines, above; that would create a gap -->
 
@@ -141,21 +145,24 @@ Most of the experiments that appear in the latest version of the Canary preview 
 
 <!-- ====================================================================== -->
 ## Allow extensions to load custom stylesheets
-<!-- present in 96, 98 -->
 
 Some Microsoft Edge Add-ons can define custom color themes for DevTools. If you install an add-on with a theme, you need to enable the **Allow extensions to load custom stylesheets** experiment to view the add-on themes.
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Capture node creation stacks
-<!-- present in 96, 98 -->
 
 To capture JavaScript stack traces when DOM nodes are added to the DOM at runtime, enable this experiment. The captured stack traces are displayed in the **Stack Trace** pane of the **Elements** panel.
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Protocol Monitor
-<!-- present in 96, 98 -->
 
 DevTools communicates with the inspected page using the DevTools protocol.
 
@@ -177,60 +184,54 @@ To monitor the messages sent and received by DevTools to debug the inspected pag
 
 1. The **Protocol monitor** tool is displayed in the **Drawer** at the bottom of DevTools.
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Show CSP Violations view
-<!-- present in 96, 98 -->
 
 Shows Content Security Policy (CSP) violations.
 <!-- needs content, 0 hits in fts in this repo - retry "csp" Find. -->
 
 See [Content Security Policy (CSP)](../../extensions-chromium/store-policies/csp.md).
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Record coverage while performance tracing
-<!-- present in 96, 98 -->
 
 Records coverage while performance tracing.
 <!-- needs content, 0 hits in fts in this repo -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Show option to take heap snapshot where globals are treated as root
-<!-- present in 96, 98 -->
 
 Shows the option to take a heap snapshot where globals are treated as root.
 <!-- needs content -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Show back/forward cache blocking reasons in the frame tree structure view
-<!-- present in v100 -->
 
 Whether to show back/forward cache blocking reasons in the frame tree structure view.
 <!-- needs content -->
 
-
-<!-- ====================================================================== -->
-## Timeline: event initiators
-<!-- present in v100 -->
-
-Whether to include event initiators in the Timeline.
-<!-- needs content -->
-
-
-<!-- ====================================================================== -->
-## Timeline: WebGL-based flamechart
-<!-- present in v100 -->
-
-Whether to use a WebGL-based flamechart in the Timeline.
-<!-- needs content -->
+*  This checkbox is not present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Source order viewer
-<!-- present in 96, 98 -->
 
 **Source Order Viewer** is an experiment that displays the order of elements in the webpage source. The on-screen display order can differ from the order of the source, which confuses screen reader and keyboard users. Use the **Source Order Viewer** experiment to find the differences between on-screen display order and the order of the source.
 
@@ -250,48 +251,71 @@ To use the **Source Order Viewer**:
 
 For more information, see [Test keyboard support using the Source Order Viewer](../accessibility/test-tab-key-source-order-viewer.md)
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
+
+
+<!-- ====================================================================== -->
+## Timeline: event initiators
+
+Whether to include event initiators in the Timeline.
+<!-- needs content -->
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
+
+<!-- ====================================================================== -->
+## Timeline: WebGL-based flamechart
+
+Whether to use a WebGL-based flamechart in the Timeline.
+<!-- needs content -->
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## WebAssembly Debugging: Enable DWARF support
-<!-- present in 96, 98 -->
 
 Enables DWARF support for WebAssembly debugging.  See [Improved WebAssembly debugging](../whats-new/2019/12/devtools.md#improved-webassembly-debugging) in _What's new in DevTools (Microsoft Edge 80)_.
 <!-- Needs content. -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Emulation: Support dual screen mode
-<!-- present in 96, 98 -->
 
 See [Emulation: Support dual screen mode](../device-mode/dual-screen-and-foldables.md).
 
-
-<!-- ====================================================================== -->
-## Enable experimental hide issues menu
-
-Enables the experimental **Hide issues** menu.
-<!-- needs content -->
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Enable new Advanced Perceptual Contrast Algorithm (APCA) replacing previous contrast ratio and AA/AAA guidelines
-<!-- present in 96, 98, 100 -->
 
 Enables the new Advanced Perceptual Contrast Algorithm (APCA), replacing previous contrast ratio and AA/AAA guidelines.
 <!-- Needs content. -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Enable full accessibility tree view in the Elements panel
-<!-- present in 96, 98, 100 -->
 
 Enables the full accessibility tree view in the **Elements** tool.
 <!-- Needs content. -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Enable the Font Editor tool within the Styles pane
-<!-- present in 96, 98, v100 -->
 
 You can use the visual [Font Editor](../inspect-styles/edit-fonts.md) to edit fonts.  Use it define fonts and font characteristics.  The visual **Font Editor** helps you do the following:
 
@@ -314,64 +338,80 @@ For more information about the visual **Font Editor**, see [Edit CSS font styles
 
 For more information, see [Edit CSS font styles and settings in the Styles pane](../inspect-styles/edit-fonts.md).
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Enable automatic contrast issue reporting via the Issues Panel
-<!-- present in 96, 98, v100 -->
 
 Enables automatic contrast issue reporting in the **Issues** tool.
 <!-- Needs content. -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Enable experimental cookie features
-<!-- present in 96, 98, v100 -->
 
 Enables experimental cookie features.
 <!-- Needs content. -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Enable Reporting API panel in the Application panel
-<!-- present in 96, 98 -->
 
 Use the Reporting API to catch certain errors such as security violations or deprecated API calls. These errors happen when users visit your site and are sent to a server endpoint. Enable this experiment to add the **Reporting API** section in the **Application** panel, which lists all of the reports sent to the endpoint.
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Display more precise changes in the Changes tab
-<!-- present in 100 -->
 
 See [More precise changes in the Changes tab](https://developer.chrome.com/blog/new-in-devtools-98/#changes).
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Sync CSS changes in the Styles pane
-<!-- present in 100 -->
 
 Whether to sync CSS changes in the **Styles** tab in the **Elements** tool.
 <!-- Needs content. -->
 
+*  This checkbox is not present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Local overrides for response headers
-<!-- present in 100 -->
 
 Whether to use local overrides for response headers.
 <!-- Needs content. -->
 
+*  This checkbox is not present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Log DevTools uncaught exceptions to Console
-<!-- present in 100 -->
 
 Controls whether to log DevTools uncaught exceptions in the **Console** tool.
 <!-- Needs content. -->
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Enable webhint
-<!-- present in 96, 98 -->
 
 [webhint](https://webhint.io) is an open-source tool that provides real-time feedback for websites and local webpages.  The type of feedback provided by [webhint](https://webhint.io) includes:
 
@@ -386,19 +426,21 @@ The [webhint](https://webhint.io) experiment displays the webhint feedback in th
 
 ![webhint feedback in the Issues panel.](../media/experiments-webhint.msft.png)
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Show issues in Elements
-<!-- present in 96, 98 -->
 
 Enable this experiment to view syntax errors under HTML in the **DOM** view of the **Elements** tool. For more information, see [Wavy underlines highlight code issues and improvements in Elements tool](../whats-new/2021/04/devtools.md#wavy-underlines-highlight-code-issues-and-improvements-in-elements-tool).
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Enable Composited Layers in 3D View
-<!-- present in 96, 98 -->
-
-Checkbox not present in v100.<!-- move down to hidden section, comment out? -->
 
 You can visualize Layers alongside z-indexes and the Document Object Model (DOM). For a comprehensive visual debugging experience, the 3D View and Composited Layers are now combined.
 
@@ -420,10 +462,12 @@ To use **Composited Layers**:
 
 See also [Navigate z-index, DOM, and layers using the 3D View tool](../3d-view/index.md).
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Enable Network Console
-<!-- present in 96, 98 -->
 
 **Network Console** is the working title of an experiment to make synthetic network requests over HTTP.  You can use the **Network Console** experiment to send web API requests.
 
@@ -442,6 +486,9 @@ To use the **Network Console**:
    ![Network Console in the Console drawer.](../media/network-network-console.msft.png)
 
 See [Compose and send web API requests using the Network Console tool](../network-console/network-console-tool.md).
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
@@ -482,26 +529,24 @@ See also:
 * [About the list of tools](../about-tools.md).
 * [DevTools: Focus Mode UI](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/DevTools/FocusMode/explainer.md) - draft documentation of this experimental feature, in the Explainers repo.
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## DevTools Tooltips
-<!-- present in 96, 98 -->
-
-Checkbox not present in Canary v100.
 
 Enable this experiment to view tooltips for all the different tools and panes in DevTools. For more information, see [Learn about DevTools with informative tooltips](../whats-new/2021/04/devtools.md#learn-about-devtools-with-informative-tooltips).
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Detached Elements
-<!-- present in 96, 98.  Selected by default for all users since v97.
-PM:
-"The Detached Elements checkbox is visible to all Edge users since Edge 93.
+<!-- PM: "The Detached Elements checkbox is visible to all Edge users since Edge 93.
 The experiment was turned on by default in Edge 93 for all internal (so has a microsoft.com account in Edge) DevTools customers.
-Starting with Edge 97, the experiment will be turned on by default for all Edge users"
--->
-
-Checkbox not present in Canary v100.
+Starting with Edge 97, the experiment will be turned on by default for all Edge users" -->
 
 Memory leaks in web applications can be difficult to locate and repair.
 
@@ -511,20 +556,22 @@ Memory leaks occur when the JavaScript code of the application retains an increa
 
 For more information, see [Debug DOM memory leaks with the Detached Elements tool](../memory-problems/dom-leaks.md)
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## VS Code themes for the DevTools
 <!-- preserve literal UI string, including "VS" & "the" -->
-<!-- present in 96, 98 -->
-
-Checkbox not present in v100.
 
 To use Visual Studio themes in DevTools, enable the **VS Code themes for the DevTools** experiment. For more information, see [Apply color themes to DevTools](../customize/theme.md).
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Open source files in Visual Studio Code
-<!-- present in 96, 98 -->
 
 The **Open source files in Visual Studio Code** experiment replaces the code editor of the Sources tool with Visual Studio Code, for editing local files. When you turn on this experiment, Developer Tools detects when you edit a local file, and prompts you to select a folder to use as your Workspace.
 
@@ -534,10 +581,12 @@ When you select a folder to use as your Workspace, selecting any link to a file 
 
 Any edits that you make in DevTools now change the file on the hard drive and sync live with Visual Studio Code. You can read about setting up your workspace in [Opening source files in Visual Studio Code](../sources/opening-sources-in-vscode.md).
 
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
 
 <!-- ====================================================================== -->
 ## Automatically pretty print in the Microsoft Edge Sources Panel
-<!-- present in 96, 98 -->
 
 When this experiment is turned on, when you display a minified file in the Sources panel, the file is opened in a single tab in the Sources panel, pretty-printed.
 
@@ -545,6 +594,9 @@ When this experiment is turned off, a UI prompt with a button asks you whether t
 
 *  A _minified_ file is concatenated into a single long line.
 *  In contrast, _pretty print_ presents the contents of a file in an indented, more human-readable format.
+
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
@@ -554,51 +606,51 @@ When this experiment is turned off, a UI prompt with a button asks you whether t
 
 <!-- ====================================================================== -->
 ## Ignore List for JavaScript frames on Timeline
-<!-- present in 96, 98 -->
 
 Whether to include the Ignore list for JavaScript frames on the Timeline.
 <!-- Needs content. -->
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Input events on Timeline overview
-<!-- present in 96, 98 -->
 
 Controls whether to include Input events on the Timeline overview.
 <!-- Needs content. -->
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Live heap profile
-<!-- present in 96, 98 -->
 
 Controls whether to live-update the heap profile.
 <!-- Needs content. -->
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Sampling heap profiler timeline
-<!-- present in 96, 98 -->
 
 Controls whether to show the Sampling heap profiler timeline.
 <!-- Needs content. -->
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
 ## Enable keyboard shortcut editor
-<!-- present in 96, 98 -->
 
 See [Edit the keyboard shortcut for a DevTools action](../customize/shortcuts.md#edit-the-keyboard-shortcut-for-a-devtools-action) in _Customize keyboard shortcuts_.
 
-This checkbox is not present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
@@ -606,7 +658,8 @@ This checkbox is not present in Canary v100.
 
 Controls whether to show invalidation tracking on the Timeline.
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
@@ -614,7 +667,8 @@ This checkbox is present in Canary v100.
 
 Controls whether to show all events on the Timeline.
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
@@ -622,7 +676,8 @@ This checkbox is present in Canary v100.
 
 Controls whether to show v8 runtime call stats on the Timeline.
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
 
 
 <!-- ====================================================================== -->
@@ -630,16 +685,31 @@ This checkbox is present in Canary v100.
 
 Controls whether to replay input events on the Timeline.
 
-This checkbox is present in Canary v100.
+*  This checkbox is present in Microsoft Edge Stable v98.
+*  This checkbox is present in Microsoft Edge Canary v100.
+
+
+<!-- /end of checkboxes -->
 
 
 <!-- ====================================================================== -->
 <!-- todo: move these sections into regular articles
 ## Previously Experimental features which are now regular features
 
-These features have been promoted from experimental to regular features, and have been removed from **Settings** > **Experiments**.
+These features have been promoted from experimental to regular features, and have been removed from **Settings** > **Experiments**. -->
 
 
+<!-- ====================================================================== -->
+<!-- ## Enable experimental hide issues menu
+
+Enables the experimental **Hide issues** menu.
+
+*  This checkbox is not present in Microsoft Edge Stable v98.
+*  This checkbox is not present in Microsoft Edge Canary v100. -->
+
+
+
+<!--
 no such, as of v98:
 *  [Enable back-forward cache debugging support](#Enable back-forward cache debugging support).
 

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -42,6 +42,7 @@ The following experimental features are turned on by default. You can use these 
 *  Show issues in Elements.
 *  Enable Composited Layers in 3D View.
 *  DevTools Tooltips.
+*  Detached Elements.
 *  VS Code themes for the DevTools. <!-- preserve literal UI string, including "VS" & "the" -->
 *  Open source files in Visual Studio Code.
 *  Enable keyboard shortcut editor - [Edit keyboard shortcuts for any action in DevTools](../customize/shortcuts.md#edit-the-keyboard-shortcut-for-a-devtools-action).
@@ -55,6 +56,10 @@ The following experimental features are turned on by default. You can use these 
 <!-- *  Detached Elements 
 Is the Detached Elements experiment checkbox intended to be present for external users?
 Is the Detached Elements experiment checkbox intended to be turned on by default, for external users?
+PM answered:
+"The Detached Elements checkbox is visible to all Edge users since Edge 93.
+The experiment was turned on by default in Edge 93 for all internal (so has a microsoft.com account in Edge) DevTools customers.
+Starting with Edge 97, the experiment will be turned on by default for all Edge users"
 -->
 
 
@@ -441,7 +446,7 @@ Enable this experiment to view tooltips for all the different tools and panes in
 
 <!-- ====================================================================== -->
 ## Detached Elements
-<!-- present in 96, 98 -->
+<!-- present in 96, 98.  Selected by default for all users since v97. -->
 
 <!-- maintainers: see notes about this experiment, in the list of experiments which are turned on by default, at top of article -->
 

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -12,15 +12,26 @@ ms.date: 11/30/2021
 
 <!-- 
 Policies for maintaining this page:
-Cover the latest Canary version.  But also check for coherence against Edge Stable; if needed, address both extremes (Stable v[n] and Canary v[n+3]) explicitly.
+
+Cover the latest Canary version and the latest Stable version.  Address both extremes (Stable v[n] and Canary v[n+3]) explicitly, in visible text - this is required, for maintainability of this maximally volatile info.
+
 Keep h2 sections in same order as Microsoft Edge DevTools > Experiments page.
-In the heading and UI steps, keep the checkbox label UI string as-is.
-Include an h2 section for every checkbox that's in public-facing Microsoft Edge DevTools > Experiments page.
-If no info is an an h2 section, comment out the h2 heading & section.
-When a checkbox is removed from all the preview channels, move its section down to "Previously Experimental features which are now regular features" and comment it out.  Same w/ "on by default" list item if any.
+In the heading and UI steps, keep the checkbox label UI string as-is (don't revise or "fix" it).
+Include a visible h2 section for every checkbox that's in public-facing Microsoft Edge DevTools > Experiments page.  If no info, write a tautology as a starting point.
+When a checkbox is removed from all the preview channels, move its section down to "Previously Experimental features which are now regular features" and comment it out.  Same w/ any "on by default" list item.
+
+Open Edge Stable > Settings > Experiments, go to edge://settings/help, update if needed, make sure the article has an h2 for each checkbox.
+In each h2 section, write visibly & explicitly, "This checkbox is|is not present in Microsoft Edge Stable v123."
+Update the Edge Stable list at top, re: On By Default checkboxes. Link down to the h2, do not link to other page, here.
+
+Open Edge Canary > Settings > Experiments, go to edge://settings/help, update if needed, make sure the article has an h2 for each checkbox.
+In each h2 section, write visibly & explicitly, "This checkbox is|is not present in Microsoft Edge Canary v123."
+Update the Edge Canary list at top, re: On By Default checkboxes. Link down to the h2, do not link to other page, here.
 -->
 
-Microsoft Edge DevTools provide access to experimental features that are still in development.  This article lists and describes most of the experimental features which are in the latest version of the Canary preview channel of Microsoft Edge.
+Microsoft Edge DevTools provide access to experimental features that are still in development.  This article lists and describes the experimental features which are in either:
+*  The latest version of the Canary preview channel of Microsoft Edge.
+*  The latest version of the Stable version of Microsoft Edge.
 
 All [channels of Microsoft Edge](/deployedge/microsoft-edge-channels) have experimental features. You can get the latest experimental features by using the [Microsoft Edge Canary channel](https://www.microsoftedgeinsider.com/welcome?channel=canary). To view the full list available in your version of Microsoft Edge, see the **Settings** > **Experiments** page in DevTools.
 
@@ -35,7 +46,7 @@ The following experimental features are turned on by default. You can use these 
 
 <!-- listed in order of the Settings > Experiments pane -->
 
-**Turned on by default in v100:**
+**Turned on by default in Microsoft Edge Canary v100:**
 * [Enable Reporting API panel in the Application panel](#enable-reporting-api-panel-in-the-application-panel)
 * [Display more precise changes in the Changes tab](#display-more-precise-changes-in-the-changes-tab)
 * [Enable webhint](#enable-webhint)
@@ -43,7 +54,7 @@ The following experimental features are turned on by default. You can use these 
 * [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
 * [Automatically pretty print in the Microsoft Edge Sources Panel](#automatically-pretty-print-in-the-microsoft-edge-sources-panel)
 
-**Turned on by default in v98:**
+**Turned on by default in Microsoft Edge Stable v98:**
 * [Source order viewer](#source-order-viewer)
 * [Emulation: Support dual screen mode](#emulation-support-dual-screen-mode)
 * [Enable webhint](#enable-webhint)

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -25,8 +25,6 @@ As explained in [Fix memory problems](index.md), memory issues affect page perfo
 <!-- ====================================================================== -->
 ## Open the Detached Elements tool
 
-The **Detached Elements** tool is available by default in Microsoft Edge 97 and later. Check your version of Microsoft Edge by going to `edge://version`. If your version is less than 97, read [Turning an experiment on or off](../experimental-features/index.md#turning-an-experiment-on-or-off) for instructions about turning on the **Detached Elements** experiment.
-
 To open the **Detached Elements** tool and load the demo page:
 
 1. Open the [Detached Elements demo application](https://microsoftedge.github.io/Demos/detached-elements/) in a new window or tab.


### PR DESCRIPTION
Stable is 98, and about to switch to 99 this week. So 97 is outdated and our docs can assume that everyone has got it.
So I'm removing the reference to this version from the dom-leaks article.
Fixes #1770.

- Before: https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks#open-the-detached-elements-tool
- After: https://review.docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks?branch=pr-en-us-1772#open-the-detached-elements-tool
- https://review.docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/experimental-features/?branch=pr-en-us-1772#experiments-which-are-turned-on-by-default - 
   * In the list of On By Default checkboxes, added Detached Elements (on by default for external users since v97).
   * Linked all On By Default list items down to h2 sections in the present page.
   * Did a complete update against Stable 98 & against Canary 100, separately stating presence/absence of each checkbox.
   * Revealed all sections for all checkboxes.
   * Hid sections for removed checkboxes.
   * Added a system for straightforward monthly maintenance.