### PR TITLE
Removed dup index entries for "release notes" & "what's new"

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -28,113 +28,87 @@
 # What's New firstchild article
             - name: What's new in Microsoft Edge DevTools
               href: devtools-guide-chromium/whats-new/whats-new.md
-              displayName: release notes, announcements
+              displayName: what's new, release notes, announcements
 
 # What's New pages ------------------------------------------------------------
             # also add new pages to nav page: /whats-new/whats-new.md
             - name: Microsoft Edge 106
               href: devtools-guide-chromium/whats-new/2022/09/devtools-106.md
-              displayName: what's new
 
             - name: Microsoft Edge 105
               href: devtools-guide-chromium/whats-new/2022/09/devtools-105.md
-              displayName: what's new
 
             - name: Microsoft Edge 104
               href: devtools-guide-chromium/whats-new/2022/08/devtools-104.md
-              displayName: what's new
 
             - name: Microsoft Edge 103
               href: devtools-guide-chromium/whats-new/2022/06/devtools-103.md
-              displayName: what's new
 
             - name: Microsoft Edge 102
               href: devtools-guide-chromium/whats-new/2022/05/devtools-102.md
-              displayName: what's new
 
             - name: Microsoft Edge 101
               href: devtools-guide-chromium/whats-new/2022/04/devtools-101.md
-              displayName: what's new
 
             - name: Microsoft Edge 100
               href: devtools-guide-chromium/whats-new/2022/03/devtools-100.md
-              displayName: what's new
 
             - name: Microsoft Edge 99
               href: devtools-guide-chromium/whats-new/2022/03/devtools.md
-              displayName: what's new
 
             - name: Microsoft Edge 98
               href: devtools-guide-chromium/whats-new/2022/02/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 97
               href: devtools-guide-chromium/whats-new/2022/01/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 96
               href: devtools-guide-chromium/whats-new/2021/11/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 95
               href: devtools-guide-chromium/whats-new/2021/10/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 94
               href: devtools-guide-chromium/whats-new/2021/09/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 93
               href: devtools-guide-chromium/whats-new/2021/07/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 92
               href: devtools-guide-chromium/whats-new/2021/05/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 91
               href: devtools-guide-chromium/whats-new/2021/04/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 90
               href: devtools-guide-chromium/whats-new/2021/02/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 89
               href: devtools-guide-chromium/whats-new/2021/01/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 88
               href: devtools-guide-chromium/whats-new/2020/11/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 87
               href: devtools-guide-chromium/whats-new/2020/10/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 86
               href: devtools-guide-chromium/whats-new/2020/08/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 85
               href: devtools-guide-chromium/whats-new/2020/06/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 84
               href: devtools-guide-chromium/whats-new/2020/05/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 83
               href: devtools-guide-chromium/whats-new/2020/03/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 81
               href: devtools-guide-chromium/whats-new/2020/01/devtools.md
-              displayName: what's new, announcements
 
             - name: Microsoft Edge 80
               href: devtools-guide-chromium/whats-new/2019/12/devtools.md
-              displayName: what's new, announcements
 
 # Experimental features ------------------------------------------------------------------
         - name: Experimental features

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -28,41 +28,41 @@
 # What's New firstchild article
             - name: What's new in Microsoft Edge DevTools
               href: devtools-guide-chromium/whats-new/whats-new.md
-              displayName: 
+              displayName: release notes, announcements
 
 # What's New pages ------------------------------------------------------------
             # also add new pages to nav page: /whats-new/whats-new.md
             - name: Microsoft Edge 106
               href: devtools-guide-chromium/whats-new/2022/09/devtools-106.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 105
               href: devtools-guide-chromium/whats-new/2022/09/devtools-105.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 104
               href: devtools-guide-chromium/whats-new/2022/08/devtools-104.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 103
               href: devtools-guide-chromium/whats-new/2022/06/devtools-103.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 102
               href: devtools-guide-chromium/whats-new/2022/05/devtools-102.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 101
               href: devtools-guide-chromium/whats-new/2022/04/devtools-101.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 100
               href: devtools-guide-chromium/whats-new/2022/03/devtools-100.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 99
               href: devtools-guide-chromium/whats-new/2022/03/devtools.md
-              displayName: what's new, announcements, release notes
+              displayName: what's new
 
             - name: Microsoft Edge 98
               href: devtools-guide-chromium/whats-new/2022/02/devtools.md

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -28,7 +28,7 @@
 # What's New firstchild article
             - name: What's new in Microsoft Edge DevTools
               href: devtools-guide-chromium/whats-new/whats-new.md
-              displayName: what's new, release notes, announcements
+              displayName: release notes, announcements
 
 # What's New pages ------------------------------------------------------------
             # also add new pages to nav page: /whats-new/whats-new.md
@@ -956,6 +956,7 @@
 
         - name: What's new
           href: progressive-web-apps-chromium/whats-new/pwa.md
+          displayName: release notes, announcements
 
         - name: Sample PWAs
           href: progressive-web-apps-chromium/demo-pwas.md
@@ -1218,7 +1219,7 @@
 
         - name: Release Notes for the WebView2 SDK
           href: webview2/release-notes.md
-          displayName: 
+          displayName: what's new, announcements
 
         - name: WebView2 Roadmap
           href: webview2/roadmap.md


### PR DESCRIPTION
This PR causes the release notes for WebView2 to appear above the fold, instead of having to scroll to it.
And causes "What's New" for DevTools to appear only 1 time, so that PWA's What's New is immediately shown.

Rendered docs:
https://review.learn.microsoft.com/en-us/microsoft-edge/accessibility/build/aria-and-ui-automation?branch=pr-en-us-2241

To review this PR:
* In the rendered docs, in Filter By Title in upper left.  Start typing "release notes" and make sure "Release Notes for the WebView2 SDK" is immediately displayed without having to scroll to it.
* In Filter By Title in upper left.  Start typing "what's new", check resulting UX.
* In Filter By Title in upper left.  Start typing "announcements", check resulting UX for entries for:
   * PWA
   * DevTools
   * WebView2