### PR TITLE
Clarify that WV2 receives the same updates as Microsoft Edge

### DIFF
--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -119,7 +119,7 @@ Before your app creates a WebView2, the app should check whether the WebView2 Ru
 
 The Evergreen distribution mode ensures that your WebView2 app is taking advantage of the latest WebView2 features and security updates.  The Evergreen distribution mode has the following characteristics:
 
-*  The WebView2 Runtime updates automatically without more effort from you. It recevices the same [update](https://docs.microsoft.com/deployedge/microsoft-edge-relnote-stable-channel) and [security patches](https://docs.microsoft.com/deployedge/microsoft-edge-relnotes-security) as Microsoft Edge.
+*  The WebView2 Runtime updates automatically without more effort from you. It recevices the same Microsoft Edge updates described in [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Security Updates](/deployedge/microsoft-edge-relnotes-security).
 
 *  All WebView2 apps that use the Evergreen distribution mode use a shared copy of the Evergreen WebView2 Runtime, which saves disk space.
 

--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -119,7 +119,7 @@ Before your app creates a WebView2, the app should check whether the WebView2 Ru
 
 The Evergreen distribution mode ensures that your WebView2 app is taking advantage of the latest WebView2 features and security updates.  The Evergreen distribution mode has the following characteristics:
 
-*  The WebView2 Runtime updates automatically without more effort from you.
+*  The WebView2 Runtime updates automatically without more effort from you. It recevices the same [update](https://docs.microsoft.com/deployedge/microsoft-edge-relnote-stable-channel) and [security patches](https://docs.microsoft.com/deployedge/microsoft-edge-relnotes-security) as Microsoft Edge.
 
 *  All WebView2 apps that use the Evergreen distribution mode use a shared copy of the Evergreen WebView2 Runtime, which saves disk space.
 

--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -119,7 +119,7 @@ Before your app creates a WebView2, the app should check whether the WebView2 Ru
 
 The Evergreen distribution mode ensures that your WebView2 app is taking advantage of the latest WebView2 features and security updates.  The Evergreen distribution mode has the following characteristics:
 
-*  The WebView2 Runtime updates automatically without more effort from you. It recevices the same Microsoft Edge updates described in [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Security Updates](/deployedge/microsoft-edge-relnotes-security).
+*  The WebView2 Runtime updates automatically without requiring any action from you. It receives the same Microsoft Edge updates that are described in [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Security Updates](/deployedge/microsoft-edge-relnotes-security).
 
 *  All WebView2 apps that use the Evergreen distribution mode use a shared copy of the Evergreen WebView2 Runtime, which saves disk space.
 


### PR DESCRIPTION
Add text and links clarifying that the WebView2 Runtime receives the same updates and security patches as Microsoft Edge.

Preview: [https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution?branch=pr-en-us-1885](https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution?branch=pr-en-us-1885)