### PR TITLE
Move Manifest V3 to be the left, default tab

### DIFF
--- a/microsoft-edge/extensions-chromium/developer-guide/native-messaging.md
+++ b/microsoft-edge/extensions-chromium/developer-guide/native-messaging.md
@@ -33,7 +33,7 @@ The following is an example **manifest.json** file:
 {
     "name": "Native Messaging Example",
     "version": "1.0",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "description": "Send a message to a native app.",
     "app": {
         "launch": {

--- a/microsoft-edge/extensions-chromium/getting-started/part1-simple-extension.md
+++ b/microsoft-edge/extensions-chromium/getting-started/part1-simple-extension.md
@@ -29,17 +29,6 @@ Every extension package must have a `manifest.json` file at the root.  The manif
 
 The following code outlines the basic information needed in your `manifest.json` file:
 
-#### [Manifest V2](#tab/v2)
-
-```json
-{
-    "name": "NASA picture of the day viewer",
-    "version": "0.0.0.1",
-    "manifest_version": 2,
-    "description": "An extension to display the NASA picture of the day."
-}
-```
-
 #### [Manifest V3](#tab/v3)
 
 ```json
@@ -47,6 +36,17 @@ The following code outlines the basic information needed in your `manifest.json`
     "name": "NASA picture of the day viewer",
     "version": "0.0.0.1",
     "manifest_version": 3,
+    "description": "An extension to display the NASA picture of the day."
+}
+```
+
+#### [Manifest V2](#tab/v2)
+
+```json
+{
+    "name": "NASA picture of the day viewer",
+    "version": "0.0.0.1",
+    "manifest_version": 2,
     "description": "An extension to display the NASA picture of the day."
 }
 ```
@@ -79,13 +79,13 @@ The directories of your project should be similar to the following structure:
 
 Next, add the icons to the `manifest.json` file. Update your `manifest.json` file with the icons information so that it matches the following code. The `png` files listed in the following code are available in the download file mentioned earlier in this article.
 
-#### [Manifest V2](#tab/v2)
+#### [Manifest V3](#tab/v3)
 
 ```json
 {
     "name": "NASA picture of the day viewer",
     "version": "0.0.0.1",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "description": "An extension to display the NASA picture of the day.",
     "icons": {
         "16": "icons/nasapod16x16.png",
@@ -96,13 +96,13 @@ Next, add the icons to the `manifest.json` file. Update your `manifest.json` fil
 }
 ```
 
-#### [Manifest V3](#tab/v3)
+#### [Manifest V2](#tab/v2)
 
 ```json
 {
     "name": "NASA picture of the day viewer",
     "version": "0.0.0.1",
-    "manifest_version": 3,
+    "manifest_version": 2,
     "description": "An extension to display the NASA picture of the day.",
     "icons": {
         "16": "icons/nasapod16x16.png",
@@ -155,26 +155,6 @@ Ensure that you add the image file `images/stars.jpeg` to the images folder.  Th
 
 Finally, register the pop-up in `manifest.json` under `browser_action` (in Manifest V2) or under `action` (in Manifest V3), as shown in the following code:
 
-#### [Manifest V2](#tab/v2)
-
-```json
-{
-    "name": "NASA picture of the day viewer",
-    "version": "0.0.0.1",
-    "manifest_version": 2,
-    "description": "An extension to display the NASA picture of the day.",
-    "icons": {
-        "16": "icons/nasapod16x16.png",
-        "32": "icons/nasapod32x32.png",
-        "48": "icons/nasapod48x48.png",
-        "128": "icons/nasapod128x128.png"
-    },
-    "browser_action": {
-        "default_popup": "popup/popup.html"
-    }
-}
-```
-
 #### [Manifest V3](#tab/v3)
 
 ```json
@@ -190,6 +170,26 @@ Finally, register the pop-up in `manifest.json` under `browser_action` (in Manif
         "128": "icons/nasapod128x128.png"
     },
     "action": {
+        "default_popup": "popup/popup.html"
+    }
+}
+```
+
+#### [Manifest V2](#tab/v2)
+
+```json
+{
+    "name": "NASA picture of the day viewer",
+    "version": "0.0.0.1",
+    "manifest_version": 2,
+    "description": "An extension to display the NASA picture of the day.",
+    "icons": {
+        "16": "icons/nasapod16x16.png",
+        "32": "icons/nasapod32x32.png",
+        "48": "icons/nasapod48x48.png",
+        "128": "icons/nasapod128x128.png"
+    },
+    "browser_action": {
         "default_popup": "popup/popup.html"
     }
 }

--- a/microsoft-edge/extensions-chromium/getting-started/part2-content-scripts.md
+++ b/microsoft-edge/extensions-chromium/getting-started/part2-content-scripts.md
@@ -89,7 +89,7 @@ To send a unique ID to assign to the inserted image, a couple different approach
 
 The following code outlines the updated code in `popup/popup.js`.  You also pass in the current tab ID, which is used later in this article:
 
-#### [Manifest V2](#tab/v2)
+#### [Manifest V3](#tab/v3)
 
 ```javascript
 const sendMessageId = document.getElementById("sendmessageid");
@@ -99,7 +99,7 @@ if (sendMessageId) {
             chrome.tabs.sendMessage(
                 tabs[0].id,
                 {
-                    url: chrome.extension.getURL("images/stars.jpeg"),
+                    url: chrome.runtime.getURL("images/stars.jpeg"),
                     imageDivId: `${guidGenerator()}`,
                     tabId: tabs[0].id
                 },
@@ -118,7 +118,7 @@ if (sendMessageId) {
 }
 ```
 
-#### [Manifest V3](#tab/v3)
+#### [Manifest V2](#tab/v2)
 
 ```javascript
 const sendMessageId = document.getElementById("sendmessageid");
@@ -128,7 +128,7 @@ if (sendMessageId) {
             chrome.tabs.sendMessage(
                 tabs[0].id,
                 {
-                    url: chrome.runtime.getURL("images/stars.jpeg"),
+                    url: chrome.extension.getURL("images/stars.jpeg"),
                     imageDivId: `${guidGenerator()}`,
                     tabId: tabs[0].id
                 },
@@ -163,14 +163,6 @@ The reason is that you're injecting the image using the `src` attribute of the `
 
 Add another entry in the `manifest.json` file to declare that the image is available to all browser tabs.  That entry is as follows (you should see it in the full `manifest.json` file below when you add the content script declaration coming up):
 
-#### [Manifest V2](#tab/v2)
-
-```json
-"web_accessible_resources": [
-    "images/*.jpeg"
-]
-```
-
 #### [Manifest V3](#tab/v3)
 
 ```json
@@ -182,6 +174,14 @@ Add another entry in the `manifest.json` file to declare that the image is avail
   ]
 ```
 
+#### [Manifest V2](#tab/v2)
+
+```json
+"web_accessible_resources": [
+    "images/*.jpeg"
+]
+```
+
 ---
 
 You've now written the code in your `popup.js` file to send a message to the content page that is embedded on the current active tab page, but you haven't created and injected that content page.  Do that now.
@@ -191,37 +191,6 @@ You've now written the code in your `popup.js` file to send a message to the con
 ## Step 5: Update your `manifest.json` for content and web access
 
 The updated `manifest.json` that includes the `content-scripts` and `web_accessible_resources` is as follows:
-
-#### [Manifest V2](#tab/v2)
-
-```json
-{
-    "name": "NASA picture of the day viewer",
-    "version": "0.0.0.1",
-    "manifest_version": 2,
-    "description": "An extension to display the NASA picture of the day.",
-    "icons": {
-        "16": "icons/nasapod16x16.png",
-        "32": "icons/nasapod32x32.png",
-        "48": "icons/nasapod48x48.png",
-        "128": "icons/nasapod128x128.png"
-    },
-    "browser_action": {
-        "default_popup": "popup/popup.html"
-    },
-    "content_scripts": [
-        {
-            "matches": [
-              "<all_urls>"
-            ],
-            "js": ["lib/jquery.min.js","content-scripts/content.js"]
-        }
-    ],
-    "web_accessible_resources": [
-        "images/*.jpeg"
-    ]
-}
-```
 
 #### [Manifest V3](#tab/v3)
 
@@ -253,6 +222,37 @@ The updated `manifest.json` that includes the `content-scripts` and `web_accessi
             "resources": ["images/*.jpeg"],
             "matches": ["<all_urls>"]
         }
+    ]
+}
+```
+
+#### [Manifest V2](#tab/v2)
+
+```json
+{
+    "name": "NASA picture of the day viewer",
+    "version": "0.0.0.1",
+    "manifest_version": 2,
+    "description": "An extension to display the NASA picture of the day.",
+    "icons": {
+        "16": "icons/nasapod16x16.png",
+        "32": "icons/nasapod32x32.png",
+        "48": "icons/nasapod48x48.png",
+        "128": "icons/nasapod128x128.png"
+    },
+    "browser_action": {
+        "default_popup": "popup/popup.html"
+    },
+    "content_scripts": [
+        {
+            "matches": [
+              "<all_urls>"
+            ],
+            "js": ["lib/jquery.min.js","content-scripts/content.js"]
+        }
+    ],
+    "web_accessible_resources": [
+        "images/*.jpeg"
     ]
 }
 ```


### PR DESCRIPTION
**Rendered articles for review:**
https://review.learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/part1-simple-extension?branch=pr-en-us-2238
https://review.learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/part2-content-scripts?branch=pr-en-us-2238

**To review this PR:**
Click both tabs in each tab-set, make sure the left tab is V3 and is the default.
Make sure that tabs contain correct/expected info.  
Check all tab-sets in these two pages.

This PR fixes issue https://github.com/MicrosoftDocs/edge-developer/issues/2219.

Before:
https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/part1-simple-extension?tabs=v2#step-1-create-a-manifestjson-file