### PR TITLE
Redesigned firstchild page "VS Code for web dev" as nav page

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/sources/opening-sources-in-vscode.md
+++ b/microsoft-edge/devtools-guide-chromium/sources/opening-sources-in-vscode.md
@@ -9,9 +9,10 @@ ms.date: 09/22/2021
 ---
 # Opening source files in Visual Studio Code
 
-The `Open source files in Visual Studio Code` experiment allows you to use Microsoft Edge DevTools but then edit your files in Visual Studio Code instead of in the code editor of the DevTools Sources tool.
+The **Open source files in Visual Studio Code** experiment allows you to use Microsoft Edge DevTools, but then edit your files in Visual Studio Code instead of in the code editor of the DevTools **Sources** tool.
 
-If you use Visual Studio Code and you use DevTools to change your CSS rules, it seems strange that instead of using the code editor in Visual Studio Code, you have to use the code editor in the Sources tool of DevTools.  With this experiment, we want to change this.  This is why we added a new experiment to the Developer Tools.  When you turn on the **Open source files in Visual Studio Code** experiment, local files will get a different treatment.
+When you use this experiment, if you use Visual Studio Code and you use DevTools to change your CSS rules, you no longer have to use the code editor in the Sources tool of DevTools.  You can simply use the code editor in Visual Studio Code.  When you turn on this experiment,
+local files will get a different treatment.<!--TODO: be specific-->
 
 
 <!-- ====================================================================== -->
@@ -21,31 +22,31 @@ First, select DevTools > **Settings** > **Experiments** > **Open source files in
 
 With this experiment enabled, suppose that in Microsoft Edge, you go to a local server (such as `http://localhost` or `http://127.0.0.1`), or open a local file.
 
-:::image type="content" source="../media/experiment-sources-in-code-local-project.msft..png" alt-text="Microsoft Edge with a local file open." lightbox="../media/experiment-sources-in-code-local-project.msft..png":::
+![Microsoft Edge with a local file open.](../media/experiment-sources-in-code-local-project.msft..png)
 
 When you open DevTools, you are prompted to identify your root folder.  You can opt out by selecting **Close** (`x`) or selecting the `Don't show again` button.  You can get more information by selecting the `Learn more` link.
 
-:::image type="content" source="../media/experiment-sources-in-code-identify-root-folder.msft.png" alt-text="Developer Tools showing an information bar asking you to identify your root folder." lightbox="../media/experiment-sources-in-code-identify-root-folder.msft.png":::
+![Developer Tools showing an information bar asking you to identify your root folder.](../media/experiment-sources-in-code-identify-root-folder.msft.png)
 
 If you select the **Set root folder** button, the operating system prompts you to navigate to the folder and select it.
 
-:::image type="content" source="../media/experiment-sources-in-code-pick-folder.msft.png" alt-text="Picking the location of the root folder using the file manager of your operating system." lightbox="../media/experiment-sources-in-code-pick-folder.msft.png":::
+![Picking the location of the root folder using the file manager of your operating system.](../media/experiment-sources-in-code-pick-folder.msft.png)
 
 After you select a root folder, you need to grant DevTools full access to the folder.  Above the toolbar, a prompt with **Allow** or **Deny** buttons asks you whether to grant permission to DevTools to access the folder.
 
-:::image type="content" source="../media/experiment-sources-in-code-allow-access.msft.png" alt-text="DevTools asking to get access to the folder." lightbox="../media/experiment-sources-in-code-allow-access.msft.png":::
+![DevTools asking to get access to the folder.](../media/experiment-sources-in-code-allow-access.msft.png)
 
 After you grant permission, the folder you select is added as a Workspace in DevTools, in the **Filesystem** tab of the **Sources** tool.  This means that any file you edit in DevTools now opens in Microsoft Visual Studio Code instead of in the Sources tool. As an indicator, we show a `linked` icon next to the file name.  In this example, we'll select the `base.css` link in the **Styles** tool.
 
-:::image type="content" source="../media/experiment-sources-in-code-selecting-link.msft.png" alt-text="Selecting a file link in the Styles tool opens the file in Visual Studio Code." lightbox="../media/experiment-sources-in-code-selecting-link.msft.png":::
+![Selecting a file link in the Styles tool opens the file in Visual Studio Code.](../media/experiment-sources-in-code-selecting-link.msft.png)
 
 DevTools opens an instance of Visual Studio Code and shows all the files in the root folder.  DevTools also opens the file you've selected, scrolled to the correct line of the CSS selector.
 
-:::image type="content" source="../media/experiment-sources-in-code-editor-open.msft.png" alt-text="Visual Studio Code open with the root folder files and the selected file open." lightbox="../media/experiment-sources-in-code-editor-open.msft.png":::
+![Visual Studio Code open with the root folder files and the selected file open.](../media/experiment-sources-in-code-editor-open.msft.png)
 
 Any changes that you make to the file in DevTools will now be synced to Visual Studio Code.  For example, if you add a `background: green` rule to the styles of the body, the same CSS rule will automatically be added to the `base.css` file in the code editor of Visual Studio Code.
 
-:::image type="content" source="../media/experiment-sources-in-code-code-synced.msft.png" alt-text="Changes to the code in the Styles tool now are reflected in the source code in Visual Studio Code." lightbox="../media/experiment-sources-in-code-code-synced.msft.png":::
+![Changes to the code in the Styles tool now are reflected in the source code in Visual Studio Code.](../media/experiment-sources-in-code-code-synced.msft.png)
 
 
 <!-- ====================================================================== -->
@@ -53,7 +54,7 @@ Any changes that you make to the file in DevTools will now be synced to Visual S
 
 If you go to the DevTools **Settings** page by selecting **Settings** (the gear icon or `Shift + ?`), you can change the behavior of the experiment.  When you select the **Workspace** page in **Settings**, you have a few options.
 
-:::image type="content" source="../media/experiment-sources-in-code-workspace-settings.msft.png" alt-text="The settings pane of the workspace showing several options." lightbox="../media/experiment-sources-in-code-workspace-settings.msft.png":::
+![The settings pane of the workspace showing several options.](../media/experiment-sources-in-code-workspace-settings.msft.png)
 
 The **Settings** > **Workspace** page lists your workspaces, along with configuration options.
 

--- a/microsoft-edge/visual-studio-code/index.md
+++ b/microsoft-edge/visual-studio-code/index.md
@@ -60,11 +60,12 @@ Use webhint, a customizable linting tool, to improve the functionality of your s
 *   PWA compatibility.
 *   Security.
 
-webhint checks your code for best practices and common errors.  Identify and fix problems in your files, including HTML, CSS, JavaScript, and TypeScript.  Hints appear as wavy underlines in the text editor, and are summarized in the **Problems** pane:
+webhint checks your code for best practices and common errors.  Identify and fix problems in your files, including HTML, CSS, JavaScript, and TypeScript.  Hints appear as wavy underlines in the text editor, and are summarized in the **Problems** pane.
 
-![The webhint extension for Visual Studio Code.](media/webhint-extension.png)
+<!-- todo: don't have png files in this nav page.  delete png (only used here) -->
+<!-- ![The webhint extension for Visual Studio Code.](media/webhint-extension.png) -->
 
-See [The webhint extension for Visual Studio Code](webhint.md).
+Instead of webhint, see [Microsoft Edge DevTools extension for Visual Studio Code](microsoft-edge-devtools-extension.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/visual-studio-code/index.md
+++ b/microsoft-edge/visual-studio-code/index.md
@@ -5,42 +5,50 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
-ms.date: 08/24/2021
+ms.date: 05/19/2022
 ---
 # Visual Studio Code for web development
 
 Visual Studio Code includes built-in support for JavaScript, TypeScript, and Node.js, so it's a great tool for web developers.  Visual Studio Code is a lightweight but powerful source code editor that's available for Windows, Linux, and macOS.
 
-This article gives an overview of extensions for Visual Studio Code that add features for users of Microsoft Edge DevTools.
-
 
 <!-- ====================================================================== -->
 ## Microsoft Edge DevTools extension for Visual Studio Code
 
-With the **Microsoft Edge DevTools** extension for Visual Studio Code, you can use the **Elements** tool of the Microsoft Edge browser within Visual Studio Code.  Use the Elements tool to:
-*   Attach to an instance or launch an instance of Microsoft Edge.
-*   Display the runtime HTML structure.
-*   Update the layout.
-*   Fix styling issues.
+The Microsoft Edge DevTools extension for Visual Studio Code lets you use the **Elements** tool and **Network** tool of the Microsoft Edge browser from within Visual Studio Code.
 
-![The Microsoft Edge DevTools extension for Visual Studio Code.](media/microsoft-edge-tools-for-visual-studio-code.png)
+Without leaving Visual Studio Code, use Microsoft Edge DevTools to connect to an instance of Microsoft Edge and then:
+* View the runtime HTML structure.
+* Change the layout.
+* Change styles (CSS).
+* Read console messages.
+* View network requests.
 
-The Visual Studio Marketplace provides more information about [Microsoft Edge Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools).
-
-To use the extension, see [Microsoft Edge DevTools extension for Visual Studio Code](microsoft-edge-devtools-extension.md).
-
-
-### Installing the extension
-
-To install the Microsoft Edge DevTools extension:
-
-1. In Visual Studio Code, navigate to **Extensions**.  To do this, you can press `Ctrl`+`Shift`+`X` on Windows/Linux or `Command`+`Shift`+`X` on macOS.
-
-1. Search the Marketplace for the extension **Microsoft Edge Tools for VS Code**, select the extension, and then select **Install**.
-
-![Installing the Microsoft Edge DevTools extension for Visual Studio Code.](media/vscode-edge-tools-install.png)
+See [Microsoft Edge DevTools extension for Visual Studio Code](microsoft-edge-devtools-extension.md).
 
 
+<!-- ====================================================================== -->
+## Open source files in Visual Studio Code
+
+The **Open source files in Visual Studio Code** experiment allows you to use Microsoft Edge DevTools, but then edit your files in Visual Studio Code instead of in the code editor of the DevTools **Sources** tool.
+
+When you use this experiment, if you use Visual Studio Code and you use DevTools to change your CSS rules, you no longer have to use the code editor in the Sources tool of DevTools.  You can simply use the code editor in Visual Studio Code.  When you turn on this experiment,
+local files will get a different treatment.<!--TODO: be specific-->
+
+See [Opening source files in Visual Studio Code](../devtools-guide-chromium/sources/opening-sources-in-vscode.md).
+
+
+<!-- ====================================================================== -->
+## Debug Microsoft Edge in Visual Studio Code
+
+[Visual Studio Code](https://code.visualstudio.com) includes a built-in debugger for Microsoft Edge, which can launch the browser or attach to an already running browser.
+
+This built-in debugger lets you debug your front-end JavaScript code line-by-line and see `console.log()` statements directly from Visual Studio Code.
+
+See [Debug Microsoft Edge in Visual Studio Code](debugger-for-edge.md).
+
+
+<!-- what to do with this section?  present page is supposed to have h2 for each child page of TOC node, where h2 contains only 1 paragraph and link to child page -->
 <!-- ====================================================================== -->
 ## The webhint extension for Visual Studio Code
 

--- a/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension.md
+++ b/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
-ms.date: 04/29/2022
+ms.date: 05/19/2022
 ---
 # Microsoft Edge DevTools extension for Visual Studio Code
 
@@ -14,15 +14,24 @@ Microsoft Edge DevTools extension for Visual Studio Code
 Microsoft Edge DevTools extension
 -->
 
-The Microsoft Edge DevTools extension for Visual Studio Code lets you use the browser's **Elements** tool and **Network** tool from within Visual Studio Code.  Without leaving Visual Studio Code, use Microsoft Edge DevTools to connect to an instance of Microsoft Edge with the following functionality:
+The Microsoft Edge DevTools extension for Visual Studio Code lets you use the **Elements** tool and **Network** tool of the Microsoft Edge browser from within Visual Studio Code.
+
+Without leaving Visual Studio Code, use Microsoft Edge DevTools to connect to an instance of Microsoft Edge and then:
 * View the runtime HTML structure.
 * Change the layout.
 * Change styles (CSS).
 * Read console messages.
 * View network requests.
 
-> [!NOTE]
-> The Microsoft Edge DevTools extension requires Microsoft Edge.  This extension is supported in Microsoft Edge versions 80.0.361.48 and later.
+For example, use the **Elements** tool to:
+*   Attach to an instance or launch an instance of Microsoft Edge.
+*   Display the runtime HTML structure.
+*   Update the layout.
+*   Fix styling issues.
+
+![The Microsoft Edge DevTools extension for Visual Studio Code.](media/microsoft-edge-tools-for-visual-studio-code.png)
+
+The Microsoft Edge DevTools extension requires Microsoft Edge.  This extension is supported in Microsoft Edge versions 80.0.361.48 and later.
 
 In Visual Studio Code, there are multiple ways to open the Microsoft Edge DevTools extension:
 * From the **Activity Bar**.
@@ -36,13 +45,23 @@ In Visual Studio Code, this extension is referred to by several variations:
 
 This article uses the name "the Microsoft Edge DevTools extension", except for UI text.
 
+The Visual Studio Marketplace provides more information about [Microsoft Edge Tools for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools).
+
 
 <!-- ====================================================================== -->
 ## Installing the Microsoft Edge DevTools extension
 
-To install the extension from within Visual Studio Code, see [The Microsoft Edge DevTools extension for Visual Studio Code](index.md#microsoft-edge-devtools-extension-for-visual-studio-code) in _Visual Studio Code for web development_.
+To install the Microsoft Edge DevTools extension from within Visual Studio Code:
 
-Or, you can [download the Microsoft Edge DevTools extension](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools) from Visual Studio Marketplace.  You can view the [source code](https://github.com/microsoft/vscode-edge-devtools) at GitHub.
+1. In Visual Studio Code, navigate to **Extensions**.  To do this, you can press `Ctrl`+`Shift`+`X` on Windows/Linux or `Command`+`Shift`+`X` on macOS.
+
+1. Search the Marketplace for the extension **Microsoft Edge Tools for VS Code**, select the extension, and then select **Install**.
+
+  ![Installing the Microsoft Edge DevTools extension for Visual Studio Code.](media/vscode-edge-tools-install.png)
+
+
+Or, you can [download the Microsoft Edge DevTools extension](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools) from Visual Studio Marketplace.
+
 
 ### Updating the extension
 
@@ -269,6 +288,7 @@ The visual deficiencies emulation button lets you test your product in a blurred
 
 ![Browser preview in the extension showing the web product in a blurred emulation](media/edge-for-code-blurred.msft.png)
 
+
 <!-- ====================================================================== -->
 ## Inline and live issue analysis
 
@@ -388,3 +408,9 @@ As of April 20, 2022, to make the **Console** tool visible, target the Canary ve
 Send your feedback by [filing an issue](https://github.com/Microsoft/vscode-edge-devtools/issues/new) in the `vscode-edge-devtools` repo.
 
 Your contributions are welcome, to help make the Microsoft Edge DevTools extension better.  Find everything you need to get started in the [vscode-edge-devtools](https://github.com/Microsoft/vscode-edge-devtools) repo.
+
+
+<!-- ====================================================================== -->
+## See also
+
+*  [vscode-edge-devtools repo](https://github.com/microsoft/vscode-edge-devtools) - source code for the Microsoft Edge Developer Tools extension for Visual Studio Code, at GitHub.


### PR DESCRIPTION
**Rendered page for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/visual-studio-code/?branch=pr-en-us-1954

Changes made:
* Moved Installation details into main page for the extension; merged into the Install section that was already there.
* Marked webhint h2 for consideration; reduced it.  There's shouldn't be an h2 for it, since there's no child page for it.
* Added h2 sections for each child article that's in this TOC bucket.  Only a paragraph (sync'd/bubbled up) and a link, each.
* Retagged images from markup to Markdown.