### PR TITLE
Fixed h2 link to not bounce to random h2 section

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/3d-view/index.md
+++ b/microsoft-edge/devtools-guide-chromium/3d-view/index.md
@@ -76,7 +76,7 @@ The **Slow scroll rects** checkbox highlights sections of the page that cause sl
 This checkbox highlights (in pink) the boxes of the rendered webpage that may cause these performance issues.
 <!-- To try this checkbox, you can go to [YouTube](https://www.youtube.com). -->
 
-This checkbox is similar to the **Scrolling performance issues** checkbox in the **Rendering** tool, which highlights the slow rects on the page directly (in yellow).  See [Find scroll performance issues in realtime](../evaluate-performance\reference.md#find-scroll-performance-issues-in-realtime) in _Performance features reference_.  Both checkboxes are based on the same debugging info, but these two tools present this information differently.
+This checkbox is similar to the **Scrolling performance issues** checkbox in the **Rendering** tool, which highlights the slow rects on the page directly (in yellow).  See [Find scroll performance issues in realtime](../evaluate-performance/reference.md#find-scroll-performance-issues-in-realtime) in _Performance features reference_.  Both checkboxes are based on the same debugging info, but these two tools present this information differently.
 <!-- https://developer.chrome.com/docs/devtools/rendering/performance/#scrolling-performance-issues -->
 
 


### PR DESCRIPTION
Rendered section:
https://review.docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/3d-view/?branch=pr-en-us-1980#slow-scroll-rects-checkbox
Click the link in the section, make sure end up at right h2