### PR TITLE
Added Favicon API in browser features section

### DIFF
--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -723,7 +723,7 @@ In WebView2 you can you can set a [Favicon](https://developer.mozilla.org/en-US/
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.FaviconChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1293.44&preserve-view=true#faviconchanged)
+* [CoreWebView2.FaviconChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#faviconchanged)
 * [CoreWebView2.FaviconUri Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1293.44&preserve-view=true#faviconuri)
 
 ##### [Win32/C++](#tab/win32cpp)

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -719,7 +719,7 @@ In WebView2 you can you can set a [Favicon](https://developer.mozilla.org/en-US/
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2.FaviconChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconchanged?view=webview2-dotnet-1.0.1293.44&preserve-view=true)
-* [CoreWebView2.FaviconUri Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconuri?view=webview2-dotnet-1.0.1293.44&preserve-view=true)
+* [CoreWebView2.FaviconUri Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconuri)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -718,18 +718,18 @@ In WebView2 you can you can set a [Favicon](https://developer.mozilla.org/en-US/
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.FaviconChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconchanged?view=webview2-dotnet-1.0.1293.44&preserve-view=true)
+* [CoreWebView2.FaviconChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconchanged)
 * [CoreWebView2.FaviconUri Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconuri)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2.FaviconChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#faviconchanged)
-* [CoreWebView2.FaviconUri Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1293.44&preserve-view=true#faviconuri)
+* [CoreWebView2.FaviconUri Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#faviconuri)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_15::FaviconChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1293.44&preserve-view=true#add_faviconchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1293.44&preserve-view=true#remove_faviconchanged)
-* [ICoreWebView2_15::FaviconUri property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1293.44&preserve-view=true#get_faviconuri)<!--no put-->
+* [ICoreWebView2_15::FaviconChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_15#add_faviconchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_15#remove_faviconchanged)
+* [ICoreWebView2_15::FaviconUri property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_15#get_faviconuri)<!--no put-->
 
 ----
 

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -563,30 +563,6 @@ This feature is currently disabled by default in the browser.  To enable this fe
 
 ---
 
-
-<!-- ------------------------------ -->
-#### Document title
-
-Your app can detect when the title of the current top-level document has changed.
-
-##### [.NET/C#](#tab/dotnetcsharp)
-
-* [CoreWebView2.DocumentTitle Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitle)
-* [CoreWebView2.DocumentTitleChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitlechanged)
-
-##### [WinRT/C#](#tab/winrtcsharp)
-
-* [CoreWebView2.DocumentTitle Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitle)
-* [CoreWebView2.DocumentTitleChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitlechanged)
-
-##### [Win32/C++](#tab/win32cpp)
-
-* [ICoreWebView2::DocumentTitle property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_documenttitle)<!--no put-->
-* [ICoreWebView2::DocumentTitleChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_documenttitlechanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_documenttitlechanged)
-
----
-
-
 <!-- ------------------------------ -->
 #### Fullscreen
 
@@ -691,7 +667,6 @@ WebView2 provides functionality to handle the JavaScript function `window.open()
 
 ---
 
-
 <!-- ------------------------------ -->
 #### Close window
 
@@ -714,6 +689,49 @@ WebView2 provides functionality to handle the JavaScript function `window.close(
 
 ---
 
+<!-- ------------------------------ -->
+#### Document title
+
+Your app can detect when the title of the current top-level document has changed.
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2.DocumentTitle Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitle)
+* [CoreWebView2.DocumentTitleChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitlechanged)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2.DocumentTitle Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitle)
+* [CoreWebView2.DocumentTitleChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitlechanged)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2::DocumentTitle property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_documenttitle)<!--no put-->
+* [ICoreWebView2::DocumentTitleChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_documenttitlechanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_documenttitlechanged)
+
+---
+
+<!-- ------------------------------ -->
+#### Favicon 
+
+In WebView2 you can you can set a [Favicon](https://developer.mozilla.org/en-US/docs/Glossary/Favicon) for a website or get notified when it changes. 
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2.FaviconChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconchanged?view=webview2-dotnet-1.0.1293.44&preserve-view=true)
+* [CoreWebView2.FaviconUri Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconuri?view=webview2-dotnet-1.0.1293.44&preserve-view=true)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2.FaviconChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1293.44&preserve-view=true#faviconchanged)
+* [CoreWebView2.FaviconUri Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1293.44&preserve-view=true#faviconuri)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2_15::FaviconChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1293.44&preserve-view=true#add_faviconchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1293.44&preserve-view=true#remove_faviconchanged)
+* [ICoreWebView2_15::FaviconUri property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_15?view=webview2-1.0.1293.44&preserve-view=true#get_faviconuri)<!--no put-->
+
+----
 
 <!-- ====================================================================== -->
 ## Process management


### PR DESCRIPTION
The Favicon API was promoted to stable in SDK version 1.0.1293.44

**Rendered article sections for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/overview-features-apis?branch=pr-en-us-2126&tabs=dotnetcsharp#document-title
and favicon section below it