### PR TITLE
New article "Use multiple targets with Chrome DevTools Protocol (CDP)"

### DIFF
--- a/microsoft-edge/devtools-protocol-chromium/index.md
+++ b/microsoft-edge/devtools-protocol-chromium/index.md
@@ -237,4 +237,6 @@ JSON object which represents the available API surface for the version of the pr
 <!-- ====================================================================== -->
 ## See also
 
-* [Use the Chrome DevTools Protocol in WebView2 apps](../webview2/how-to/chromium-devtools-protocol.md)
+* [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
+* [Chrome DevTools Protocol (CDP)](../concepts/overview-features-apis.md#chrome-devtools-protocol-cdp) in _Overview of WebView2 features and APIs_
+* [Use the Chrome DevTools Protocol (CDP) in WebView2 apps](../webview2/how-to/chromium-devtools-protocol.md)

--- a/microsoft-edge/puppeteer/index.md
+++ b/microsoft-edge/puppeteer/index.md
@@ -103,15 +103,36 @@ The preceding example demonstrates basic automation and testing scenarios that y
 <!-- ====================================================================== -->
 ## See also
 
-*  [WebDriver](../webdriver-chromium/index.md)
-*  [WebDriver (EdgeHTML)](/archive/microsoft-edge/legacy/developer/webdriver/index)
-*  [Chrome DevTools Protocol Viewer on GitHub](https://chromedevtools.github.io/devtools-protocol)
-*  [Microsoft Edge:  Making the web better through more open source collaboration on Microsoft Experience Blog](https://blogs.windows.com/windowsexperience/2018/12/06/microsoft-edge-making-the-web-better-through-more-open-source-collaboration)
-*  [Download Microsoft Edge Insider Channels](https://www.microsoftedgeinsider.com/download)
-*  [Chromium on The Chromium Projects](https://www.chromium.org/Home)
-*  [Node.js](https://nodejs.org)
-*  [Puppeteer](https://pptr.dev)
-*  [puppeteer vs. puppeteer-core](https://pptr.dev/#?product=Puppeteer&version=v2.0.0&show=api-puppeteer-vs-puppeteer-core)
-*  [page.setViewport() on Puppeteer](https://pptr.dev/#?product=Puppeteer&version=v2.0.0&show=api-pagesetviewportviewport)
-*  [Headless browser on Wikipedia](https://en.wikipedia.org/wiki/Headless_browser)
-*  [Contact the Microsoft Edge DevTools team](../devtools-guide-chromium/contact.md) to send feedback about using Puppeteer, puppeteer-core, and Microsoft Edge.
+<!-- TODO: thin out? -->
+
+#### Local articles
+
+* [WebDriver](../webdriver-chromium/index.md)
+* [Contact the Microsoft Edge DevTools team](../devtools-guide-chromium/contact.md) to send feedback about using Puppeteer, puppeteer-core, and Microsoft Edge.
+* [Chrome DevTools Protocol (CDP)](../concepts/overview-features-apis.md#chrome-devtools-protocol-cdp) in _Overview of WebView2 features and APIs_
+* [Use the Chrome DevTools Protocol (CDP) in WebView2 apps](../webview2/how-to/chromium-devtools-protocol.md)
+
+#### Archive
+
+* [WebDriver (EdgeHTML)](/archive/microsoft-edge/legacy/developer/webdriver/index)
+
+#### Blog posts
+
+* [Microsoft Edge:  Making the web better through more open source collaboration on Microsoft Experience Blog](https://blogs.windows.com/windowsexperience/2018/12/06/microsoft-edge-making-the-web-better-through-more-open-source-collaboration)
+
+#### Tools
+
+* [Download Microsoft Edge Insider Channels](https://www.microsoftedgeinsider.com/download)
+* [Chromium on The Chromium Projects](https://www.chromium.org/Home)
+* [Node.js](https://nodejs.org)
+* [Puppeteer](https://pptr.dev)
+* [puppeteer vs. puppeteer-core](https://pptr.dev/#?product=Puppeteer&version=v2.0.0&show=api-puppeteer-vs-puppeteer-core)
+* [page.setViewport() on Puppeteer](https://pptr.dev/#?product=Puppeteer&version=v2.0.0&show=api-pagesetviewportviewport)
+
+#### Protocols
+
+* [Chrome DevTools Protocol Viewer](https://chromedevtools.github.io/devtools-protocol)
+
+#### Info
+
+* [Headless browser on Wikipedia](https://en.wikipedia.org/wiki/Headless_browser)

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1208,9 +1208,13 @@
               href: webview2/how-to/context-menus.md
               displayName: right-click menu, Customize context menus in WebView2  # top-of-page title
 
-            - name: Use the Chrome DevTools Protocol
+            - name: Use the Chrome DevTools Protocol (CDP)
               href: webview2/how-to/chromium-devtools-protocol.md
-              displayName: Use the Chrome DevTools Protocol in WebView2  # old title
+              displayName: Use the Chrome DevTools Protocol in WebView2, chrome developer protocol  # old title & catch mis-type
+
+            - name: Use multiple targets with Chrome DevTools Protocol (CDP)
+              href: webview2/how-to/multiple-cdp-targets.md
+              displayName: 
 
             - name: Automate and test with Microsoft Edge WebDriver
               href: webview2/how-to/webdriver.md

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -27,7 +27,7 @@ When hosting the WebView2 control, your app has access to the following features
 | [Rendering WebView2 using Composition](#rendering-webview2-using-composition) | For composition-based WebView2 rendering, use `CoreWebView2Environment` to create a `CoreWebView2CompositionController`.  `CoreWebView2CompositionController` provides the same APIs as `CoreWebView2Controller`, but also includes APIs for composition-based rendering. |
 | [User data](#user-data) | Manage the user data folder (UDF), which is a folder on the user's machine.  The UDF contains data related to the host app and WebView2.  WebView2 apps use user data folders to store browser data, such as cookies, permissions, and cached resources. |
 | [Performance and debugging](#performance-and-debugging) | Analyze and debug performance, handle performance-related events, and manage memory usage to increase the responsiveness of your app. |
-| [Chrome Developer Protocol (CDP)](#chrome-developer-protocol-cdp) | Instrument, inspect, debug, and profile Chromium-based browsers.  The Chrome DevTools Protocol is the foundation for the Microsoft Edge DevTools.  Use the Chrome DevTools Protocol for features that aren't implemented in the WebView2 platform. |
+| [Chrome DevTools Protocol (CDP)](#chrome-devtools-protocol-cdp) | Instrument, inspect, debug, and profile Chromium-based browsers.  The Chrome DevTools Protocol (CDP) is the foundation for the Microsoft Edge DevTools.  Use the Chrome DevTools Protocol for features that aren't implemented in the WebView2 platform. |
 
 
 <!-- ====================================================================== -->
@@ -1531,7 +1531,7 @@ Analyze and debug performance, handle performance-related events, and manage mem
 
 
 <!-- ====================================================================== -->
-## Chrome Developer Protocol (CDP)
+## Chrome DevTools Protocol (CDP)
 
 The Chrome DevTools Protocol provides APIs to instrument, inspect, debug, and profile Chromium-based browsers.  The Chrome DevTools Protocol is the foundation for the Microsoft Edge DevTools.  Use the Chrome DevTools Protocol for features that aren't implemented in the WebView2 platform.
 

--- a/microsoft-edge/webview2/how-to/chromium-devtools-protocol.md
+++ b/microsoft-edge/webview2/how-to/chromium-devtools-protocol.md
@@ -184,3 +184,4 @@ The Chrome DevTools Protocol is maintained by the open source Chromium project, 
 
 * [Microsoft Edge DevTools Protocol overview](../../devtools-protocol-chromium/index.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples)
+* [Chrome DevTools Protocol (CDP)](../concepts/overview-features-apis.md#chrome-devtools-protocol-cdp) in _Overview of WebView2 features and APIs_

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -107,7 +107,7 @@ You might need to attach the debugger to running WebView2 processes.  To do that
 "useWebView": true
 ```
 
-Your WebView2 control must open the CDP port to allow debugging of the WebView2 control.  Your code must be built to ensure that only one WebView2 control has a Chrome Developer Protocol (CDP) port open, before starting the debugger.
+Your WebView2 control must open the CDP port to allow debugging of the WebView2 control.  Your code must be built to ensure that only one WebView2 control has a Chrome DevTools Protocol (CDP) port open, before starting the debugger.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/how-to/multiple-cdp-targets.md
+++ b/microsoft-edge/webview2/how-to/multiple-cdp-targets.md
@@ -1,0 +1,22 @@
+---
+title: Use multiple targets with Chrome DevTools Protocol (CDP)
+description: Use multiple targets with the Chrome DevTools Protocol (CDP) WebView2 extension.
+author: MSEdgeTeam
+ms.author: msedgedevrel
+ms.topic: conceptual
+ms.prod: microsoft-edge
+ms.technology: webview
+ms.date: 09/30/2022
+---
+# Use multiple targets with Chrome DevTools Protocol (CDP)
+
+tbd
+
+
+<!-- ====================================================================== -->
+## See also
+
+* [Chrome DevTools Protocol (CDP)](../concepts/overview-features-apis.md#chrome-devtools-protocol-cdp) in _Overview of WebView2 features and APIs_
+* [Use the Chrome DevTools Protocol (CDP) in WebView2 apps](../webview2/how-to/chromium-devtools-protocol.md)
+* [WPF sample app with CDP extension](../samples/wv2cdpextensionwpfsample.md)
+* [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)


### PR DESCRIPTION
**Rendered article for review:**
pending

This PR does the following:
*  Adds new article.
*  Changes "Developer" to "DevTools" in acronym expansion.
*  Cross-links CDP docs.