### PR TITLE
Remove en-us from developer.microsoft.com/microsoft-edge links after testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repo, `edge-developer`, is the repository for the source Markdown files for
 
 If you want to include new coverage or have feedback, consider [contributing](CONTRIBUTING.md).  You can edit the existing content, add new content, or report new [issues](https://github.com/MicrosoftDocs/edge-developer/issues).  The Microsoft Edge team reviews a look at your suggestions and works to incorporate the suggestions into the docs.
 
-For the latest implementation status and future plans for web platform features in Microsoft Edge, see [Microsoft Edge Platform Status](https://developer.microsoft.com/en-us/microsoft-edge/status).<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> For the data that's used to populate the above status site, see [https://github.com/MicrosoftEdge/Status](https://github.com/MicrosoftEdge/Status).
+For the latest implementation status and future plans for web platform features in Microsoft Edge, see [Microsoft Edge Platform Status](https://developer.microsoft.com/microsoft-edge/status). For the data that's used to populate the above status site, see [https://github.com/MicrosoftEdge/Status](https://github.com/MicrosoftEdge/Status).
 
 
 ### File names and directories

--- a/microsoft-edge/accessibility/build/index.md
+++ b/microsoft-edge/accessibility/build/index.md
@@ -94,7 +94,7 @@ Most devices include assistive technology that is built-in to the OS.  Microsoft
 
 ### Testing in virtual machines and emulators
 
-Under macOS, if you want to test with an assistive technology only available for Windows, like Windows Narrator or NVDA, create a Windows virtual machine.  Virtual machines with Microsoft Edge (EdgeHTML) and IE are available for VirtualBox and VMWare on the [Virtual Machines download page](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+Under macOS, if you want to test with an assistive technology only available for Windows, like Windows Narrator or NVDA, create a Windows virtual machine.  Virtual machines with Microsoft Edge (EdgeHTML) and IE are available for VirtualBox and VMWare on the [Virtual Machines download page](https://developer.microsoft.com/microsoft-edge/tools/vms).
 
 [Android Studio](https://developer.android.com/sdk/installing/studio.html) includes an emulator that for you to test assistive technologies in the [Android Accessibility Suite](https://play.google.com/store/apps/details?id=com.google.android.marvin.talkback).  Follow the instructions to [set up a virtual device](https://developer.android.com/tools/devices/managing-avds.html) and [start the emulator](https://developer.android.com/tools/devices/emulator.html), then install [Android Accessibility Suite](https://play.google.com/store/apps/details?id=com.google.android.marvin.talkback) from the GooglePlay store.
 
@@ -207,7 +207,7 @@ A list of quick web development tips for accessibility by [The A11Y Project](htt
 
 ### Site Scan
 
-The Site Scan tool on Microsoft Edge Dev Center checks for out-of-date libraries, layout issues, and accessibility issues.  For more information, go to [Site Scan](https://developer.microsoft.com/en-us/microsoft-edge/tools).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+The Site Scan tool on Microsoft Edge Dev Center checks for out-of-date libraries, layout issues, and accessibility issues.  For more information, go to [Site Scan](https://developer.microsoft.com/microsoft-edge/tools).
 
 ### Techniques for WCAG 2.0
 

--- a/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
+++ b/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
@@ -110,7 +110,7 @@ When you are done, learn how to work with the simulator through [Apple Developer
 
 :::image type="content" source="../media/device-mode-modern-ie-vm.msft.png" alt-text="modern.IE VM." lightbox="../media/device-mode-modern-ie-vm.msft.png":::
 
-Microsoft Edge (EdgeHTML) Virtual Machines (VMs) enable you to access different versions of EdgeHTML and Internet Explorer on your computer through VirtualBox (or VMWare).  Select a [virtual machine on the download page](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+Microsoft Edge (EdgeHTML) Virtual Machines (VMs) enable you to access different versions of EdgeHTML and Internet Explorer on your computer through VirtualBox (or VMWare).  Select a [virtual machine on the download page](https://developer.microsoft.com/microsoft-edge/tools/vms).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2020/11/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2020/11/devtools.md
@@ -34,7 +34,7 @@ ms.date: 05/04/2021
 
 Microsoft Edge Dev is now supported on Ubuntu, Debian, Fedora, and openSUSE distributions.  Download and install the Microsoft Edge Dev `.deb` or `.rpm` package directly from the [Microsoft Edge Insider site](https://www.microsoftedgeinsider.com/download?platform=linux) or use the standard package management tools of your Linux distribution.
 
-If you are using a Linux environment in your continuous integration and delivery (CI/CD) solutions, Microsoft Edge WebDriver is also available on Linux.  To get started automating Microsoft Edge with Microsoft Edge WebDriver, see [Microsoft Edge WebDriver Downloads page](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver#downloads).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->  For help with automating Microsoft Edge with Microsoft Edge WebDriver, see [Use WebDriver for test automation](../../../../webdriver-chromium/index.md).
+If you are using a Linux environment in your continuous integration and delivery (CI/CD) solutions, Microsoft Edge WebDriver is also available on Linux.  To get started automating Microsoft Edge with Microsoft Edge WebDriver, see [Recent versions](https://developer.microsoft.com/microsoft-edge/tools/webdriver#downloads) at the Microsoft Edge WebDriver page.  For help with automating Microsoft Edge with Microsoft Edge WebDriver, see [Use WebDriver for test automation](../../../../webdriver-chromium/index.md).
 
 ![DevTools in Microsoft Edge on Linux.](../../media/2020/11/edge-on-linux.msft.png)
 

--- a/microsoft-edge/extensions-chromium/index.md
+++ b/microsoft-edge/extensions-chromium/index.md
@@ -33,12 +33,12 @@ Some of the most popular browsers to build extensions for include Safari, Firefo
 
 | Web browser | Chromium-based? | Extension development webpage |
 |:--- |:--- |:--- |
-| Safari | No | [developer.apple.com/documentation/safariservices/safari_app_extensions](https://developer.apple.com/documentation/safariservices/safari_app_extensions) |
-| Firefox | No | [developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions) |
-| Chrome | Yes | [developer.chrome.com/extensions](https://developer.chrome.com/extensions) |
-| Opera | Yes | [dev.opera.com/extensions](https://dev.opera.com/extensions) |
+| Safari | No | [Safari App Extensions](https://developer.apple.com/documentation/safariservices/safari_app_extensions) |
+| Firefox | No | [Browser Extensions](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions) |
+| Chrome | Yes | [API Reference](https://developer.chrome.com/extensions) |
+| Opera | Yes | [Extensions Documentation](https://dev.opera.com/extensions) |
 | Brave | Yes | Uses [Chrome Web Store](https://chrome.google.com/webstore/category/extensions) |
-| Microsoft Edge | Yes | [developer.microsoft.com/microsoft-edge/extensions](https://developer.microsoft.com/en-us/microsoft-edge/extensions)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> |
+| Microsoft Edge | Yes | [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions) |
 
 > [!IMPORTANT]
 > Many of the tutorials of the sites use browser-specific APIs that might not match the browser for which you develop.  In most cases, a Chromium extension works as-is in different Chromium browsers and the APIs work as expected.  Some less-common APIs might be browser-specific.  Links to the tutorials are in the [See also](#see-also) section, below.

--- a/microsoft-edge/extensions-chromium/whats-new/released-features.md
+++ b/microsoft-edge/extensions-chromium/whats-new/released-features.md
@@ -28,7 +28,7 @@ You can integrate APIs directly into your Continuous Integration / Continuous De
 <!-- ====================================================================== -->
 ## Microsoft Edge extensions developer portal
 
-The new edition of the developer portal contains relevant resources and documentation for Microsoft Edge extensions. For more information, see [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/en-us/microsoft-edge/extensions/).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+The new edition of the developer portal contains relevant resources and documentation for Microsoft Edge extensions. For more information, see [Microsoft Edge Add-ons Developer](https://developer.microsoft.com/microsoft-edge/extensions/).
 
 *Released January 2022*
 

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -368,8 +368,8 @@ additionalContent:
           links:
             - text: How to detect Microsoft Edge in your website
               url: /microsoft-edge/web-platform/user-agent-guidance
-            - text: Platform Status
-              url: https://developer.microsoft.com/en-us/microsoft-edge/status # temp keep /en-us, delete it later when omitting it ends up at right url
+            - text: Microsoft Edge Platform Status
+              url: https://developer.microsoft.com/microsoft-edge/status
             - text: Visual Studio Code
               url: /microsoft-edge/visual-studio-code/index
             - text: Privacy Whitepaper

--- a/microsoft-edge/origin-trials/index.md
+++ b/microsoft-edge/origin-trials/index.md
@@ -11,13 +11,13 @@ ms.date: 01/07/2021
 
 You can use Origin Trials to try out experimental APIs on live sites for a limited period of time.  When using Origin Trials, users of Microsoft Edge that visit your site may run code that uses experimental APIs.  To access the experimental APIs on each user machine, you don't need to go to `edge://flags` and turn on feature flags.
 
-For more information, see [experimental APIs](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->  You can also provide feedback on the design of the API, your use cases, or your experience using the APIs to browser engineers and the web standard community.
+For more information, see [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials).  You can also provide feedback on the design of the API, your use cases, or your experience using the APIs to browser engineers and the web standard community.
 
 
 <!-- ====================================================================== -->
 ## Get started using Origin Trials
 
-For more information about the experimental APIs available in Microsoft Edge, see [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->  Be sure to review the minimum version requirements for Microsoft Edge, and the trial end date, to assess the suitability of using the experimental APIs on your website.
+For more information about the experimental APIs available in Microsoft Edge, see [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials).  Be sure to review the minimum version requirements for Microsoft Edge, and the trial end date, to assess the suitability of using the experimental APIs on your website.
 
 > [!NOTE]
 > An experiment may end earlier than planned if any of the following situations occur:
@@ -29,7 +29,7 @@ For more information about the experimental APIs available in Microsoft Edge, se
 
 To register for a trial of an experimental API:
 
-1. Go to [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+1. Go to [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials).
 
 1. Click the **Register** button on any of the available experiments.
 
@@ -52,7 +52,7 @@ To register for a trial of an experimental API:
 
 ### Apply your token
 
-A token is instantly generated and displayed on the [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> page.  To begin using the trial on your website, use either of the following methods to apply the token to your page:
+A token is instantly generated and displayed on the [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials).  To begin using the trial on your website, use either of the following methods to apply the token to your page:
 
 *  Add the `origin-trial` attribute value and your token to the `meta` tag on every page that uses the experimental API.
 

--- a/microsoft-edge/progressive-web-apps-chromium/how-to/index.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/index.md
@@ -183,7 +183,7 @@ To build a robust, real-world PWA, consider the following best practices for web
 
 ### Cross-browser compatibility
 
-Test your app for [cross-browser compatibility](https://developer.mozilla.org/docs/Learn/Tools_and_testing/Cross_browser_testing).  Make sure your PWA works, by testing it in different browsers and environments.  See [Tools](https://developer.microsoft.com/en-us/microsoft-edge/tools/)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> at _Microsoft Edge Developer_.
+Test your app for [cross-browser compatibility](https://developer.mozilla.org/docs/Learn/Tools_and_testing/Cross_browser_testing).  Make sure your PWA works, by testing it in different browsers and environments.  See [Tools](https://developer.microsoft.com/microsoft-edge/tools/) at _Microsoft Edge Developer_.
 
 ### Responsive design
 

--- a/microsoft-edge/progressive-web-apps-chromium/how-to/origin-trials.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/origin-trials.md
@@ -34,7 +34,7 @@ To turn experimental features on or off:
 
 Microsoft Edge sometimes uses origin trials to test features for specific domains or websites. You may want to use an origin trial for your website to apply a specific feature. If you're a website owner, you can enroll in an origin trial. An origin trial provides features to a percentage of Microsoft Edge users who visit your website.
 
-For more information about Origin Trials, see [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+For more information about Origin Trials, see [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/progressive-web-apps-chromium/how-to/window-controls-overlay.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/window-controls-overlay.md
@@ -41,7 +41,7 @@ To enable the Window Controls Overlay API:
 
 The Window Controls Overlay API is also available as an origin trials feature.  For your app's users to benefit from the Window Controls Overlay without having to enable it in Microsoft Edge, you can use an origin trial.
 
-For more information about Origin Trials, go to [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+For more information about Origin Trials, go to [Microsoft Edge Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/progressive-web-apps-chromium/whats-new/pwa.md
+++ b/microsoft-edge/progressive-web-apps-chromium/whats-new/pwa.md
@@ -170,7 +170,7 @@ To have more control over the title bar area that's currently displayed in stand
 
 Learn more about experimenting with Window Controls Overlay at [Experimental features in Progressive Web Apps (PWAs)](../how-to/window-controls-overlay.md).
 
-Register your origin for the **Web App Window Controls Overlay** trial at our [Origin Trials Developer Console](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/web-app-window-controls-overlay/registration/).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+Register your origin for the **Web App Window Controls Overlay** trial at our [Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials/web-app-window-controls-overlay/registration/).
 
 
 ### URL Handlers origin trial
@@ -179,7 +179,7 @@ Developers can now use the experimental feature Web App URL Handlers in origin t
 
 Learn more about experimenting with URL handlers at [Experimental features in Progressive Web Apps (PWAs)](../how-to/handle-urls.md).
 
-Register your domain for the **Web App URL Handlers** trial at our [Origin Trials Developer Console](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/web-app-url-handlers/registration/).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+Register your domain for the **Web App URL Handlers** trial at our [Origin Trials Developer Console](https://developer.microsoft.com/microsoft-edge/origin-trials/web-app-url-handlers/registration/).
 
 
 ### Support for the Share API on macOS
@@ -197,7 +197,7 @@ Microsoft Edge version 92 became the stable channel of Microsoft Edge on July 22
 
 ### Protocol handlers origin trial
 
-You can now register your PWA to handle specific protocols with the host operating system. The Windows trial for protocol handlers is now available. You can register your origin for the **Web App Protocol Handler** trial at the [origin trial signup page](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/web-app-protocol-handler-registration/registration).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+You can now register your PWA to handle specific protocols with the host operating system. The Windows trial for protocol handlers is now available. You can register your origin for the **Web App Protocol Handler** trial at the [origin trial signup page](https://developer.microsoft.com/microsoft-edge/origin-trials/web-app-protocol-handler-registration/registration).
 
 Learn more about using protocol handlers with your PWA at [Experimental features in Progressive Web Apps (PWAs)](../how-to/handle-protocols.md).
 

--- a/microsoft-edge/webdriver-chromium/index.md
+++ b/microsoft-edge/webdriver-chromium/index.md
@@ -52,7 +52,7 @@ To begin writing automated tests, make sure the Edge WebDriver version you insta
 
     ![The build number for Microsoft Edge on April 15, 2021.](media/microsoft-edge-version.msft.png)
 
-1.  Go to [Microsoft Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+1.  Go to [Microsoft Edge WebDriver](https://developer.microsoft.com/microsoft-edge/tools/webdriver).
 
 1.  In the **Get the latest version** section of the page, select a platform in the channel that matches your version number of Microsoft Edge.
 

--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -61,7 +61,7 @@ Cons:
 <!-- ====================================================================== -->
 ## Understanding the options at the Runtime download page
 
-The [Download the WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2#download-section)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> section of the **Microsoft Edge WebView2** page provides several options for distributing the WebView2 Runtime onto client machines.  Understanding the options at this page provides a good introduction, to help decide which approach you want to use.
+The [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2#download-section) section of the **Microsoft Edge WebView2** page provides several options for distributing the WebView2 Runtime onto client machines.  Understanding the options at this page provides a good introduction, to help decide which approach you want to use.
 
 ![Options for distributing and updating the WebView2 Runtime.](../media/runtime-distrib-options.png)
 
@@ -132,7 +132,7 @@ See [Understanding browser versions and WebView2](versioning.md).
 
 ### Deploying the Evergreen WebView2 Runtime
 
-Only one installation of the Evergreen WebView2 Runtime is needed for all Evergreen apps on the device.  Several tools are available at [Download the WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2#download-section)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> to help you deploy the Evergreen Runtime.
+Only one installation of the Evergreen WebView2 Runtime is needed for all Evergreen apps on the device.  Several tools are available at [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2#download-section) to help you deploy the Evergreen Runtime.
 
 *  For online clients: _WebView2 Runtime Bootstrapper_ is a tiny (approximately 2 MB) installer.  The WebView2 Runtime Bootstrapper downloads and installs the Evergreen Runtime from Microsoft servers that matches the user's device architecture.
 
@@ -186,7 +186,7 @@ Alternatively, instead of programmatically downloading the bootstrapper on-deman
 
 If you have an offline deployment scenario, where app deployment has to work entirely offline, use the following workflow.
 
-1. Download the Evergreen Standalone Installer from [Download the WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2#download-section)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> to your development machine.  The Evergreen Standalone Installer installs the WebView2 Evergreen Runtime on the client.
+1. Download the Evergreen Standalone Installer from [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2#download-section) to your development machine.  The Evergreen Standalone Installer installs the WebView2 Evergreen Runtime on the client.
 
 1. Include the Evergreen Standalone Installer in your app installer or updater.
 
@@ -267,7 +267,7 @@ The Fixed Version binaries are over 250 MB and will make your app package larger
 
 To use the Fixed Version distribution mode:
 
-1. Download the Fixed Version of the WebView2 Runtime from [Download the WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2#download-section),<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> as a package.
+1. Download the Fixed Version of the WebView2 Runtime from [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2#download-section), as a package.
 
    The most-patched version of the latest and second-latest major releases are available for download at this site.  Keep an archived copy of any versions you need.
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -119,7 +119,7 @@ Once an API has been moved from experimental to stable APIs, you need to move yo
 
 In the Evergreen distribution approach, the client's WebView2 Runtime automatically updates to the latest version available.  However, a user or IT admin might choose to prevent automatic updating of the WebView2 Runtime.  The resulting outdated Runtime on the client might cause compatibility issues with your updated WebView2 app that uses new APIs from a recent SDK.
 
-In case updating the WebView2 Runtime is prevented on the client, make sure that you know the minimum build number of the [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> that is required by your app.  The minimum required Runtime version to support the General Availability release of the SDK (build 616) is older than for the latest Runtime.  The latest Runtime supports all APIs that are in the latest SDK release build.
+In case updating the WebView2 Runtime is prevented on the client, make sure that you know the minimum build number of the WebView2 Runtime that is required by your app.  See [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/).  The minimum required Runtime version to support the General Availability release of the SDK (build 616) is older than for the latest Runtime.  The latest Runtime supports all APIs that are in the latest SDK release build.
 
 To check the compatibility between specific build numbers of the SDK and the Runtime or Microsoft Edge preview channel, see [Release Notes for the WebView2 SDK](../release-notes.md).
 

--- a/microsoft-edge/webview2/get-started/get-started.md
+++ b/microsoft-edge/webview2/get-started/get-started.md
@@ -22,5 +22,5 @@ These articles cover how to set up your development tools and create an initial 
 <!-- ====================================================================== -->
 ## See also
 
-* [Microsoft Edge WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> - initial introduction to WebView2, at `developer.microsoft.com`.
+* [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2, at `developer.microsoft.com`.
 * [Sample Code for WebView2](../code-samples-links.md) - a guide to the `WebView2Samples` repo.

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -691,7 +691,7 @@ Congratulations, you built your first WebView2 app!  Your development environmen
 ## See also
 
 developer.microsoft.com:
-* [Microsoft Edge WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> - initial introduction to WebView2 features at developer.microsoft.com.
+* [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2 features at developer.microsoft.com.
 
 Local pages:
 * [WebView2 sample: Win32 C++ app](../samples/webview2apissample.md)

--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -55,7 +55,7 @@ Microsoft Visual Studio is required.  Microsoft Visual Studio Code is not suppor
 <!-- ====================================================================== -->
 ## Step 4 - Install the WebView2 Runtime (optional)
 
-1. Optionally, install the [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+1. Optionally, install the WebView2 Runtime.  See [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2).
 
    If unsure, skip this step; you can use the Microsoft Edge preview channel from the previous step instead.
   
@@ -586,7 +586,7 @@ Congratulations, you built your first WebView2 app!
 ## See also
 
 developer.microsoft.com:
-* [Microsoft Edge WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> - initial introduction to WebView2 features at developer.microsoft.com.
+* [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2 features at developer.microsoft.com.
 
 Local pages:
 * [WebView2 sample: WinForms browser app](../samples/webview2windowsformsbrowser.md) - Demonstrates more WebView2 APIs than the present tutorial.

--- a/microsoft-edge/webview2/get-started/winui.md
+++ b/microsoft-edge/webview2/get-started/winui.md
@@ -37,7 +37,7 @@ Return from that page and continue the steps below.
 <!-- ====================================================================== -->
 ## Step 2 - Install a preview channel of Microsoft Edge
 
-1. Install the [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> or any [Microsoft Edge preview channel](https://www.microsoftedgeinsider.com/download) (Beta, Dev, or Canary) installed on Windows 10 version 1803 (build 17134) or later.
+1. Install the [WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2) or any [Microsoft Edge preview channel](https://www.microsoftedgeinsider.com/download) (Beta, Dev, or Canary) installed on Windows 10 version 1803 (build 17134) or later.
 
 Return from that page and continue the steps below.
 
@@ -374,7 +374,7 @@ Congratulations, you built your first WebView2 app!
 ## See also
 
 developer.microsoft.com:
-* [Microsoft Edge WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> - initial introduction to WebView2 features at developer.microsoft.com.
+* [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2 features at developer.microsoft.com.
 
 Local pages:
 * [Introduction to Microsoft Edge WebView2](../index.md) - overview of features.

--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -100,7 +100,7 @@ Visual Studio 2019 version 16.9 or later is required, for this tutorial.  Visual
 
    ![Visual Studio Installer working.](media/winui2-vs-installer-working.png)
 
-   This can take several minutes.  In a new window or tab, you can check out a top-level overview at [Microsoft Edge WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> - an initial introduction to WebView2 features at developer.microsoft.com.
+   This can take several minutes.  In a new window or tab, you can check out a top-level overview at [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - an initial introduction to WebView2 features at developer.microsoft.com.
 
    When Visual Studio Installer is finished, return to this page and continue with the steps below.
 

--- a/microsoft-edge/webview2/get-started/wpf.md
+++ b/microsoft-edge/webview2/get-started/wpf.md
@@ -34,9 +34,6 @@ This tutorial requires Microsoft Visual Studio, not Microsoft Visual Studio Code
 
    We recommend using the Canary channel of Microsoft Edge.  The minimum required version is 82.0.488.0.
 
-<!-- Or, download the [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section), or  -->
-<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
-
 
 <!-- ====================================================================== -->
 ## Step 3 - Create a single-window WebView2 app
@@ -457,7 +454,7 @@ Congratulations, you built your first WebView2 app!
 ## See also
 
 developer.microsoft.com:
-* [Microsoft Edge WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2)<!-- temp keep /en-us, delete it later when omitting it ends up at right url --> - initial introduction to WebView2 features at developer.microsoft.com.
+* [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2 features at developer.microsoft.com.
 
 Local pages:
 * [WebView2 sample: WPF .NET browser app](../samples/webview2wpfbrowser.md)

--- a/microsoft-edge/webview2/how-to/machine-setup.md
+++ b/microsoft-edge/webview2/how-to/machine-setup.md
@@ -38,7 +38,7 @@ We recommend using the Canary channel.  The minimum required version is 82.0.488
 <!-- ====================================================================== -->
 ## Install the WebView2 Runtime
 
-1. Optionally, install the [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->
+1. Optionally, install the WebView2 Runtime.  To do that, go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2).
 
 If unsure, skip this step; you can use the Microsoft Edge preview channel from the previous step instead.
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -1076,7 +1076,7 @@ This version of the WebView2 SDK requires WebView2 Runtime version 86.0.616.0 or
 > [!IMPORTANT]
 > **Announcement**:  Win32 C/C++ WebView2 is now Generally Available (GA).  Starting this release, Release SDKs are forward-compatible.  See [GA announcement blog post](https://blogs.windows.com/msedgedev/edge-webview2-general-availability).
 
-*  The Evergreen WebView2 Runtime and installer are GA.  The bootstrapper, the downlink link for the Bootstrapper, and the Standalone Installer for the Evergreen WebView2 Runtime are available on [Microsoft Edge WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).<!-- temp keep /en-us, delete it later when omitting it ends up at right url -->  Sample code for the installation workflow is also available in the [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples).
+*  The Evergreen WebView2 Runtime and installer are GA.  The bootstrapper, the downlink link for the Bootstrapper, and the Standalone Installer for the Evergreen WebView2 Runtime are available on [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/).  Sample code for the installation workflow is also available in the [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples).
 
 For more information about the Runtime, Evergreen distribution, and Fixed Version distribution, see [Distribute your app and the WebView2 Runtime](concepts/distribution.md).
 


### PR DESCRIPTION
Fixes https://github.com/MicrosoftDocs/edge-developer/issues/1947 

Now that developer.microsoft.com/microsoft-edge is redirecting correctly, removed en-us from links to it.

Tested all links for developer.microsoft.com/microsoft-edge