### PR TITLE
Validation messages for ProductId, OperationId, unexpected failures

### DIFF
--- a/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
+++ b/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
@@ -344,6 +344,15 @@ A `GET` operation status API can be called in the following scenarios.  In all v
 }
 ```
 
+#### Response when the publish call fails with an unexpected failure
+
+```json
+{
+    "id": "{operationID}",
+    "message": "An error occurred while processing the request. Please contact support Correlation ID: {operationID} Timestamp: {timeStamp}",
+}
+```
+
 #### Response headers
 
 None.
@@ -374,7 +383,7 @@ Here are a list of common error codes and possible reasons.  For a full list, se
 |---|---|---|
 | 400 Bad Request | The server didn't understand the request. | There's no package (zip file) in the body.  Or, `Content-Type` header is missing or its value is incorrect. |
 | 401 Unauthorized | The request page needs an authorization. | The auth token is missing, expired, or not valid. |
-| 404 Not Found | The server can't find the requested page. | The specified `productID` or `operationID` isn't valid, or doesn't belong to the developer who is making the request. |
+| 404 Not Found | The server can't find the requested page. | The specified `productID` or `operationID` isn't valid GUID, not valid, or doesn't belong to the developer who is making the request. |
 | 408 Request Timeout | The request took longer than the server was prepared to wait. | There was a timeout while uploading a package. |
 | 429 Too many requests | Too many requests were sent by the user. | Too many requests were sent and they got throttled. |
 

--- a/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
+++ b/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
@@ -383,7 +383,7 @@ Here are a list of common error codes and possible reasons.  For a full list, se
 |---|---|---|
 | 400 Bad Request | The server didn't understand the request. | There's no package (zip file) in the body.  Or, `Content-Type` header is missing or its value is incorrect. |
 | 401 Unauthorized | The request page needs an authorization. | The auth token is missing, expired, or not valid. |
-| 404 Not Found | The server can't find the requested page. | The specified `productID` or `operationID` isn't valid GUID, not valid, or doesn't belong to the developer who is making the request. |
+| 404 Not Found | The server can't find the requested page. | The specified `productID` or `operationID` doesn't have a  valid GUID, isn't valid, or doesn't belong to the developer who is making the request. |
 | 408 Request Timeout | The request took longer than the server was prepared to wait. | There was a timeout while uploading a package. |
 | 429 Too many requests | Too many requests were sent by the user. | Too many requests were sent and they got throttled. |
 


### PR DESCRIPTION
The following are the new documentation changes inline with code changes
1. In case of invalid guid in productId or operationId, 404 would be returned
2. In case of unexpected errors, new custom message with correlationId and timestamp would be returned

Rendered article: [https://review.docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/addons-api-reference?branch=pr-en-us-1773](https://review.docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/addons-api-reference?branch=pr-en-us-1773)