### PR TITLE
WebView2 in WinUI 2 is no longer in preview

### DIFF
--- a/microsoft-edge/webview2/index.md
+++ b/microsoft-edge/webview2/index.md
@@ -74,8 +74,8 @@ A General Availability (GA) or Preview version of WebView2 is available for the 
 *  .NET Core 3.1 or later
 *  .NET 5
 *  .NET 6
-*  [WinUI 2.0](/uwp/toolkits/winui2/index)
-*  [WinUI 3.0](/uwp/toolkits/winui3/index)
+*  [WinUI 2.0](/windows/apps/winui/winui2/)
+*  [WinUI 3.0](/windows/apps/winui/winui3/)
 
 WebView2 apps can run on the following versions of Windows:
 

--- a/microsoft-edge/webview2/index.md
+++ b/microsoft-edge/webview2/index.md
@@ -74,7 +74,7 @@ The following programming environments are supported:
 *  .NET Core 3.1 or later
 *  .NET 5
 *  .NET 6
-*  [WinUI 2.0](/windows/apps/winui/winui3/)
+*  [WinUI 2.0](/windows/apps/winui/winui2/)
 *  [WinUI 3.0](/windows/apps/winui/winui3/)
 
 WebView2 apps can run on the following versions of Windows:

--- a/microsoft-edge/webview2/index.md
+++ b/microsoft-edge/webview2/index.md
@@ -55,7 +55,7 @@ Hybrid apps, in the middle of this spectrum, allow you to enjoy the best of both
 
 *  **Code-sharing**.  Add web code to your codebase allows for increased reuse across multiple platforms.
 
-*  **Microsoft support**.  Microsoft provides support and adds new feature requests when WebView2 releases at General Availability (GA).
+*  **Microsoft support**.  Microsoft provides support and adds new feature requests when WebView2 releases at General Availability.
 
 *  **Evergreen distribution**.  Rely on an up-to-date version of Chromium with regular platform updates and security patches.
 
@@ -67,14 +67,14 @@ Hybrid apps, in the middle of this spectrum, allow you to enjoy the best of both
 <!-- ====================================================================== -->
 ## Supported platforms
 
-A General Availability (GA) or Preview version of WebView2 is available for the following programming environments:
+The following programming environments are supported:
 
-*  Win32 C/C++ (GA)
+*  Win32 C/C++
 *  .NET Framework 4.5 or later
 *  .NET Core 3.1 or later
 *  .NET 5
 *  .NET 6
-*  [WinUI 2.0](/windows/apps/winui/winui2/)
+*  [WinUI 2.0](/windows/apps/winui/winui3/)
 *  [WinUI 3.0](/windows/apps/winui/winui3/)
 
 WebView2 apps can run on the following versions of Windows:

--- a/microsoft-edge/webview2/index.md
+++ b/microsoft-edge/webview2/index.md
@@ -55,7 +55,7 @@ Hybrid apps, in the middle of this spectrum, allow you to enjoy the best of both
 
 *  **Code-sharing**.  Add web code to your codebase allows for increased reuse across multiple platforms.
 
-*  **Microsoft support**.  Microsoft provides support and adds new feature requests when WebView2 releases at General Availability.
+*  **Microsoft support**.  Microsoft provides support and adds new feature requests on supported platforms.
 
 *  **Evergreen distribution**.  Rely on an up-to-date version of Chromium with regular platform updates and security patches.
 

--- a/microsoft-edge/webview2/index.md
+++ b/microsoft-edge/webview2/index.md
@@ -74,7 +74,7 @@ A General Availability (GA) or Preview version of WebView2 is available for the 
 *  .NET Core 3.1 or later
 *  .NET 5
 *  .NET 6
-*  WinUI 2.0 (Preview)
+*  [WinUI 2.0](/uwp/toolkits/winui2/index)
 *  [WinUI 3.0](/uwp/toolkits/winui3/index)
 
 WebView2 apps can run on the following versions of Windows:


### PR DESCRIPTION
I'm not sure if that link is right, I'm never sure about relative links in the docs. But:
* WebView2 in WinUI 2 is no longer in preview
* The WinUI 3 link goes to https://docs.microsoft.com/en-us/windows/apps/winui/winui3/
* The WinUI 2 link should probably go to https://docs.microsoft.com/en-us/windows/apps/winui/winui2/

WebView2 in WinUI 2 has GA'ed. Has it on all the listed environments? Should we remove the "(GA)" from Win32 C/C++?

**Rendered article section for review:**
https://review.docs.microsoft.com/en-us/microsoft-edge/webview2/?branch=pr-en-us-2130#supported-platforms