### PR TITLE
Fixed a code typo in webpack plugin

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/javascript/publish-source-maps-to-azure.md
+++ b/microsoft-edge/devtools-guide-chromium/javascript/publish-source-maps-to-azure.md
@@ -126,6 +126,7 @@ module.exports = class PrepareSourceMapsForSymbolServerPlugin {
           sourceMapAsset,
         };
       });
+    });
   }
 };
 ```


### PR DESCRIPTION
Fixes #1898.

The code snippet on this page was incorrect. It missed a closing `}` and `)`. So this really small PR just adds them where they need to be.

Direct link to relevant section: https://review.docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/javascript/publish-source-maps-to-azure?branch=pr-en-us-1901#step-2-compute-the-sha-256-hash-of-your-script-and-append-it-to-your-source-maps