### PR TITLE
Release Note for WebView2 with Stable 103 and prerelease 105

### DIFF
--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -108,6 +108,8 @@ The following APIs are promoted to stable in this prerelease SDK:
 * [ICoreWebView2_15::FaviconChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1305-prerelease&preserve-view=true#add_faviconchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1305-prerelease&preserve-view=true#remove_faviconchanged)
 * [ICoreWebView2_15::FaviconUri property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1305-prerelease&preserve-view=true#get_faviconuri)<!--no put-->
 
+---
+
 #### Bug fixes
 
 <!-- TODO: check indent experiment, of link tabs: -->

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -38,10 +38,10 @@ To use a prerelease SDK along with a Microsoft Edge preview channel, see [Test u
 <!-- ====================================================================== -->
 ## Platforms covered
 
-Generally, release notes apply across Win32, .NET, and WinRT.  The APIs for the platforms are roughly parallel, such as:
-* Win32 [ICoreWebView2](/microsoft-edge/webview2/reference/win32/icorewebview2) together with similarly named interfaces such as [ICoreWebView2_10](/microsoft-edge/webview2/reference/win32/icorewebview2_10).
-* .NET [CoreWebView2 Class](/dotnet/api/microsoft.web.webview2.core.corewebview2).
-* WinRT [CoreWebView2 Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2).
+Generally, release notes apply across the supported platforms.  The APIs for the platforms are roughly parallel, such as:
+* .NET/C# [CoreWebView2 Class](/dotnet/api/microsoft.web.webview2.core.corewebview2).
+* WinRT/C# [CoreWebView2 Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2).
+* Win32/C++ [ICoreWebView2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2) together with similarly named interfaces such as [ICoreWebView2_10](/microsoft-edge/webview2/reference/win32/icorewebview2_10).
 
 
 <!-- ====================================================================== -->
@@ -59,7 +59,21 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 The following items are now stable:
 
-*  Added [ContextMenuRequested API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1245.22&preserve-view=true) to enable host app to create or modify their own context menu.
+*  Added `ContextMenuRequested`API to enable host app to create or modify their own context menu.
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2.ContextMenuRequested Event](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.contextmenurequested?view=webview2-dotnet-1.0.1264.42&preserve-view=true)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2.ContextMenuRequested Event](https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1264.42&preserve-view=true#contextmenurequested)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2_11::add_ContextMenuRequested event (add](https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1264.42&preserve-view=true#add_contextmenurequested), [remove)](https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1264.42&preserve-view=true#remove_contextmenurequested)
+
+---
 
 
 <!-- ====================================================================== -->
@@ -77,6 +91,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 The following APIs are promoted to stable in this prerelease SDK:
 
+<!-- TODO: link -->
 * The [Favicon API](#):
    * `add_FaviconChanged`
    * `remove_FaviconChanged`
@@ -84,21 +99,23 @@ The following APIs are promoted to stable in this prerelease SDK:
 
 #### Bug fixes
 
-* Fixed an issue that `PrintToPdfAsync` may hang for long time. ([Issue #1974](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1974))
+<!-- TODO: check indent experiment, of link tabs: -->
 
-##### [.NET/C#](#tab/dotnetcsharp)
+*  Fixed an issue that `PrintToPdfAsync` may hang for long time. ([Issue #1974](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1974))
 
-* [CoreWebView2.PrintToPdfAsync Method](https://docs.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync?view=webview2-dotnet-1.0.1305-prerelease&preserve-view=true)
+   ##### [.NET/C#](#tab/dotnetcsharp)
 
-##### [WinRT/C#](#tab/winrtcsharp)
+   * [CoreWebView2.PrintToPdfAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync?view=webview2-dotnet-1.0.1305-prerelease&preserve-view=true)
 
-* [CoreWebView2.PrintToPdfAsync Method](https://docs.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1305-prerelease&preserve-view=true#printtopdfasync)
+   ##### [WinRT/C#](#tab/winrtcsharp)
 
-##### [Win32/C++](#tab/win32cpp)
+   * [CoreWebView2.PrintToPdfAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1305-prerelease&preserve-view=true#printtopdfasync)
 
-* [ICoreWebView2_7::PrintToPdf method](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1305-prerelease#printtopdf&preserve-view=true)
+   ##### [Win32/C++](#tab/win32cpp)
 
----
+   * [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1305-prerelease#printtopdf&preserve-view=true)
+
+   ---
 
 * Fixed regression where WebView2 would steal focus from the app when the WebView2 was made visible. ([Issue #862](https://github.com/MicrosoftEdge/WebView2Feedback/issues/862))
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -12,6 +12,8 @@ ms.date: 07/05/2022
 
 The WebView2 team updates the [WebView2 SDK](https://www.nuget.org/packages/Microsoft.Web.WebView2) on a four-week cadence. This article contains the latest information on product announcements, additions, modifications, and breaking changes to the APIs.
 
+Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).
+
 WebView2 bug fixes, such as the fixes listed below, are either Runtime-specific or SDK-specific.
 
 
@@ -33,15 +35,6 @@ For more information, see [Matching the Runtime version with the SDK version](co
 To load WebView2, the minimum version of Microsoft Edge or the WebView2 Runtime is 86.0.616.0.  The minimum version to load WebView2 only changes when a breaking change occurs in the web platform.
 
 To use a prerelease SDK along with a Microsoft Edge preview channel, see [Test upcoming APIs and features](how-to/set-preview-channel.md).
-
-
-<!-- ====================================================================== -->
-## Platforms covered
-
-Generally, release notes apply across the supported platforms.  The APIs for the platforms are roughly parallel, such as:
-* .NET/C# [CoreWebView2 Class](/dotnet/api/microsoft.web.webview2.core.corewebview2).
-* WinRT/C# [CoreWebView2 Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2).
-* Win32/C++ [ICoreWebView2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2) together with similarly named interfaces such as [ICoreWebView2_10](/microsoft-edge/webview2/reference/win32/icorewebview2_10).
 
 
 <!-- ====================================================================== -->
@@ -111,8 +104,6 @@ The following APIs are promoted to stable in this prerelease SDK:
 ---
 
 #### Bug fixes
-
-<!-- TODO: check indent experiment, of link tabs: -->
 
 *  Fixed an issue where `PrintToPdfAsync` may hang for long time. ([Issue #1974](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1974))
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 06/15/2022
+ms.date: 07/05/2022
 ---
 # Release Notes for the WebView2 SDK
 
@@ -43,6 +43,7 @@ Generally, release notes apply across Win32, .NET, and WinRT.  The APIs for the 
 * .NET [CoreWebView2 Class](/dotnet/api/microsoft.web.webview2.core.corewebview2).
 * WinRT [CoreWebView2 Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2).
 
+
 <!-- ====================================================================== -->
 ## 1.0.1264.42
 
@@ -50,7 +51,7 @@ Release Date: July 4, 2022
 
 [NuGet package for WebView2 SDK 1.0.1264.42](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1264.42)
 
-For full API compatibility, this version of the WebView2 SDK requires WebView2 Runtime version 103.1264.42 or higher.
+For full API compatibility, this version of the WebView2 SDK requires WebView2 Runtime version 103.0.1264.42 or higher.
 
 ### General
 
@@ -58,14 +59,15 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 The following items are now stable:
 
-*   Added [ContextMenuRequested API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1245.22&preserve-view=true) to enable host app to create or modify their own context menu.
+*  Added [ContextMenuRequested API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1245.22&preserve-view=true) to enable host app to create or modify their own context menu.
+
 
 <!-- ====================================================================== -->
 ## 1.0.1305-prerelease
 
 Release Date: July 4, 2022
 
-[NuGet package for WebView2 SDK 1.0.1305-prelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1305-prerelease)
+[NuGet package for WebView2 SDK 1.0.1305-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1305-prerelease)
 
 For full API compatibility, this version of the WebView2 SDK requires Microsoft Edge version 105.0.1305.0 or higher.
 
@@ -83,6 +85,20 @@ The following APIs are promoted to stable in this prerelease SDK:
 #### Bug fixes
 
 * Fixed an issue that `PrintToPdfAsync` may hang for long time. ([Issue #1974](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1974))
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2.PrintToPdfAsync Method](https://docs.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync?view=webview2-dotnet-1.0.1305-prerelease&preserve-view=true)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2.PrintToPdfAsync Method](https://docs.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1305-prerelease&preserve-view=true#printtopdfasync)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2_7::PrintToPdf method](https://docs.microsoft.com/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1305-prerelease#printtopdf&preserve-view=true)
+
+---
 
 * Fixed regression where WebView2 would steal focus from the app when the WebView2 was made visible. ([Issue #862](https://github.com/MicrosoftEdge/WebView2Feedback/issues/862))
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -43,6 +43,49 @@ Generally, release notes apply across Win32, .NET, and WinRT.  The APIs for the 
 * .NET [CoreWebView2 Class](/dotnet/api/microsoft.web.webview2.core.corewebview2).
 * WinRT [CoreWebView2 Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2).
 
+<!-- ====================================================================== -->
+## 1.0.1264.42
+
+Release Date: July 4, 2022
+
+[NuGet package for WebView2 SDK 1.0.1264.42](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1264.42)
+
+For full API compatibility, this version of the WebView2 SDK requires WebView2 Runtime version 103.1264.42 or higher.
+
+### General
+
+#### Promotions
+
+The following items are now stable:
+
+*   Added [ContextMenuRequested API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1245.22&preserve-view=true) to enable host app to create or modify their own context menu.
+
+<!-- ====================================================================== -->
+## 1.0.1305-prerelease
+
+Release Date: July 4, 2022
+
+[NuGet package for WebView2 SDK 1.0.1305-prelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1305-prerelease)
+
+For full API compatibility, this version of the WebView2 SDK requires Microsoft Edge version 105.0.1305.0 or higher.
+
+### General
+
+#### Promotions
+
+The following APIs are promoted to stable in this prerelease SDK:
+
+* The [Favicon API](#):
+   * `add_FaviconChanged`
+   * `remove_FaviconChanged`
+   * `get_FaviconUri`
+
+#### Bug fixes
+
+* Fixed an issue that `PrintToPdfAsync` may hang for long time. ([Issue #1974](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1974))
+
+* Fixed regression where WebView2 would steal focus from the app when the WebView2 was made visible. ([Issue #862](https://github.com/MicrosoftEdge/WebView2Feedback/issues/862))
+
 
 <!-- ====================================================================== -->
 ## 1.0.1245.22

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -63,15 +63,15 @@ The following items are now stable:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ContextMenuRequested Event](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.contextmenurequested?view=webview2-dotnet-1.0.1264.42&preserve-view=true)
+* [CoreWebView2.ContextMenuRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.contextmenurequested?view=webview2-dotnet-1.0.1264.42&preserve-view=true)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ContextMenuRequested Event](https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1264.42&preserve-view=true#contextmenurequested)
+* [CoreWebView2.ContextMenuRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1264.42&preserve-view=true#contextmenurequested)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_11::add_ContextMenuRequested event (add](https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1264.42&preserve-view=true#add_contextmenurequested), [remove)](https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1264.42&preserve-view=true#remove_contextmenurequested)
+* [ICoreWebView2_11::add_ContextMenuRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1264.42&preserve-view=true#add_contextmenurequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1264.42&preserve-view=true#remove_contextmenurequested)
 
 ---
 
@@ -91,31 +91,42 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 The following APIs are promoted to stable in this prerelease SDK:
 
-<!-- TODO: link -->
-* The [Favicon API](#):
-   * `add_FaviconChanged`
-   * `remove_FaviconChanged`
-   * `get_FaviconUri`
+* The Favicon API:
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2.FaviconChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconchanged?view=webview2-dotnet-1.0.1305-prerelease&preserve-view=true)
+* [CoreWebView2.FaviconUri Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconuri?view=webview2-dotnet-1.0.1305-prerelease&preserve-view=true)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2.FaviconChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1305-prerelease&preserve-view=true#faviconchanged)
+* [CoreWebView2.FaviconUri Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1305-prerelease&preserve-view=true#faviconuri)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2_15::FaviconChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1305-prerelease&preserve-view=true#add_faviconchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1305-prerelease&preserve-view=true#remove_faviconchanged)
+* [ICoreWebView2_15::FaviconUri property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1305-prerelease&preserve-view=true#get_faviconuri)<!--no put-->
 
 #### Bug fixes
 
 <!-- TODO: check indent experiment, of link tabs: -->
 
-*  Fixed an issue that `PrintToPdfAsync` may hang for long time. ([Issue #1974](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1974))
+*  Fixed an issue where `PrintToPdfAsync` may hang for long time. ([Issue #1974](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1974))
 
-   ##### [.NET/C#](#tab/dotnetcsharp)
+##### [.NET/C#](#tab/dotnetcsharp)
 
-   * [CoreWebView2.PrintToPdfAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync?view=webview2-dotnet-1.0.1305-prerelease&preserve-view=true)
+* [CoreWebView2.PrintToPdfAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync?view=webview2-dotnet-1.0.1305-prerelease&preserve-view=true)
 
-   ##### [WinRT/C#](#tab/winrtcsharp)
+##### [WinRT/C#](#tab/winrtcsharp)
 
-   * [CoreWebView2.PrintToPdfAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1305-prerelease&preserve-view=true#printtopdfasync)
+* [CoreWebView2.PrintToPdfAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1305-prerelease&preserve-view=true#printtopdfasync)
 
-   ##### [Win32/C++](#tab/win32cpp)
+##### [Win32/C++](#tab/win32cpp)
 
-   * [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1305-prerelease#printtopdf&preserve-view=true)
+* [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1305-prerelease#printtopdf&preserve-view=true)
 
-   ---
+---
 
 * Fixed regression where WebView2 would steal focus from the app when the WebView2 was made visible. ([Issue #862](https://github.com/MicrosoftEdge/WebView2Feedback/issues/862))
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -117,7 +117,7 @@ The following APIs are promoted to stable in this prerelease SDK:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1305-prerelease#printtopdf&preserve-view=true)
+* [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1305-prerelease&preserve-view=true#printtopdf)
 
 ---
 


### PR DESCRIPTION
Release Note for WebView2 with Stable 103 and prerelease 105 draft.

**Rendered article sections for review:**
* https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/release-notes?branch=pr-en-us-2044#10126442
   * SDK 1.0.1264.42 uses WebView2 Runtime 103+
* https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/release-notes?branch=pr-en-us-2044#101305-prerelease
   * SDK 1.0.1305-prerelease uses Microsoft Edge 105+