### PR TITLE
Correct obsolete edgedriver method name

### DIFF
--- a/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
+++ b/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
@@ -6,13 +6,13 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: devtools
-ms.date: 02/10/2021
+ms.date: 06/09/2022
 ---
 # Capabilities and EdgeOptions
 
 Capabilities are options that you can use to customize and configure an `EdgeDriver` session.  To learn about starting a new `EdgeDriver` session, see [Automating Microsoft Edge](index.md#automate-microsoft-edge).  This article describes all supported capabilities for Microsoft Edge and provides details about passing the capabilities to `EdgeDriver` sessions.
 
-Capabilities are passed to a WebDriver session as a JSON map.  A WebDriver testing framework provides a WebDriver language binding.  WebDriver language bindings typically provide type-safe convenience methods so you don't need to configure the JSON map yourself.  Different WebDriver language bindings use different mechanisms to configure capabilities.  [Selenium](https://www.selenium.dev) configures capabilities through the `EdgeOptions` class.
+Capabilities are passed to a WebDriver session as a JSON map but it is not necessary, or recommended to set them this way.  WebDriver testing frameworks (such as [Selenium](https://www.selenium.dev)) provide language bindings which typically have convenience methods so you don't need to configure the JSON map yourself.  For example Selenium configures capabilities through the `EdgeOptions` class.
 
 To learn more about how to configure capabilities, consult the documentation for your preferred WebDriver testing framework.  For more information, see [Choose a WebDriver testing framework](index.md#choose-a-webdriver-testing-framework).
 

--- a/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
+++ b/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
@@ -28,10 +28,10 @@ options.AddExtensions("/path/to/extension.crx");
 var driver = new EdgeDriver(options);
 ```
 
-To use capabilities that don't have an associated convenience method, use the `AddAdditionalCapability` method.  You must pass the full name of the capability and a value with the correct type.  For the full list of accepted capabilities and value types, see [EdgeOptions object](#edgeoptions-object).
+To use capabilities that don't have an associated convenience method, use the `AddAdditionalEdgeOption` method.  You must pass the full name of the capability and a value with the correct type.  For the full list of accepted capabilities and value types, see [EdgeOptions object](#edgeoptions-object).
 
 ```csharp
-options.AddAdditionalCapability("wdpAddress", "remotehost:50080");
+options.AddAdditionalEdgeOption("wdpAddress", "remotehost:50080");
 ```
 
 

--- a/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
+++ b/microsoft-edge/webdriver-chromium/capabilities-edge-options.md
@@ -12,7 +12,8 @@ ms.date: 06/09/2022
 
 Capabilities are options that you can use to customize and configure an `EdgeDriver` session.  To learn about starting a new `EdgeDriver` session, see [Automating Microsoft Edge](index.md#automate-microsoft-edge).  This article describes all supported capabilities for Microsoft Edge and provides details about passing the capabilities to `EdgeDriver` sessions.
 
-Capabilities are passed to a WebDriver session as a JSON map but it is not necessary, or recommended to set them this way.  WebDriver testing frameworks (such as [Selenium](https://www.selenium.dev)) provide language bindings which typically have convenience methods so you don't need to configure the JSON map yourself.  For example Selenium configures capabilities through the `EdgeOptions` class.
+Capabilities are passed to a WebDriver session as a JSON map, but it is not necessary or recommended to set them this way.  WebDriver testing frameworks (such as [Selenium](https://www.selenium.dev)) provide language bindings which typically have convenience methods so you don't need to configure the JSON map yourself.  For example, Selenium configures capabilities through the `EdgeOptions` class.
+
 
 To learn more about how to configure capabilities, consult the documentation for your preferred WebDriver testing framework.  For more information, see [Choose a WebDriver testing framework](index.md#choose-a-webdriver-testing-framework).
 


### PR DESCRIPTION
`AddAdditionalCapability` is now obsolete and replaced by the less browser-agnostic `AddAdditionalEdgeOption` method. So this PR corrects the code in our docs that uses it.
I've also tried to make it clearer that people should use their framework of choice's convenience methods. The second paragraph already did that, but I rephrased slightly to make it clearer.

Fixes #1986.

@bwalderman could you please take a look at let me know if this is an improvement?