### PR TITLE
Add additional approaches for getting to DevTools

### DIFF
--- a/microsoft-edge/webview2/how-to/debug-devtools.md
+++ b/microsoft-edge/webview2/how-to/debug-devtools.md
@@ -1,16 +1,18 @@
 ---
 title: Debug WebView2 apps with Microsoft Edge DevTools
-description: How to debug WebView2 apps with Microsoft Edge DevTools.
+description: How to open Microsoft Edge DevTools when using a WebView2 app.
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 02/11/2022
+ms.date: 07/07/2022
 ---
 # Debug WebView2 apps with Microsoft Edge DevTools
 
 Use Microsoft Edge Developer Tools to debug web content displayed in WebView2 controls, in the same way that you can debug another webpage that's displayed in Microsoft Edge.
+
+![DevTools debugging in a WebView2 control.](media/f12.png)
 
 When you're using a WebView2 app, there are several ways to open DevTools:
 
@@ -18,12 +20,23 @@ When you're using a WebView2 app, there are several ways to open DevTools:
 *  Press `Ctrl`+`Shift`+`I`.
 *  Right-click the page and then select `Inspect`.
 
-Apps can also use the `CoreWebView2.OpenDevToolsWindow` / `ICoreWebView2::OpenDevToolswindow` API to programmatically open a DevTools window if they remove those hotkeys and the context menu items. In the event none of those options are possible, adding `--auto-open-devtools-for-tabs` to additional browser arguments via an environment variable or registry key will open a DevTools window when a WebView2 is created.
+An app can also use the `OpenDevToolsWindow` API to programmatically open a DevTools window.  For example, you can use this approach if the above hotkeys and the context menu items have been removed.
 
-![DevTools debugging.](media/f12.png)
+##### [.NET/C#](#tab/dotnetcsharp)
 
-_To zoom, right-click > **Open image in new tab**._
+* [CoreWebView2.OpenDevToolsWindow Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.opendevtoolswindow)
 
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2.OpenDevToolsWindow Method](/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#opendevtoolswindow)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2::OpenDevToolsWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2#opendevtoolswindow)
+
+---
+
+If none of the above approaches are available, your app can add `--auto-open-devtools-for-tabs` to the browser arguments via an environment variable or registry key.  This approach will open a DevTools window when a WebView2 is created.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/how-to/debug-devtools.md
+++ b/microsoft-edge/webview2/how-to/debug-devtools.md
@@ -18,6 +18,8 @@ When you're using a WebView2 app, there are several ways to open DevTools:
 *  Press `Ctrl`+`Shift`+`I`.
 *  Right-click the page and then select `Inspect`.
 
+Apps can also use the `CoreWebView2.OpenDevToolsWindow` / `ICoreWebView2::OpenDevToolswindow` API to programmatically open a DevTools window if they remove those hotkeys and the context menu items. In the event none of those options are possible, adding `--auto-open-devtools-for-tabs` to additional browser arguments via an environment variable or registry key will open a DevTools window when a WebView2 is created.
+
 ![DevTools debugging.](media/f12.png)
 
 _To zoom, right-click > **Open image in new tab**._

--- a/microsoft-edge/webview2/how-to/debug-devtools.md
+++ b/microsoft-edge/webview2/how-to/debug-devtools.md
@@ -36,7 +36,7 @@ An app can also use the `OpenDevToolsWindow` API to programmatically open a DevT
 
 ---
 
-If none of the above approaches are available, your app can add `--auto-open-devtools-for-tabs` to the browser arguments via an environment variable or registry key.  This approach will open a DevTools window when a WebView2 is created.
+If none of the above approaches are available, you can add `--auto-open-devtools-for-tabs` to the browser arguments via an environment variable or registry key.  This approach will open a DevTools window when a WebView2 is created.
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
Was writing a doc and noticed these were missing.

**Rendered article for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/how-to/debug-devtools?branch=pr-en-us-2049