### PR TITLE
Fixing broken link in What's New 99

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/whats-new/2022/03/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2022/03/devtools.md
@@ -35,7 +35,7 @@ To try this feature:
 See also:
 *  [Map the processed code to your original source code, for debugging](../../../javascript/source-maps.md)
 *  [Securely debug original code by publishing source maps to the Azure Artifacts symbol server](../../../javascript/publish-source-maps-to-azure.md)
-*  [Securely debug original code by using Azure Artifacts symbol server source maps](/javascript/consume-source-maps-from-azure.md)
+*  [Securely debug original code by using Azure Artifacts symbol server source maps](../../../javascript/consume-source-maps-from-azure.md)
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
This PR updates our What's New 99 doc to fix a broken link in the Symbol Server announcement

Preview: https://review.docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/whats-new/2022/03/devtools?branch=pr-en-us-1852