### PR TITLE
Fixed 2 small errors in extension tutorial part 2

### DIFF
--- a/microsoft-edge/extensions-chromium/getting-started/part2-content-scripts.md
+++ b/microsoft-edge/extensions-chromium/getting-started/part2-content-scripts.md
@@ -167,7 +167,7 @@ The updated `manifest.json` that includes the `content-scripts` and `web_accessi
 }
 ```
 
-The section you added is `content_scripts`.  The `matches` attribute is set to `<all_urls>`, which means that all files in `content_scripts` are injected into all browser tab pages when each tab is loaded.  The allowed files types that can be injected are JavaScript and CSS.  You also added `libjquery.min.js`.  You're able to include that from the download mentioned at the top of the section.
+The section you added is `content_scripts`.  The `matches` attribute is set to `<all_urls>`, which means that all files in `content_scripts` are injected into all browser tab pages when each tab is loaded.  The allowed files types that can be injected are JavaScript and CSS.  You also added `lib\jquery.min.js`.  You're able to include that from the download mentioned at the top of the section.
 
 6. Add jQuery and understanding the associated thread
 
@@ -206,8 +206,8 @@ The first parameter of the `addListener` method is a function whose first parame
 
 When an event is processed by the listener, the function that is the first parameter is run.  The first parameter of that function is an object that has attributes as assigned by `sendMessage`.  That function simply processes the three jQuery script lines.
 
-*   The first script line dynamically inserts into the DOM header a **\<style\>** section that you must assign as a `slide-image` class to your `img` element.
-*   The second script line appends an `img` element right below the `body` of your browser tab that has the `slide-image` class assigned as well as the `imageDivId` as the ID of that image element.
+*   The first script line appends an `img` element right below the `body` of your browser tab that has the `slide-image` class assigned as well as the `imageDivId` as the ID of that image element.
+*   The second script line dynamically inserts into the DOM header a **\<style\>** section that you must assign as a `slide-image` class to your `img` element.
 *   The third script line adds a `click` event that covers the entire image allowing the user to select anywhere on the image and that image is removed from the page (along with it is event listener).
 
 8. Add functionality to remove the displayed image when selected


### PR DESCRIPTION
This fixes 2 small mistakes in the extensions tutorial part 2 and fixes #1949.

1. We were missing a `\` character in a file path.
2. The order in which the documentation of each script line was incorrect. I switched 1 and 2.