### PR TITLE
Changed text about process handling to call Browser Task Manager

### DIFF
--- a/microsoft-edge/webview2/concepts/process-model.md
+++ b/microsoft-edge/webview2/concepts/process-model.md
@@ -63,7 +63,7 @@ To react to crashes and hangs in the browser and renderer processes, use the `Pr
 
 To safely shut down associated browser and renderer processes, use the `Close` method of `CoreWebView2Controller`.
 
-To open the **Browser Task Manager**, call the appropriate method.
+To open the **Browser Task Manager**, call the `OpenTaskManagerWindow` method.
 
 <!-- ------------------------------ -->
 

--- a/microsoft-edge/webview2/concepts/process-model.md
+++ b/microsoft-edge/webview2/concepts/process-model.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 09/21/2021
+ms.date: 03/29/2022
 ---
 # Process model for WebView2 apps
 <!-- old title: # The WebView2 process model -->
@@ -63,7 +63,7 @@ To react to crashes and hangs in the browser and renderer processes, use the `Pr
 
 To safely shut down associated browser and renderer processes, use the `Close` method of `CoreWebView2Controller`.
 
-To open the **Browser Task Manager** window from the **DevTools** window of a WebView2 instance, right-click the DevTools window title bar, and then select `Browser task manager`.  Or, press `Shift`+`Escape`.
+To open the **Browser Task Manager** call the [OpenTaskManagerWindow](/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow) function.
 
 All processes that are associated with the browser process of your WebView2 are displayed, including their associated purposes.
 

--- a/microsoft-edge/webview2/concepts/process-model.md
+++ b/microsoft-edge/webview2/concepts/process-model.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 03/29/2022
+ms.date: 04/01/2022
 ---
 # Process model for WebView2 apps
 <!-- old title: # The WebView2 process model -->
@@ -63,7 +63,7 @@ To react to crashes and hangs in the browser and renderer processes, use the `Pr
 
 To safely shut down associated browser and renderer processes, use the `Close` method of `CoreWebView2Controller`.
 
-To open the **Browser Task Manager**, call the [OpenTaskManagerWindow](/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow) method.
+To open the **Browser Task Manager**, call the [OpenTaskManagerWindow](/microsoft-edge/webview2/reference/win32/icorewebview2_6#opentaskmanagerwindow) method.
 
 All processes that are associated with the browser process of your WebView2 are displayed, including their associated purposes.
 

--- a/microsoft-edge/webview2/concepts/process-model.md
+++ b/microsoft-edge/webview2/concepts/process-model.md
@@ -63,7 +63,25 @@ To react to crashes and hangs in the browser and renderer processes, use the `Pr
 
 To safely shut down associated browser and renderer processes, use the `Close` method of `CoreWebView2Controller`.
 
-To open the **Browser Task Manager**, call the [OpenTaskManagerWindow](/microsoft-edge/webview2/reference/win32/icorewebview2_6#opentaskmanagerwindow) method.
+To open the **Browser Task Manager**, call the appropriate method.
+
+<!-- ------------------------------ -->
+
+# [C#](#tab/csharp)
+
+[OpenTaskManagerWindow](/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow#microsoft-web-webview2-core-corewebview2-opentaskmanagerwindow)
+
+
+<!-- ------------------------------ -->
+
+# [C++](#tab/cpp)
+
+[OpenTaskManagerWindow](/microsoft-edge/webview2/reference/win32/icorewebview2_6#opentaskmanagerwindow)
+
+
+---
+
+<!-- end of tab-set -->
 
 All processes that are associated with the browser process of your WebView2 are displayed, including their associated purposes.
 

--- a/microsoft-edge/webview2/concepts/process-model.md
+++ b/microsoft-edge/webview2/concepts/process-model.md
@@ -63,7 +63,7 @@ To react to crashes and hangs in the browser and renderer processes, use the `Pr
 
 To safely shut down associated browser and renderer processes, use the `Close` method of `CoreWebView2Controller`.
 
-To open the **Browser Task Manager** call the [OpenTaskManagerWindow](/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow) function.
+To open the **Browser Task Manager**, call the [OpenTaskManagerWindow](/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow) method.
 
 All processes that are associated with the browser process of your WebView2 are displayed, including their associated purposes.
 


### PR DESCRIPTION
Changed text about calling Browser Task Manager.

Preview: [https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model?branch=pr-en-us-1847](https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/process-model?branch=pr-en-us-1847)

To test the new link on line 66, you need to remove the "review." text from the beginning and the trailing "?branch=pr-en-us-1847" leaving [https://docs.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow](https://docs.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow)