### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you are a Microsoft Employee, follow the internal guidance.
 
 To suggest a change to the docs:
 
-1.  If you are viewing the [Microsoft Edge documentation](https://docs.microsoft.com/microsoft-edge) page, click the **Edit** button in the upper right of the page.  You are redirected to the corresponding Markdown source file in the [GitHub repository](https://github.com/MicrosoftDocs/edge-developer).  If you are already in the GitHub repo, navigate to the source file that you are changing.
+1.  If you are viewing the [Microsoft Edge documentation](https://learn.microsoft.com/microsoft-edge) page, click the **Edit** button in the upper right of the page.  You are redirected to the corresponding Markdown source file in the [GitHub repository](https://github.com/MicrosoftDocs/edge-developer).  If you are already in the GitHub repo, navigate to the source file that you are changing.
 
 1.  If you don't already have a GitHub account, click **Sign Up** in the upper-right corner and create a new account.
 
@@ -26,7 +26,7 @@ To suggest a change to the docs:
 
 1.  When you are done, commit your changes and open a pull request.
 
-After you create the pull request, the Microsoft Edge Developer Docs team reviews it.  If your pull request is approved, updates are published to [Microsoft Edge Developer documentation](https://docs.microsoft.com/microsoft-edge/developer/).
+After you create the pull request, the Microsoft Edge Developer Docs team reviews it.  If your pull request is approved, updates are published to [Microsoft Edge Developer documentation](https://learn.microsoft.com/microsoft-edge/developer/).
 
 
 <!-- ====================================================================== -->
@@ -77,7 +77,7 @@ When you are happy with your changes and ready to submit a PR:
 
 1.  Click the green **Create pull request** button.  Give your Pull Request a title and description, then click the **Create pull request** button again.
 
-1.  After pushing your contribution to the remote repo, you receive an email from **Open Publishing Build Service** indicating whether your commit built successfully.  The email contains links to any errors or warnings, such as broken links.  Click the **View** links to see your content staged on the `review.docs.microsoft.com` site.
+1.  After pushing your contribution to the remote repo, you receive an email from **Open Publishing Build Service** indicating whether your commit built successfully.  The email contains links to any errors or warnings, such as broken links.  Click the **View** links to see your content staged on the `review.learn.microsoft.com` site.
 
 1.  After your PR is submitted, the Microsoft Edge Developer Docs team reviews the PR, approves the PR, merges the PR into the `main` branch, and then merges the PR's commits into the `live` branch.
 
@@ -92,7 +92,7 @@ The [Microsoft Edge Docs GitHub repository](https://github.com/MicrosoftDocs/edg
 | Branch  | Details  |
 |:--- |:--- |
 | [main](https://github.com/MicrosoftDocs/edge-developer/tree/main)  | The content in the `main` branch has been internally reviewed. |
-| [live](https://github.com/MicrosoftDocs/edge-developer/tree/live)  |  The content in the `live` branch has been published on the [live site](https://docs.microsoft.com/microsoft-edge). |
+| [live](https://github.com/MicrosoftDocs/edge-developer/tree/live)  |  The content in the `live` branch has been published on the [live site](https://learn.microsoft.com/microsoft-edge). |
 
 The series of branches is as follows:
 
@@ -110,7 +110,7 @@ The series of branches is as follows:
 
 1. The Microsoft Edge Developer Docs team merges commits from the `main` branch into the `live` branch of the `edge-developer` repo.
 
-1. The build process publishes the PR's commits at the public site, [Microsoft Edge Developer documentation](https://docs.microsoft.com/microsoft-edge/developer/).
+1. The build process publishes the PR's commits at the public site, [Microsoft Edge Developer documentation](https://learn.microsoft.com/microsoft-edge/developer/).
 
 
 <!-- ====================================================================== -->
@@ -125,5 +125,5 @@ Be sure to include the topic title and the URL for the page.
 ## See also
 
 *  [Getting started with writing and formatting on GitHub](https://help.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github)
-*  [Docs Contributor Guide](https://docs.microsoft.com/contribute/)
+*  [Docs Contributor Guide](https://learn.microsoft.com/contribute/)
 *  [README](README.md)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Microsoft and any contributors reserve all others rights, whether under their re
 <!-- ====================================================================== -->
 ## Contributing
 
-This repo, `edge-developer`, is the repository for the source Markdown files for the Microsoft Edge Developer documentation.  The resulting rendered documentation is hosted at [Microsoft Edge documentation](https://docs.microsoft.com/microsoft-edge/developer/).  This repo also includes the hub page for the Microsoft Edge Enterprise documentation and the Microsoft Edge Developer documentation.  The source files for the Microsoft Edge Enterprise documentation aren't in this repo, but are in the [Edge-Enterprise](https://github.com/MicrosoftDocs/Edge-Enterprise) repo.
+This repo, `edge-developer`, is the repository for the source Markdown files for the Microsoft Edge Developer documentation.  The resulting rendered documentation is hosted at [Microsoft Edge documentation](https://learn.microsoft.com/microsoft-edge/developer/).  This repo also includes the hub page for the Microsoft Edge Enterprise documentation and the Microsoft Edge Developer documentation.  The source files for the Microsoft Edge Enterprise documentation aren't in this repo, but are in the [Edge-Enterprise](https://github.com/MicrosoftDocs/Edge-Enterprise) repo.
 
 If you want to include new coverage or have feedback, consider [contributing](CONTRIBUTING.md).  You can edit the existing content, add new content, or report new [issues](https://github.com/MicrosoftDocs/edge-developer/issues).  The Microsoft Edge team reviews a look at your suggestions and works to incorporate the suggestions into the docs.
 
@@ -35,14 +35,14 @@ For the latest implementation status and future plans for web platform features 
 
 *  A directory can contain more directories or `readme.md` files.
 
-*  Folder/directory names are dash-separated (for example, `f12-tools`) and lowercase.  Directories are used in URLs on the `docs.microsoft.com` site.  Avoid using underscores, PascalCase, or camelCase.
+*  Folder/directory names are dash-separated (for example, `f12-tools`) and lowercase.  Directories are used in URLs on the `learn.microsoft.com` site.  Avoid using underscores, PascalCase, or camelCase.
 
 
 <!-- ====================================================================== -->
 ## Markdown tagging
 
 * [Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) - GitHub Flavored Markdown, in _GitHub Docs_.
-* [Docs Markdown reference](https://docs.microsoft.com/contribute/markdown-reference) - in _Docs Contributor Guide_.
+* [Docs Markdown reference](https://learn.microsoft.com/contribute/markdown-reference) - in _Docs Contributor Guide_.
 
 
 ### Images

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -40,7 +40,7 @@ landingContent:
 # Number of linkListType in a card: 1-6
 # Number of links in a linkListType: 1-10
 
-# https://review.docs.microsoft.com/help/contribute/contribute-how-to-write-landing-page?branch=main
+# https://review.learn.microsoft.com/help/contribute/contribute-how-to-write-landing-page?branch=main
 
 # =============================================================================
 # Row 1 with 3 cards

--- a/microsoft-edge/devtools-guide-chromium/about-tools.md
+++ b/microsoft-edge/devtools-guide-chromium/about-tools.md
@@ -72,7 +72,7 @@ Microsoft Edge DevTools includes the following tools.
 
 <!-- when no longer experimental, move into table:
 | **CSP Violations** tool | Displays any Content Security Policy (CSP) violations that are detected on the inspected webpage. | [CSP Violations tool](csp-violations/csp-violations-tool.md) |
-https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/experimental-features/#show-csp-violations-view
+https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/experimental-features/#show-csp-violations-view
 -->
 
 

--- a/microsoft-edge/devtools-guide-chromium/console/console-dom-interaction.md
+++ b/microsoft-edge/devtools-guide-chromium/console/console-dom-interaction.md
@@ -154,7 +154,7 @@ The `$` has special powers in **Console**, and you may remember that from jQuery
    $$('a').map(a => {
       return {text: a.innerText, url: a.href}
    }).filter(a => {
-      return a.text !== '' && !a.url.match('docs.microsoft.com')
+      return a.text !== '' && !a.url.match('learn.microsoft.com')
    })
    ```
 

--- a/microsoft-edge/devtools-guide-chromium/console/index.md
+++ b/microsoft-edge/devtools-guide-chromium/console/index.md
@@ -47,7 +47,7 @@ Search the web for your **Console** error messages, right from within DevTools. 
 
 ![The 'Search for this message on the Web' button on an error message in the Console.](../media/search-console-icon.msft.png)
 <!-- to set up screenshot, went to 
-https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/console/console-debug-javascript to get a good page that has an error: 
+https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/console/console-debug-javascript to get a good page that has an error: 
 https://microsoftedge.github.io/Demos/devtools-console/error.html -->
 
 When you click the **Search for this message on the Web** button, a new tab opens in the browser and shows search results for the error message:

--- a/microsoft-edge/devtools-guide-chromium/css/css-in-js.md
+++ b/microsoft-edge/devtools-guide-chromium/css/css-in-js.md
@@ -48,7 +48,7 @@ This feature is available starting with Microsoft Edge version 93. <!-- delete s
 <!-- ====================================================================== -->
 ## Editing style rules that were initially defined by a CSSOM function
 
-<!-- from https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/whats-new/2020/06/devtools#style-editing-for-css-in-js-frameworks -->
+<!-- from https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/whats-new/2020/06/devtools#style-editing-for-css-in-js-frameworks -->
 
 The **Styles** pane supports editing styles that were created with the [CSS Object Model (CSSOM)](https://drafts.csswg.org/cssom) APIs.  Many CSS-in-JS frameworks and libraries use the CSS Object Model APIs under the hood to construct styles.
 

--- a/microsoft-edge/devtools-guide-chromium/css/reference.md
+++ b/microsoft-edge/devtools-guide-chromium/css/reference.md
@@ -56,8 +56,8 @@ If the stylesheet is minified, click the **Format** (![Format.](../media/format-
 
 <!-- todo: delete /en-us ? 2x -->
 In the following figure, after you click
-`https://docs.microsoft.com/_themes/docs.theme/master/en-us/_themes/styles/b66bc881.site-ltr.css:2`<!-- :2 at end causes not to work. --> you are taken to line 2 of
-`https://docs.microsoft.com/_themes/docs.theme/master/en-us/_themes/styles/b66bc881.site-ltr.css`, where the `.content h1:first-of-type` CSS rule is defined.<!-- master kind of works but all lines are concated.  changing master to main doesn't work -->
+`https://learn.microsoft.com/_themes/docs.theme/master/en-us/_themes/styles/b66bc881.site-ltr.css:2`<!-- :2 at end causes not to work. --> you are taken to line 2 of
+`https://learn.microsoft.com/_themes/docs.theme/master/en-us/_themes/styles/b66bc881.site-ltr.css`, where the `.content h1:first-of-type` CSS rule is defined.<!-- master kind of works but all lines are concated.  changing master to main doesn't work -->
 
 ![Viewing the stylesheet where a rule is defined.](../media/css-elements-styles-h1-highlight.msft.png)
 

--- a/microsoft-edge/devtools-guide-chromium/inspect-styles/animations.md
+++ b/microsoft-edge/devtools-guide-chromium/inspect-styles/animations.md
@@ -86,7 +86,7 @@ To capture an animation, just perform the interaction that triggers the animatio
 
 <!--  old link: <video src="animations/capture-animations.mp4" autoplay loop muted controls></video>  -->
 
-<!--  import the video to ACOM using https://review.docs.microsoft.com/help/contribute/contribute-video-publish  -->
+<!--  import the video to ACOM using https://review.learn.microsoft.com/help/contribute/contribute-video-publish  -->
 
 <!--  > [!VIDEO animations/capture-animations.mp4]  -->
 

--- a/microsoft-edge/devtools-guide-chromium/memory-inspector/memory-inspector-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-inspector/memory-inspector-tool.md
@@ -41,7 +41,7 @@ The **Memory Inspector** tool provides greater ability than the **Sources** tool
 ![Sources tool scope panel provides limited ability to inspect memory](../media/memory-inspector-sources-scope-limited-ability.png)
 
 <!-- this page's initial content was from
-https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/whats-new/2021/04/devtools#new-memory-inspector-tool
+https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/whats-new/2021/04/devtools#new-memory-inspector-tool
 -->
 
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2020/08/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2020/08/devtools.md
@@ -147,7 +147,7 @@ To meet your translation needs, the Microsoft Edge DevTools team is focused on i
 The current effort to improve translation quality enables easier support for more languages in the future.
 
 See also:
-* [Change DevTools language settings](https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/customize/localization)
+* [Change DevTools language settings](https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/customize/localization)
 -->
 
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2020/11/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2020/11/devtools.md
@@ -343,7 +343,7 @@ See also:
 <!-- ====================================================================== -->
 #### Display opener frame details for opened windows
 
-DevTools now organizes opened [Windows](https://developer.mozilla.org/docs/Web/API/Window#Constructors) under the relevant parent [frame](https://developer.mozilla.org/docs/Web/API/Window/frames).  For example, if the `top` frame opens a `Window` to `https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium`, then the `Window` appears under `top` in the **Frames** list.
+DevTools now organizes opened [Windows](https://developer.mozilla.org/docs/Web/API/Window#Constructors) under the relevant parent [frame](https://developer.mozilla.org/docs/Web/API/Window/frames).  For example, if the `top` frame opens a `Window` to `https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium`, then the `Window` appears under `top` in the **Frames** list.
 
 To reveal the frame that's responsible for opening another Window, and see that frame in the **Elements** tool:
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2021/02/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2021/02/devtools.md
@@ -258,7 +258,7 @@ For the history of this feature in the Chromium open-source project, see Issues 
 See also:
 * [Application tool, to manage storage](../../../storage/application-tool.md)
 <!-- todo: the Application tool seems under-doc'd; contrast the TOC > Tools > Application tool vs. the left-side tree in the tool:
-https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/storage/application-tool -->
+https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/storage/application-tool -->
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-protocol-chromium/index.md
+++ b/microsoft-edge/devtools-protocol-chromium/index.md
@@ -155,11 +155,11 @@ None.
 [{
    "description": "",
     "devtoolsFrontendUrl": "http://172.17.75.195:80/msedge/7264/devtools/inspector.html?ws=172.17.75.195:80/msedge/7264/devtools/page/ED4FFDB4529723A0FAFCBDB9B45851BB",
-    "faviconUrl": "https://docs.microsoft.com/favicon.ico",
+    "faviconUrl": "https://learn.microsoft.com/favicon.ico",
     "id": "ED4FFDB4529723A0FAFCBDB9B45851BB",
     "title": "Get Started with Remote Debugging Windows Devices - Microsoft Edge Development | Microsoft Docs",
     "type": "page",
-    "url": "https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/remote-debugging/windows",
+    "url": "https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/remote-debugging/windows",
     "webSocketDebuggerUrl": "ws://172.17.75.195:80/msedge/7264/devtools/page/ED4FFDB4529723A0FAFCBDB9B45851BB",
     "browserProcessId": 7264
 }, ...  ]
@@ -187,11 +187,11 @@ None.
 [{
     "description": "",
     "devtoolsFrontendUrl": "http://172.17.75.195:80/msedge/7264/devtools/inspector.html?ws=172.17.75.195:80/msedge/7264/devtools/page/ED4FFDB4529723A0FAFCBDB9B45851BB",
-    "faviconUrl": "https://docs.microsoft.com/favicon.ico",
+    "faviconUrl": "https://learn.microsoft.com/favicon.ico",
     "id": "ED4FFDB4529723A0FAFCBDB9B45851BB",
     "title": "Get Started with Remote Debugging Windows Devices - Microsoft Edge Development | Microsoft Docs",
     "type": "page",
-    "url": "https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/remote-debugging/windows",
+    "url": "https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/remote-debugging/windows",
     "webSocketDebuggerUrl": "ws://172.17.75.195:80/msedge/7264/devtools/page/ED4FFDB4529723A0FAFCBDB9B45851BB"
 }, ...  ]
 ```

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -370,7 +370,7 @@
                   displayName: Coverage tool
 # CSP Violations --------------------------------------------------------------
             # - name: CSP Violations tool
-            #   https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/experimental-features/#show-csp-violations-view
+            #   https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/experimental-features/#show-csp-violations-view
             #   items:
             #     - name: Display Content Security Policy (CSP) violations
             #       href: devtools-guide-chromium/csp-violations/csp-violations-tool.md

--- a/microsoft-edge/webview2/concepts/user-data-folder.md
+++ b/microsoft-edge/webview2/concepts/user-data-folder.md
@@ -468,7 +468,7 @@ For examples of reading the `UserDataFolder` property, see the Win32 samples in 
 
 <!-- Use the .NET [CoreWebView2Environment.UserDataFolder Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.userdatafolder). -->
 
-<!-- dev: add example code to https://docs.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2environment.userdatafolder showing how to read the `UserDataFolder` property, copy that from the below code block: -->
+<!-- dev: add example code to https://learn.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2environment.userdatafolder showing how to read the `UserDataFolder` property, copy that from the below code block: -->
 
 
 **Example code:**
@@ -687,4 +687,4 @@ Each WebView2 browser process consumes additional memory and disk space.  Theref
 * [ClickOnce security and deployment](/visualstudio/deployment/clickonce-security-and-deployment) - Visual Studio deployment documentation.
 * [Understand the ClickOnce and DirectInvoke features in Microsoft Edge](/deployedge/edge-learn-more-co-di) - in Microsoft Edge Enterprise documentation.
 
-<!-- clickable: https://docs.microsoft.com/windows/apps/package-and-deploy/ -->
+<!-- clickable: https://learn.microsoft.com/windows/apps/package-and-deploy/ -->

--- a/microsoft-edge/webview2/get-started/winui.md
+++ b/microsoft-edge/webview2/get-started/winui.md
@@ -34,7 +34,7 @@ The present tutorial is updated and only creates a single project, not a second,
 Even if you have Visual Studio installed, read the following page and possibly update your software and install project templates.
 
 1.  In a new window or tab, open the page [Install tools for the Windows App SDK](/windows/apps/windows-app-sdk/set-up-your-development-environment) and then follow the steps on that page, to install Microsoft Visual Studio, such as Visual Studio 2022.
-<!-- clickable: https://docs.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment -->
+<!-- clickable: https://learn.microsoft.com/windows/apps/windows-app-sdk/set-up-your-development-environment -->
 
 1.  If needed, in a new window or tab, see [Install Visual Studio](../how-to/machine-setup.md#install-visual-studio) in _Set up your Dev environment for WebView2_.
 

--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -43,7 +43,7 @@ Follow the major Step sections in sequence, below.
 ## Step 1 - Install Visual Studio
 
 Visual Studio 2019 version 16.9 or later is required, for this tutorial.  Visual Studio 2022 is supported.  Visual Studio 2017 isn't supported.
-<!-- https://docs.microsoft.com/visualstudio/releases/2019/release-notes-v16.9 -->
+<!-- https://learn.microsoft.com/visualstudio/releases/2019/release-notes-v16.9 -->
 
 1. If a suitable version of Microsoft Visual Studio isn't installed already, in a new window or tab, see [Install Visual Studio](../how-to/machine-setup.md#install-visual-studio) in _Set up your Dev environment for WebView2_.  Follow the steps in that page to do a basic default installation of Visual Studio.
 

--- a/microsoft-edge/webview2/how-to/publish-uwp-app-store.md
+++ b/microsoft-edge/webview2/how-to/publish-uwp-app-store.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Publish a UWP WebView2 app to the Microsoft Store
 description: How to publish a Universal Windows Platform (UWP) app that hosts the WebView2 control to the Microsoft Store.
 author: MSEdgeTeam
@@ -70,7 +70,7 @@ To make sure that all required content files are present in the package, and to 
 <!-- ====================================================================== -->
 ## Step 5: Run Windows App Certification Kit (WACK)
 
-<!-- * [Windows App Certification Kit](https://docs.microsoft.com/windows/uwp/debug-test-perf/windows-app-certification-kit) -->
+<!-- * [Windows App Certification Kit](https://learn.microsoft.com/windows/uwp/debug-test-perf/windows-app-certification-kit) -->
 
 Windows App Certification Kit (WACK) is an app that's a certification tool.  This tool evaluates your host app against the Microsoft Store's requirements.
 


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
