### PR TITLE
Remove mentions of the FPS chart in the Performance docs

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -116,7 +116,7 @@ The main metric for measuring the performance of any animation is frames per sec
 
    ![The CPU chart and Summary panel.](../media/evaluate-performance-performance-cpu-chart.msft.png)
 
-1. Hover over the **CPU**, or **NET** charts.  DevTools shows a screenshot of the page at that point in time.  Move your mouse left and right to replay the recording.  The action is called _scrubbing_, and it's useful for manually analyzing the progression of animations.
+1. Hover over the **CPU** or **NET** charts.  DevTools shows a screenshot of the page at that point in time.  Move your mouse left and right to replay the recording.  The action is called _scrubbing_, and it's useful for manually analyzing the progression of the performance recording.
 
    ![View a screenshot of the page around the 2500ms mark of the recording.](../media/evaluate-performance-performance-screenshot-hover.msft.png)
 

--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
-ms.date: 05/04/2021
+ms.date: 10/10/2022
 ---
 <!-- Copyright Kayce Basques
 
@@ -114,13 +114,11 @@ The main metric for measuring the performance of any animation is frames per sec
 
 1. Look at the **FPS** chart, shown below.  Whenever a red bar is displayed above **FPS**, it means that the framerate dropped so low that it's probably harming the user experience.  In general, the higher the green bar, the higher the FPS.
 
-   ![The FPS chart.](../media/evaluate-performance-performance-fps-chart.msft.png)
-
-1. Below the **FPS** chart, the **CPU** chart is displayed.  The colors in the **CPU** chart correspond to the colors in the **Summary** panel, at the bottom of the **Performance** tool.  The fact that the **CPU** chart is full of color means that the CPU was maxed out during the recording.  Whenever the CPU is maxed out for long periods, that's an indicator that you should find ways to do less work.
+1. The **CPU** chart is displayed.  The colors in the **CPU** chart correspond to the colors in the **Summary** panel, at the bottom of the **Performance** tool.  The fact that the **CPU** chart is full of color means that the CPU was maxed out during the recording.  Whenever the CPU is maxed out for long periods, that's an indicator that you should find ways to do less work.
 
    ![The CPU chart and Summary panel.](../media/evaluate-performance-performance-cpu-chart.msft.png)
 
-1. Hover over the **FPS**, **CPU**, or **NET** charts.  DevTools shows a screenshot of the page at that point in time.  Move your mouse left and right to replay the recording.  The action is called _scrubbing_, and it's useful for manually analyzing the progression of animations.
+1. Hover over the **CPU**, or **NET** charts.  DevTools shows a screenshot of the page at that point in time.  Move your mouse left and right to replay the recording.  The action is called _scrubbing_, and it's useful for manually analyzing the progression of animations.
 
    ![View a screenshot of the page around the 2500ms mark of the recording.](../media/evaluate-performance-performance-screenshot-hover.msft.png)
 

--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -107,20 +107,11 @@ That's an overwhelming amount of data, but it'll all make more sense shortly.
 
 Once you have a recording of the page's performance, you can assess the page's performance and find the cause of any performance issues.
 
-
-### Analyze frames per second
-
-The main metric for measuring the performance of any animation is frames per second (FPS).  Users are happy when animations run at 60 FPS.
-
 1. The **CPU** chart is displayed along the top.  The colors in the **CPU** chart correspond to the colors in the **Summary** panel, at the bottom of the **Performance** tool.  The **CPU** chart shows that these regions make up a large area, meaning that the CPU was maxed out during the recording.  Whenever the CPU is maxed out for long periods, that's an indicator that you should find ways to do less work.
 
    ![The CPU chart and Summary panel.](../media/evaluate-performance-performance-cpu-chart.msft.png)
 
 1. Hover over the **CPU** or **NET** charts.  DevTools shows a screenshot of the page at that point in time.  Move your mouse left and right to replay the recording.  The action is called _scrubbing_, and it's useful for manually analyzing the progression of the performance recording.
-
-   ![View a screenshot of the page around the 2500ms mark of the recording.](../media/evaluate-performance-performance-screenshot-hover.msft.png)
-
-1. In the **Frames** section, hover on one of the green squares.  DevTools shows you the FPS for that particular frame.  Each frame is probably well below the target of 60 FPS.
 
    ![Hover on a frame.](../media/evaluate-performance-performance-frame-hover.msft.png)
 

--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -220,7 +220,7 @@ Last, there are many ways to improve runtime performance.  This article focused 
 
 <!-- ====================================================================== -->
 > [!NOTE]
-> Portions of this page are modifications based on work created and [shared by Google](https://developers.google.com/terms/site-policies) and used according to terms described in the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0).
+> Portions of this page are modifications based on work created and [shared by Google](https://developers.google.com/terms/site-policies) and used according to terms described in the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0). 
 > The original page is found [here](https://developer.chrome.com/docs/devtools/evaluate-performance/) and is authored by [Kayce Basques](https://developers.google.com/web/resources/contributors#kayce-basques) (Technical Writer, Chrome DevTools \& Lighthouse).
 
 [![Creative Commons License.](../../media/cc-logo/88x31.png)](https://creativecommons.org/licenses/by/4.0)

--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -112,8 +112,6 @@ Once you have a recording of the page's performance, you can assess the page's p
 
 The main metric for measuring the performance of any animation is frames per second (FPS).  Users are happy when animations run at 60 FPS.
 
-1. Look at the **FPS** chart, shown below.  Whenever a red bar is displayed above **FPS**, it means that the framerate dropped so low that it's probably harming the user experience.  In general, the higher the green bar, the higher the FPS.
-
 1. The **CPU** chart is displayed.  The colors in the **CPU** chart correspond to the colors in the **Summary** panel, at the bottom of the **Performance** tool.  The fact that the **CPU** chart is full of color means that the CPU was maxed out during the recording.  Whenever the CPU is maxed out for long periods, that's an indicator that you should find ways to do less work.
 
    ![The CPU chart and Summary panel.](../media/evaluate-performance-performance-cpu-chart.msft.png)

--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -112,7 +112,7 @@ Once you have a recording of the page's performance, you can assess the page's p
 
 The main metric for measuring the performance of any animation is frames per second (FPS).  Users are happy when animations run at 60 FPS.
 
-1. The **CPU** chart is displayed.  The colors in the **CPU** chart correspond to the colors in the **Summary** panel, at the bottom of the **Performance** tool.  The fact that the **CPU** chart is full of color means that the CPU was maxed out during the recording.  Whenever the CPU is maxed out for long periods, that's an indicator that you should find ways to do less work.
+1. The **CPU** chart is displayed along the top.  The colors in the **CPU** chart correspond to the colors in the **Summary** panel, at the bottom of the **Performance** tool.  The **CPU** chart shows that these regions make up a large area, meaning that the CPU was maxed out during the recording.  Whenever the CPU is maxed out for long periods, that's an indicator that you should find ways to do less work.
 
    ![The CPU chart and Summary panel.](../media/evaluate-performance-performance-cpu-chart.msft.png)
 


### PR DESCRIPTION
See the [rendered section](https://review.learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/evaluate-performance/?branch=pr-en-us-2242#analyze-frames-per-second) for review.

This PR removes mentions of the FPS chart from the Application tool since this chart does not exist anymore.