### PR TITLE
Removed suggestion to use twitter to contact the team

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -128,11 +128,7 @@ You can filter the experimental features by text included in the title.
 <!-- ====================================================================== -->
 ## Providing feedback about the experiments
 
-We're eager to hear your feedback about experimental features.
-
-* Send us your feedback by tweeting [@EdgeDevTools](https://twitter.com/edgedevtools).
-
-* [Contact the Microsoft Edge DevTools team](../contact.md).
+We're eager to hear your feedback about experimental features. [Contact the Microsoft Edge DevTools team](../contact.md) to share feedback with us.
 
 * With the **Focus Mode** experiment turned on, at the bottom of the **Activity Bar**, select **Help** (![the Help icon in the Activity Bar in Focus Mode.](../media/help-icon-of-focus-mode.png)) > **Feedback**, to show the **Send feedback** window.
 


### PR DESCRIPTION
We no longer are advertising our twitter account as a way to send us feedback. This was recently removed from the [Contact DevTools team page](https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/contact).

This PR removes the only other instance of this in the docs.

There are other places in the docs where we talk about the EdgeDevTools twitter account, but these are fine as we don't tell users to send feedback there.