### PR TITLE
Improve selenium's required configuration link

### DIFF
--- a/microsoft-edge/webdriver-chromium/ie-mode.md
+++ b/microsoft-edge/webdriver-chromium/ie-mode.md
@@ -28,7 +28,7 @@ To begin automating tests in IE mode in Microsoft Edge, [download IEDriver](http
 <!-- ====================================================================== -->
 ## Required Configuration
 
-To configure IEDriver, Windows, and Microsoft Edge correctly, complete the requirements for [Selenium's required configuration](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver#required-configuration).  
+To configure IEDriver, Windows, and Microsoft Edge correctly, complete the requirements for [Selenium's required configuration](https://www.selenium.dev/documentation/ie_driver_server/).  
 
 
 ### Place the driver executable in the PATH

--- a/microsoft-edge/webdriver-chromium/ie-mode.md
+++ b/microsoft-edge/webdriver-chromium/ie-mode.md
@@ -28,7 +28,7 @@ To begin automating tests in IE mode in Microsoft Edge, [download IEDriver](http
 <!-- ====================================================================== -->
 ## Required Configuration
 
-To configure IEDriver, Windows, and Microsoft Edge correctly, complete the requirements for [Selenium's required configuration](https://www.selenium.dev/documentation/ie_driver_server/).  
+To configure IEDriver, Windows, and Microsoft Edge correctly, complete the requirements for [Selenium's required configuration](https://www.selenium.dev/documentation/ie_driver_server/#required-configuration).
 
 
 ### Place the driver executable in the PATH


### PR DESCRIPTION
The [old link](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver#required-configuration) took you to a github wiki with a "moved to" link to the final destination.
I'm changing the link so it takes you to the final destination.