### PR TITLE
Popup refocus - F6 now supported, moves focus to next pane

### DIFF
--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -114,7 +114,7 @@ To avoid such changes to your keyboard shortcuts, you can set `AreBrowserAcceler
 
 The following shortcuts are always turned off in WebView2, or are effectively turned off.  An asterisk (`*`) indicates that the shortcut isn't turned off, but the feature that it accesses is turned off, or the feature doesn't apply to WebView2.
 
-| Action | Windows |
+| Action | Shortcut |
 |:--- |:--- |
 | Add to Favorites | `Ctrl`+`D` |
 | Add All Tabs to Favorites | `Ctrl`+`Shift`+`D` |
@@ -131,8 +131,8 @@ The following shortcuts are always turned off in WebView2, or are effectively tu
 | Select Tab (1 - 8) | `Ctrl`+`(1-8)` |
 | Show Favorites Bar `*` | `Ctrl`+`Shift`+`B` |
 | Help | `F1` |
-| Focus Next Pane `*` | `F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shiftf6). |
-| Focus Previous Pane `*` | `Shift`+`F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shiftf6). |
+| Focus Next Pane `*` | `F6`.  Supported in windowed hosting mode, but not in visual hosting mode. |
+| Focus Previous Pane `*` | `Shift`+`F6`.  Supported in windowed hosting mode, but not in visual hosting mode. |
 | Reading View `*` | `F9` |
 | Focus Menu Bar | `F10` |
 | Show Identity Menu `*` | `Ctrl`+`Shift`+`M` |
@@ -157,16 +157,11 @@ The following shortcuts are always turned off in WebView2, or are effectively tu
 | Show Collections `*` | `Ctrl`+`Shift`+`Y` |
 
 
-### Support for F6 and Shift+F6
-
-`F6` and `Shift`+`F6` are supported in windowed hosting mode, but not in visual hosting mode.  
-
-
 ### Shortcuts turned off except when event not handled
 
 The following keyboard shortcuts are always turned off, except in windows that display when the `NewWindowRequested` event isn't handled:
 
-| Action | Windows |
+| Action | Shortcut |
 |:--- |:--- |
 | Close Tab | `Ctrl`+`W, Ctrl`+`F4` |
 | Close Window | `Ctrl`+`Shift`+`W` |
@@ -177,7 +172,7 @@ The following keyboard shortcuts are always turned off, except in windows that d
 
 If you set `AreBrowserAcceleratorKeysEnabled` to `FALSE`, the following additional keyboard shortcuts are turned off:
 
-| Action | Windows |
+| Action | Shortcut |
 |:--- |:--- |
 | Stop | `Escape` |
 | Find on Page | `Ctrl`+`F` |

--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -136,8 +136,8 @@ The following shortcuts are always turned off in WebView2, or are effectively tu
 | Select Tab (1 - 8) | `Ctrl`+`(1-8)` |
 | Show Favorites Bar `*` | `Ctrl`+`Shift`+`B` |
 | Help | `F1` |
-| Focus Next Pane `*` | `F6`.  Supported in windowed hosting mode, but not in visual hosting mode. |
-| Focus Previous Pane `*` | `Shift`+`F6`.  Supported in windowed hosting mode, but not in visual hosting mode. |
+| Focus Next Pane `*` | `F6`.  Supported in windowed hosting mode, but not in visual hosting mode.  Visual hosting mode is used for [WinUI 2 (UWP) apps](../samples/webview2_sample_uwp.md), and for [Win32 C++ apps with Visual Composition](../samples/webview2samplewincomp.md). |
+| Focus Previous Pane `*` | `Shift`+`F6`.  Same as `F6` support, above. |
 | Reading View `*` | `F9` |
 | Focus Menu Bar | `F10` |
 | Show Identity Menu `*` | `Ctrl`+`Shift`+`M` |

--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -7,7 +7,7 @@ ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
 no-loc: ["Autofill for Addresses", "Autofill for Passwords", Autofill for Payments", Browser Extensions", "Browser Task Manager", "Collections", "Continue-where-I-left-off prompt", "Downloads", "Edge Shopping", "Family Safety", "Favorites", "Hotkeys", "IE Mode" ,"Immersive Reader", "Intrusive Ads", "Read Aloud", "Smart Screen", "Translate", "Tracking Prevention", "Profile and Identity", "Web Payment API", "Windows Defender Application Guard","edge:// URLs"]
-ms.date: 03/11/2022
+ms.date: 03/14/2022
 ---
 # Differences between Microsoft Edge and WebView2
 
@@ -40,7 +40,7 @@ The following table displays the WebView2 features that differ from the Microsof
 *  **Configurable** indicates that you can turn on or off the feature using WebView2 APIs or command-line switches.
 
 > [!NOTE]
-> This article doesn't cover modifying features using command-line switches.  For more information about turning on and off features with command-line switches, see [List of Chromium Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches).
+> This article doesn't cover modifying features by using command-line switches.  For more information about turning on and off features by using command-line switches, see [List of Chromium Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches).
 
 | Feature | Default state | Configurable | Details |
 | --- | --- | --- | --- |
@@ -105,7 +105,12 @@ The following Microsoft Edge and Google Chrome settings webpages aren't availabl
 <!-- ====================================================================== -->
 ## Additional keyboard shortcuts information
 
-Keyboard shortcuts or key bindings are supported in Microsoft Edge and WebView2.  When Microsoft Edge is updated, the default key bindings might change.  Furthermore, a keyboard shortcut that is turned off by default might instead be turned on, if the feature is now supported in WebView2.
+Keyboard shortcuts or key bindings are supported in Microsoft Edge and WebView2.
+
+
+### Preventing shortcuts from changing during update
+
+When Microsoft Edge is updated, the default key bindings might change.  Furthermore, a keyboard shortcut that is turned off by default might instead be turned on, if the feature is now supported in WebView2.
 
 To avoid such changes to your keyboard shortcuts, you can set `AreBrowserAcceleratorKeysEnabled` to `FALSE`, which turns off all keys that access browser features, but keeps all basic text-editing and movement shortcuts turned on.
 

--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -7,10 +7,9 @@ ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
 no-loc: ["Autofill for Addresses", "Autofill for Passwords", Autofill for Payments", Browser Extensions", "Browser Task Manager", "Collections", "Continue-where-I-left-off prompt", "Downloads", "Edge Shopping", "Family Safety", "Favorites", "Hotkeys", "IE Mode" ,"Immersive Reader", "Intrusive Ads", "Read Aloud", "Smart Screen", "Translate", "Tracking Prevention", "Profile and Identity", "Web Payment API", "Windows Defender Application Guard","edge:// URLs"]
-ms.date: 09/21/2021
+ms.date: 03/11/2022
 ---
 # Differences between Microsoft Edge and WebView2
-<!-- old title: # Differences between Microsoft Edge and WebView2 -->
 
 WebView2 is based on the Microsoft Edge browser.  You have the opportunity to extend features from the browser to WebView2-based apps, which is useful.  However, since WebView2 isn't limited to browser-like apps, there are some browser features that need to be modified or removed.
 
@@ -129,8 +128,8 @@ The following shortcuts are always turned off in WebView2.  An asterisk (`*`) in
 | Select Tab (1 - 8) | `Ctrl`+`(1-8)` |
 | Show Favorites Bar `*` | `Ctrl`+`Shift`+`B` |
 | Help | `F1` |
-| Focus Next Pane `*` | `F6` |
-| Focus Previous Pane `*` | `Shift`+`F6` |
+| Focus Next Pane | `F6` |
+| Focus Previous Pane | `Shift`+`F6` |
 | Reading View `*` | `F9` |
 | Focus Menu Bar | `F10` |
 | Show Identity Menu `*` | `Ctrl`+`Shift`+`M` |

--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -109,7 +109,10 @@ Keyboard shortcuts or key bindings are supported in Microsoft Edge and WebView2.
 
 To avoid such changes to your keyboard shortcuts, you can set `AreBrowserAcceleratorKeysEnabled` to `FALSE`, which turns off all keys that access browser features, but keeps all basic text-editing and movement shortcuts turned on.
 
-The following shortcuts are always turned off in WebView2.  An asterisk (`*`) indicates that the shortcut isn't turned off, but the feature that it accesses is turned off, or the feature doesn't apply to WebView2.
+
+### Shortcuts that are turned off
+
+The following shortcuts are always turned off in WebView2, or are effectively turned off.  An asterisk (`*`) indicates that the shortcut isn't turned off, but the feature that it accesses is turned off, or the feature doesn't apply to WebView2.
 
 | Action | Windows |
 |:--- |:--- |
@@ -128,8 +131,8 @@ The following shortcuts are always turned off in WebView2.  An asterisk (`*`) in
 | Select Tab (1 - 8) | `Ctrl`+`(1-8)` |
 | Show Favorites Bar `*` | `Ctrl`+`Shift`+`B` |
 | Help | `F1` |
-| Focus Next Pane | `F6` |
-| Focus Previous Pane | `Shift`+`F6` |
+| Focus Next Pane `*` | `F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shift-f6). |
+| Focus Previous Pane `*` | `Shift`+`F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shift-f6). |
 | Reading View `*` | `F9` |
 | Focus Menu Bar | `F10` |
 | Show Identity Menu `*` | `Ctrl`+`Shift`+`M` |
@@ -153,6 +156,14 @@ The following shortcuts are always turned off in WebView2.  An asterisk (`*`) in
 | Show Reading Mode Bar `*` | `Shift`+`Alt`+`R` |
 | Show Collections `*` | `Ctrl`+`Shift`+`Y` |
 
+
+### Support for F6 and Shift+F6
+
+`F6` and `Shift`+`F6` are supported in windowed hosting mode, but not in visual hosting mode.  
+
+
+### Shortcuts turned off except when event not handled
+
 The following keyboard shortcuts are always turned off, except in windows that display when the `NewWindowRequested` event isn't handled:
 
 | Action | Windows |
@@ -160,6 +171,9 @@ The following keyboard shortcuts are always turned off, except in windows that d
 | Close Tab | `Ctrl`+`W, Ctrl`+`F4` |
 | Close Window | `Ctrl`+`Shift`+`W` |
 | Fullscreen | `F11` |
+
+
+### Shortcuts turned off if AcceleratorEnabled is False
 
 If you set `AreBrowserAcceleratorKeysEnabled` to `FALSE`, the following additional keyboard shortcuts are turned off:
 
@@ -184,5 +198,7 @@ If you set `AreBrowserAcceleratorKeysEnabled` to `FALSE`, the following addition
 | Open DevTools Console | `Ctrl`+`Shift`+`J` |
 | Open DevTools Inspect | `Ctrl`+`Shift`+`C` |
 
-> [!Note]
-> To customize any of the keys individually, use the [AcceleratorKeyPressed](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.acceleratorkeypressed?view=webview2-dotnet-1.0.774.44&preserve-view=true) event.
+
+### Customizing an individual key
+
+To customize any of the keys individually, use the [AcceleratorKeyPressed](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.acceleratorkeypressed?view=webview2-dotnet-1.0.774.44&preserve-view=true) event.

--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -131,8 +131,8 @@ The following shortcuts are always turned off in WebView2, or are effectively tu
 | Select Tab (1 - 8) | `Ctrl`+`(1-8)` |
 | Show Favorites Bar `*` | `Ctrl`+`Shift`+`B` |
 | Help | `F1` |
-| Focus Next Pane `*` | `F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shift-f6). |
-| Focus Previous Pane `*` | `Shift`+`F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shift-f6). |
+| Focus Next Pane `*` | `F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shiftf6). |
+| Focus Previous Pane `*` | `Shift`+`F6`.  See [Support for F6 and Shift+F6](#support-for-f6-and-shiftf6). |
 | Reading View `*` | `F9` |
 | Focus Menu Bar | `F10` |
 | Show Identity Menu `*` | `Ctrl`+`Shift`+`M` |


### PR DESCRIPTION
**Rendered article section for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/browser-features?branch=pr-en-us-1795#additional-keyboard-shortcuts-information
Find "F6", about the 18th row of the section's table.  Added a note in the F6 & Shift+F6 rows.

**Other changes:**
* Added h3 headings for other tables in that h2 section; those tables needed a skimmable heading/label.
*  Changed the table column 2 heading from "Windows" to "Shortcut", in most tables.

[Before](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/browser-features#additional-keyboard-shortcuts-information)