### PR TITLE
Fixed the case to represent the placeholder

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/css/reference.md
+++ b/microsoft-edge/devtools-guide-chromium/css/reference.md
@@ -274,7 +274,7 @@ To add a class to an element:
 
 1. Click **.cls**.
 
-1. Enter the name of the class in the **Add New Class** text box.
+1. Enter the name of the class in the **Add new class** text box.
 
 1. Press `Enter`.
 


### PR DESCRIPTION
I'm not sure what's the convention for representing placeholder text in documentations, but if it should match the case exactly, then you can merge this PR.