### PR TITLE
Remove C# from WinRT TOC, re-outline WinRT Refs

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1236,7 +1236,7 @@
 
             - name: WinRT
               items:
-                - name: Microsoft.Web.WebView2.Core (C#)
+                - name: Microsoft.Web.WebView2.Core
                   href: /microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index
                   displayName: functions, methods
 

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1240,11 +1240,11 @@
                   href: /microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index
                   displayName: functions, methods
 
-                - name: COM Interop (C++)
+                - name: COM Interop/C++
                   href: /microsoft-edge/webview2/reference/winrt/interop/index
                   displayName: functions, methods
 
-            - name: Win32 C++
+            - name: Win32/C++
               items:
                 - name: Win32 C++ WebView2 API conventions
                   href: webview2/concepts/win32-api-conventions.md

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -14,18 +14,18 @@ The Microsoft Edge WebView2 control enables you to host web content in your appl
 
 WebView2 is available for the following frameworks (or platforms) and programming languages:
 
-* .NET
-   * [Core/C#](/dotnet/api/microsoft.web.webview2.core)
+*  .NET
+   * [Core](/dotnet/api/microsoft.web.webview2.core)
    * [WPF](/dotnet/api/microsoft.web.webview2.wpf)
    * [Windows Forms](/dotnet/api/microsoft.web.webview2.winforms)
 
-* WinRT for WinUI 2 (UWP) 
+*  WinRT
    * [Core](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index)
-   * [COM Interop/C++](/microsoft-edge/webview2/reference/winrt/interop/index) 
-
-* WinRT for WinUI 3 (Windows App SDK) 
-   * [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.webview2)
-      * [Spec: WebView2 Xaml control](https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/WebView2/WebView2_spec.md)<!-- changing master to main doesn't work 5/19/2022 -->
+   * [COM Interop/C++](/microsoft-edge/webview2/reference/winrt/interop/index)
+   *  WinUI 2 (UWP)
+      *  Microsoft.UI.Xaml.Controls.WebView2 Class - TODO: need correct Ref URL if exists
+   *  WinUI 3 (Windows App SDK)
+      * [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.webview2)
 
 * [Win32/C++](/microsoft-edge/webview2/reference/win32/index)
 

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -20,10 +20,10 @@ WebView2 is available for the following frameworks (or platforms) and programmin
    * [Windows Forms](/dotnet/api/microsoft.web.webview2.winforms)
 
 *  WinRT
-   * [Core](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index)
+   * [Microsoft.Web.WebView2.Core](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index)
    * [COM Interop/C++](/microsoft-edge/webview2/reference/winrt/interop/index)
    *  WinUI 2 (UWP)
-      *  Microsoft.UI.Xaml.Controls.WebView2 Class - TODO: need correct Ref URL if exists
+      * [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/winui/api/microsoft.ui.xaml.controls.webview2)
    *  WinUI 3 (Windows App SDK)
       * [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.webview2)
 

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 07/06/2022
+ms.date: 08/03/2022
 ---
 # WebView2 API Reference
 
@@ -19,11 +19,11 @@ WebView2 is available for the following frameworks (or platforms) and programmin
    * [WPF](/dotnet/api/microsoft.web.webview2.wpf)
    * [Windows Forms](/dotnet/api/microsoft.web.webview2.winforms)
 
-* WinRT for WinUI 2 (UWP)
-   * [Core/C#](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index)
-   * [COM Interop/C++](/microsoft-edge/webview2/reference/winrt/interop/index)
+* WinRT for WinUI 2 (UWP) 
+   * [Core](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index)
+   * [COM Interop/C++](/microsoft-edge/webview2/reference/winrt/interop/index) 
 
-* WinRT for WinUI 3 (Windows App SDK)
+* WinRT for WinUI 3 (Windows App SDK) 
    * [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.webview2)
       * [Spec: WebView2 Xaml control](https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/WebView2/WebView2_spec.md)<!-- changing master to main doesn't work 5/19/2022 -->
 

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -20,8 +20,8 @@ WebView2 is available for the following frameworks (or platforms) and programmin
    * [Windows Forms](/dotnet/api/microsoft.web.webview2.winforms)
 
 *  WinRT
-   * [Microsoft.Web.WebView2.Core](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index)
-   * [COM Interop/C++](/microsoft-edge/webview2/reference/winrt/interop/index)
+   * [Microsoft.Web.WebView2.Core](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index) - Common to all WinRT frameworks.
+   * [COM Interop/C++](/microsoft-edge/webview2/reference/winrt/interop/index) - Common to all WinRT frameworks.
    *  WinUI 2 (UWP)
       * [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/winui/api/microsoft.ui.xaml.controls.webview2)
    *  WinUI 3 (Windows App SDK)


### PR DESCRIPTION
To review, check the TOC > Reference > WinRT and the top-level Reference page:
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/webview2-api-reference?branch=pr-en-us-2094