### PR TITLE
Fixed punctuation in "Add-ons store developer policies"

### DIFF
--- a/microsoft-edge/extensions-chromium/store-policies/developer-policies.md
+++ b/microsoft-edge/extensions-chromium/store-policies/developer-policies.md
@@ -24,7 +24,9 @@ The _Microsoft Edge Add-ons store_ is also called the _Microsoft Edge Add-ons we
 A few principles to get you started:
 
 *   You should offer unique and distinct value within your extensions for Microsoft Edge.  Provide a compelling reason to download your extensions from the Microsoft Edge Add-ons store (Microsoft Edge Add-ons).
+
 *   You must not mislead our joint users about what your extension does, who is offering it, and so on.
+
 *   You must not attempt to cheat users, the system or the ecosystem.  There is no place in our Microsoft Edge Add-ons for any kind of fraud; be it ratings and review manipulation, credit card fraud or other fraudulent activity.
 
 Adhering to the Microsoft Edge Add-ons store developer policies should help you make choices that enhance the appeal and audience of your extension.
@@ -81,8 +83,7 @@ Your extension must not jeopardize or compromise user security, or the security 
 
 #### 1.2.1 Content Security Policies
 
-> [!NOTE]
-> If you make any changes to your extension beyond the described functionality, any changes to code must be compliant with the [Microsoft Edge content security policy](csp.md#relaxing-the-default-policy).  For example, your extension should not download a remote script and subsequently run that script in a manner that is not consistent with the described functionality.
+If you make any changes to your extension beyond the described functionality, any changes to code must be compliant with the [Microsoft Edge content security policy](csp.md#relaxing-the-default-policy).  For example, your extension should not download a remote script and subsequently run that script in a manner that is not consistent with the described functionality.
 
 #### 1.2.2 Unwanted and Malicious Software
 
@@ -90,7 +91,7 @@ Your extension must not contain or enable malware as defined by the Microsoft cr
 
 #### 1.2.3 Dependency on other software
 
-Your extension may depend on non-integrated software (such as another product, module, or service) to deliver the primary functionality, provided you disclose the dependency in the description
+Your extension may depend on non-integrated software (such as another product, module, or service) to deliver the primary functionality, provided you disclose the dependency in the description.
 
 #### 1.2.4 Extensions Update
 
@@ -130,7 +131,9 @@ Your extension may collect, access, use, or transmit Personal Information (inclu
 
 #### 1.5.2 Maintain a privacy policy
 
-Regardless of whether your extension accesses, collects, or transmits Personal Information; you must provide prominent notice of and comply with your privacy policy if required by law.  Your privacy policy must inform users of the Personal Information accessed, collected, or transmitted by your extension, how that information is used, stored, and secured, and indicate the types of parties to whom it is disclosed.  Your privacy policy must describe the controls that users have over the use and sharing of their information, how they access their information, and it must comply with applicable laws and regulations.  Your privacy policy must be kept up-to-date as you add new features and functionality to your extension.
+Regardless of whether your extension accesses, collects, or transmits Personal Information; you must provide prominent notice of and comply with your privacy policy if required by law.  Your privacy policy must inform users of the Personal Information accessed, collected, or transmitted by your extension, how that information is used, stored, and secured, and indicate the types of parties to whom it is disclosed.
+
+Your privacy policy must describe the controls that users have over the use and sharing of their information, how they access their information, and it must comply with applicable laws and regulations.  Your privacy policy must be kept up-to-date as you add new features and functionality to your extension.
 
 If you provide Microsoft with your privacy policy, you agree to permit Microsoft to share such privacy policy with users of your extension.
 
@@ -138,17 +141,22 @@ If you provide Microsoft with your privacy policy, you agree to permit Microsoft
 
 You may publish the Personal Information of users of your extension to an outside service or third-party through your extension or associated metadata only after obtaining opt-in consent from those users.  Opt-in consent means the users give their express permission in the user interface of your extension for the requested activity, after you:
 
-*   Describe to your users how the information is accessed, used or shared and indicate the types of parties to whom it is disclosed, and
+*   Describe to your users how the information is accessed, used or shared and indicate the types of parties to whom it is disclosed.
+
 *   Provide your users a mechanism in your extension user interface through which they have the option to later rescind the permission and opt-out.
 
 #### 1.5.4 Sharing information of non-Users
 
-If you publish a person's Personal Information to an outside service or third-party through your extension or the metadata, but the person whose information is being shared is not a user of your extension;
+If you publish a person's Personal Information to an outside service or third-party through your extension or the metadata, but the person whose information is being shared is not a user of your extension:
 
 1.  You must obtain express written consent to publish that Personal Information.
+
 1.  You must permit the person whose information is shared to withdraw that consent at any time.
+
 1.  Your privacy policy must clearly disclose that you may collect personal information in this manner.
+
 1.  If required by applicable law you must delete the Personal Information of any individual upon request, including individuals whose information you collect in this manner.
+
 1.  If your extension provides users with access to another person's Personal Information, this requirement also applies.
 
 #### 1.5.5 Transmit information securely
@@ -166,6 +174,7 @@ Your extension must only request those permissions that are necessary for functi
 ### 1.7 Localization
 
 You should localize your extension for all languages that your extension claims to support.  The text of the description of your extension should be localized in each language that you declare.
+
 If your extension is localized such that some features aren't available in a localized version, you must clearly state or display the limits of localization in your extension description. The experience provided by an Extension must be reasonably similar in all languages that it supports.
 
 ### 1.8 Financial Transactions
@@ -179,18 +188,24 @@ Your extension may enable users to consume digital content or services purchased
 You must use a secure third-party purchase API for purchases of physical goods or services.  You must use a secure third-party purchase API for payments made in connection with any other services including real world gambling or charitable contributions.
 
 *   If your extension is used to facilitate or collect charitable contributions or to conduct a promotional sweepstakes or contest, you must do so in compliance with applicable law.
+
 *   You must also state clearly that Microsoft is not the fundraiser or sponsor of the promotion.
+
 *   In-product offerings sold in your extension must not be converted to any legally valid currency (such as USD, Euro, and so on) or any physical goods or services.
 
 The following requirements apply to your use of a secure third-party purchase API:
 
 *   At the time of the transaction or when you collect any payment or financial information from the user; your extension must identify the commerce transaction provider, authenticate the user, and obtain user confirmation for the transaction.  A commerce transaction provider maintains a secure platform for financial exchanges.
+
 *   Your extension may offer users the ability to save this authentication, but users must have the ability to either require an authentication on every transaction or to turn off in-product transactions.
+
 *   If your extension collects credit card information or uses a third-party payment processor that collects credit card information, the payment processing must meet the current PCI Data Security Standard (PCI DSS).
 
 #### 1.8.2 Disclosing paid features
 
-Your extension and associated metadata must provide information about the types of in-product purchases offered and the range of prices.  You must not mislead users and must be clear about the nature of your in-product promotions and offerings including the scope and terms of any trial experiences.  If your extension restricts access to user-created content during or after a trial, you must notify users in advance.  In addition, your extension must make it clear to users that they are initiating a purchase option in your extension.
+Your extension and associated metadata must provide information about the types of in-product purchases offered and the range of prices.  You must not mislead users and must be clear about the nature of your in-product promotions and offerings including the scope and terms of any trial experiences.
+
+If your extension restricts access to user-created content during or after a trial, you must notify users in advance.  In addition, your extension must make it clear to users that they are initiating a purchase option in your extension.
 
 ### 1.9 Notifications
 
@@ -225,11 +240,13 @@ The primary content of your extension must not be advertising, and advertising m
 #### 1.10.2 Policies and Agreements
 
 Any advertising content your extension displays must adhere to [Microsoft Creative Acceptance Policy](https://about.ads.microsoft.com/solutions/ad-products/display-advertising/creative-acceptance-policies).
+
 If your extension displays ads, all content displayed must conform to the advertising requirements of the [App Developer Agreement](/legal/windows/agreements/app-developer-agreement) and this Policy.
 
 #### 1.10.3 Quality of advertising
 
 *   The primary purpose of your extension must not be to get users to click ads.
+
 *   Your extension must not do anything that interferes with or diminishes the visibility, value, or quality of any ads that it does display.
 
 #### 1.10.4 Promotions
@@ -248,9 +265,11 @@ If your extension is directed at children under the age of 13, as defined in the
 <!-- ====================================================================== -->
 ## 2 Content Policies
 
-The following policies apply to content and metadata (including publisher name, extension name, extension icon, extension description, extension screenshots, extension trailers and trailer thumbnails, and any other extension metadata) offered for distribution in Microsoft Edge Add-ons.  Content means the images, sounds, videos and text contained in your extension, the tiles, notifications, error messages or ads exposed through your extension, and anything delivered from a server or to which your extension connects.  Because extensions and Microsoft Edge Add-ons are used around the world, these requirements are interpreted and applied in the context of regional and cultural norms.
+The following policies apply to content and metadata (including publisher name, extension name, extension icon, extension description, extension screenshots, extension trailers and trailer thumbnails, and any other extension metadata) offered for distribution in Microsoft Edge Add-ons.  _Content_ means the images, sounds, videos and text contained in your extension, the tiles, notifications, error messages or ads exposed through your extension, and anything delivered from a server or to which your extension connects.
 
-### 2.1 Content Requirements for Microsoft Edge Addon Catalog Listing
+Because extensions and Microsoft Edge Add-ons are used around the world, these requirements are interpreted and applied in the context of regional and cultural norms.
+
+### 2.1 Content Requirements for Microsoft Edge Add-on Catalog Listing
 
 Metadata and other content you submit to accompany your extension may not contain mature content.  Submissions that don't meet Microsoft Edge Add-ons store listings requirements are rejected or promptly removed.
 
@@ -266,7 +285,9 @@ Your extension must not contain any content that facilitates or glamorizes the f
 
 #### 2.3.2 Responsibility
 
-Your extension must not: (a) pose a safety risk to, nor result in discomfort, injury or any other harm to end users or to any other person or animal; or (b) pose a risk of or result in damage to real or personal property.  You are solely responsible for all extension safety testing, certificate acquisition, and implementation of any appropriate feature safeguards.  You must not disable any platform safety or comfort features and you must include all applicable legally required and industry-standard warnings, notices, and disclaimers in your extension.
+Your extension must not: (a) pose a safety risk to, nor result in discomfort, injury or any other harm to end users or to any other person or animal; or (b) pose a risk of or result in damage to real or personal property.  You are solely responsible for all extension safety testing, certificate acquisition, and implementation of any appropriate feature safeguards.
+
+You must not disable any platform safety or comfort features and you must include all applicable legally required and industry-standard warnings, notices, and disclaimers in your extension.
 
 ### 2.4 Defamatory, Libelous, Slanderous, and Threatening
 
@@ -289,8 +310,11 @@ Your extension must not contain or display content that a reasonable person woul
 Your extension must adhere to the following conditions.
 
 *   Your extension must not contain content or provide services that facilitate online gambling.  Online gambling includes but is not limited to online casinos, sports betting, lotteries, or games of skill that offer prizes of cash or other value.
+
 *   Your extension must not provide unauthorized access to website content, such as by circumventing paywalls or login restrictions.
+
 *   Your extension must not provide, encourage, or enable the unauthorized access, download, or streaming of copyrighted content or media.
+
 *   Your extension must not mine cryptocurrency.
 
 ### 2.9 Illegal Activity
@@ -300,6 +324,7 @@ Your extension must not contain content or functionality that encourages, facili
 ### 2.10 Excessive Profanity and Inappropriate Content
 
 *   Your extension must not contain excessive or gratuitous profanity.
+
 *   Your extension must not contain or display content that a reasonable person considers obscene.
 
 ### 2.11 Country/Region Specific Requirements
@@ -308,15 +333,17 @@ Content that is offensive in any country/region to which your extension is targe
 
 **China**
 
-*   Prohibited sexual content
-*   Disputed territory or region references
-*   Providing or enabling access to content or services that are illegal under applicable local law
+*   Prohibited sexual content.
+*   Disputed territory or region references.
+*   Providing or enabling access to content or services that are illegal under applicable local law.
 
 ### 2.12 Age Ratings
 
 #### 2.12.1 Mature Content
 
-When you submit your extension to [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd), you must indicate whether your extension displays content that should be marked "Mature".  When determining the rating for your extension, consider all the content in your app, including user generated content and ads, and to the content that your extension links.  If you indicate that your extension doesn't contain any "Mature" content, you are responsible for maintaining the accuracy of this rating.  Regardless of the rating given to your extension, it must still adhere to all the content requirements of Microsoft Edge Add-ons Developer policies
+When you submit your extension to [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd), you must indicate whether your extension displays content that should be marked "Mature".  When determining the rating for your extension, consider all the content in your app, including user generated content and ads, and to the content that your extension links.  If you indicate that your extension doesn't contain any "Mature" content, you are responsible for maintaining the accuracy of this rating.
+
+Regardless of the rating given to your extension, it must still adhere to all the content requirements of Microsoft Edge Add-ons Developer policies.
 
 #### 2.12.2 Ratings Change
 


### PR DESCRIPTION
- Added missing period at end of [1.2.3](https://review.docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/store-policies/developer-policies?branch=pr-en-us-1937#123-dependency-on-other-software) & [2.12.1](https://review.docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/store-policies/developer-policies?branch=pr-en-us-1937#2121-mature-content)
- Hyphenate Addons
- Break up paragraphs
- Space out lists

after: 
https://review.docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/store-policies/developer-policies?branch=pr-en-us-1937

before:
https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/store-policies/developer-policies