### PR TITLE
Add WebView2Samples dependency

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -38,7 +38,7 @@
       "branch_mapping": {}
     },
     {
-      "path_to_root": "microsoft-edge/webview2/code/",
+      "path_to_root": "microsoft-edge/webview2/code/sample/",
       "url": "https://github.com/MicrosoftEdge/WebView2Samples",
       "branch": "master",
       "branch_mapping": {}

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -36,6 +36,12 @@
       "url": "https://github.com/Microsoft/templates.docs.msft.pdf",
       "branch": "main",
       "branch_mapping": {}
+    },
+    {
+      "path_to_root": "microsoft-edge/webview2/code/",
+      "url": "https://github.com/MicrosoftEdge/WebView2Samples",
+      "branch": "master",
+      "branch_mapping": {}
     }
   ],
   "branch_target_mapping": {

--- a/microsoft-edge/docfx.json
+++ b/microsoft-edge/docfx.json
@@ -9,6 +9,7 @@
         "exclude": [
           "**/obj/**",
           "microsoft-edge/**",
+          "microsoft-edge/webview2/code/**",
           "**/includes/**"
         ]
       }


### PR DESCRIPTION
Add [WebView2Samples](https://github.com/MicrosoftEdge/WebView2Samples) as dependent_repositories to enable [Cross-repository reference](https://review.docs.microsoft.com/en-us/help/onboard/admin/cross-repository-reference?branch=main#data-structure). Those under `webview2/` can reference WebView2 sample code with such syntax:

```
:::code language="cpp" source="../code/sample/SampleApps/WebView2APISample/ScenarioAuthentication.cpp" range="50-69":::
```

```
:::code language="csharp" source="../code/sample/SampleApps/WebView2WpfBrowser/MainWindow.xaml.cs" id="BasicAuthenticationRequested":::
```