### PR TITLE
Adding a few request pattern examples to the Network Request Blocking docs

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/network-request-blocking/network-request-blocking-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/network-request-blocking/network-request-blocking-tool.md
@@ -29,7 +29,18 @@ To block a network request:
 
 1. Click the **Add pattern** (![Add pattern icon.](media/add-pattern-icon.png)) button.  The **Enable network request blocking** checkbox is automatically selected.
 
-1. In the **Text pattern to block network requests** text box, type the URL of a network request that you want to block.  You can either type the full URL, or replace parts of it with `*` for wildcard pattern matching.
+1. In the **Text pattern to block network requests** text box, type the URL of a network request that you want to block.  You can either type the full URL, just the domain name to block all requests from this domain, or replace parts of it with `*` for wildcard pattern matching.
+   
+   For example, `contoso.com` matches URLs like:
+
+   * `https://contoso.com`
+   * `https://subdomain.contoso.com`
+   * `https://subdomain.contoso.com/path/to/resource`
+
+   And `*.png` matches URLs like:
+   
+   * `https://www.contoso.com/resource.png`
+   * `http://third-party.com/6469272/163348534-b90ea1a3-c33cbeb1aed8.png`
 
 1. Click the **Add** button:
 


### PR DESCRIPTION
The Network Request blocking docs: https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/network-request-blocking/network-request-blocking-tool are not very thorough when it comes to explaining how patterns are actually matched.

This PR hopefully makes it clearer how users can use domain names or patterns to block whole classes of URLs without having to list them all one by one.

This fixes #1899, at least the first part of it.