### PR TITLE
Show Sensors is listed as a Drawer (not Panel)

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/device-mode/geolocation.md
+++ b/microsoft-edge/devtools-guide-chromium/device-mode/geolocation.md
@@ -32,7 +32,7 @@ If you are building a UI that changes depending on where the user is located, yo
 
    ![The Command Menu.](../media/device-mode-console-command-menu.msft.png)
 
-1. Type `sensors`, select **Panel: Show Sensors**, and then press `Enter`.  The **Sensors** tool opens at the bottom of the DevTools window.
+1. Type `sensors`, select **Drawer: Show Sensors**, and then press `Enter`.  The **Sensors** tool opens at the bottom of the DevTools window.
 
 1. Click the **Location** dropdown list, and then:
    *  Select a city, such as `Tokyo`.


### PR DESCRIPTION
It would be useful to use a screenshot of the command menu illustrating the "Show Sensors" option, just like below,

<img width="952" alt="image" src="https://user-images.githubusercontent.com/38640616/190853706-642defab-7e9e-405d-bda4-7861d5d35b9f.png">
