### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/beginners/html.md
+++ b/microsoft-edge/devtools-guide-chromium/beginners/html.md
@@ -60,7 +60,7 @@ You'll build a site in the Glitch online code editor.
 
 1. Open the [source code](https://glitch.com/edit/#!/alluring-shock?path=index.html). This tab is called the **editor tab** throughout this tutorial.
 
-   ![The editor tab.](media/beginners-html-setup1.msft.png)
+   ![The editor tab.](/media/beginners-html-setup1.msft.png)
 
 1. Select **alluring-shock**. The **Project Options** menu opens.
 


### PR DESCRIPTION
typo missing (/)

Rendered article for review:
https://review.docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/beginners/html?branch=pr-en-us-2061#set-up-your-code

Before:
https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/beginners/html#set-up-your-code