### PR TITLE
Including support for Windows Server 2022

### DIFF
--- a/microsoft-edge/webview2/index.md
+++ b/microsoft-edge/webview2/index.md
@@ -86,6 +86,7 @@ WebView2 apps can run on the following versions of Windows:
 *  Windows 10 IoT Enterprise 21h1 x64
 *  Windows 8.1
 *  Windows 7 \*\*
+*  Windows Server 2022
 *  Windows Server 2019
 *  Windows Server 2016
 *  Windows Server 2012


### PR DESCRIPTION
In response to the following issue: https://github.com/MicrosoftEdge/WebView2Feedback/issues/2279. The WebView2Samples repo was cloned and tested on a Windows Server 2022 VM. After performing smoke tests and Sanity Checks successfully, we concluded that Webview2 is supported on that platform.