### PR TITLE
Removes broken external link in Performance Tool section

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/rendering-tools/index.md
+++ b/microsoft-edge/devtools-guide-chromium/rendering-tools/index.md
@@ -87,7 +87,7 @@ Select a `Recalculate Style` event to view more information about it in the **De
 
 ![Long recalculate style.](../media/rendering-tools-performance-recalculate-style-summary.msft.png)
 
-To reduce the impact of `Recalculate Style` events, minimize use of CSS properties that trigger layout, paint, and composite.  These properties have the worst impact on rendering performance.
+To reduce the impact of `Recalculate Style` events, minimize use of CSS properties that trigger layout, paint, and composite.  These properties have the worst impact on rendering performance.  For more information, see [Stick to Compositor-Only Properties and Manage Layer Count](https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/)
 
 <!--todo: add Stick to compositor-only properties and manage layer count section when available -->
 

--- a/microsoft-edge/devtools-guide-chromium/rendering-tools/index.md
+++ b/microsoft-edge/devtools-guide-chromium/rendering-tools/index.md
@@ -87,7 +87,7 @@ Select a `Recalculate Style` event to view more information about it in the **De
 
 ![Long recalculate style.](../media/rendering-tools-performance-recalculate-style-summary.msft.png)
 
-To reduce the impact of `Recalculate Style` events, minimize use of CSS properties that trigger layout, paint, and composite.  These properties have the worst impact on rendering performance.  For more information, see [Stick to Compositor-Only Properties and Manage Layer Count](https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/)
+To reduce the impact of `Recalculate Style` events, minimize use of CSS properties that trigger layout, paint, and composite.  These properties have the greatest impact on rendering performance.  For more information, see [Stick to Compositor-Only Properties and Manage Layer Count](https://web.dev/stick-to-compositor-only-properties-and-manage-layer-count/)
 
 <!--todo: add Stick to compositor-only properties and manage layer count section when available -->
 

--- a/microsoft-edge/devtools-guide-chromium/rendering-tools/index.md
+++ b/microsoft-edge/devtools-guide-chromium/rendering-tools/index.md
@@ -87,10 +87,7 @@ Select a `Recalculate Style` event to view more information about it in the **De
 
 ![Long recalculate style.](../media/rendering-tools-performance-recalculate-style-summary.msft.png)
 
-To reduce the impact of `Recalculate Style` events:
-
-*  Use the [CSS Triggers](https://csstriggers.com) to learn which CSS properties trigger layout, paint, and composite.  These properties have the worst impact on rendering performance.
-*  Switch to properties that have less impact.  <!--For more guidance, See [Stick to compositor-only properties and manage layer count](/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count).  -->
+To reduce the impact of `Recalculate Style` events, minimize use of CSS properties that trigger layout, paint, and composite.  These properties have the worst impact on rendering performance.
 
 <!--todo: add Stick to compositor-only properties and manage layer count section when available -->
 


### PR DESCRIPTION
The external site listed as a reference for information on CSS properties no longer appears to be online. Section containing it has been modified accordingly.