### PR TITLE
Removed preview channel & Runtime steps from Getstart Winforms

### DIFF
--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/27/2022
+ms.date: 10/26/2022
 ---
 # Get started with WebView2 in WinForms apps
 
@@ -22,23 +22,19 @@ This tutorial helps you:
 *  Learn about WebView2 concepts along the way.
 
 
-#### Completed project
-
-A completed version<!--TODO: what date?--> of this tutorial project is available in the **WebView2Samples** repo:
-
-*  Sample name: **Win32_GettingStarted**
-*  Repo directory: [Win32_GettingStarted](https://github.com/MicrosoftEdge/WebView2Samples/tree/main/GettingStartedGuides/Win32_GettingStarted)
-*  Solution file: **WebView2GettingStarted.sln**
-
-
 <!-- ====================================================================== -->
 ## Step 1 - Optionally clone or download the WebView2Samples repo
 
 Do either of the following:
 
-*  Create a new project in Visual Studio starting from a project template, using the steps below.
+*  Create a new project in Visual Studio starting from a project template, using the steps in the sections below.  This will give you the latest code and project structure.
 
 *  Clone or download the `WebView2Samples` repo, open the completed project in Visual Studio, and follow the steps in this article to understand creating the WinForms project and understand the added WebView2 code.  See [Download the WebView2Samples repo](../how-to/machine-setup.md#download-the-webview2samples-repo) in _Set up your Dev environment for WebView2_.  A completed version of this tutorial project is available in the WebView2Samples repo directory [WinForms_GettingStarted](https://github.com/MicrosoftEdge/WebView2Samples/tree/main/GettingStartedGuides/WinForms_GettingStarted).
+   *  Sample name: **Win32_GettingStarted**
+   *  Repo directory: [Win32_GettingStarted](https://github.com/MicrosoftEdge/WebView2Samples/tree/main/GettingStartedGuides/Win32_GettingStarted)
+   *  Solution file: **WebView2GettingStarted.sln**
+
+The sample in the repo might not be as up-to-date as a project that you create by using the latest Visual Studio project templates.
 
 
 <!-- ====================================================================== -->
@@ -52,22 +48,23 @@ Microsoft Visual Studio is required.  Microsoft Visual Studio Code is not suppor
 
 
 <!-- ====================================================================== -->
-## Step 3 - Install the WebView2 Runtime (optional)
+## Step 3 - Install the WebView2 Runtime
 
-<!-- TODO: delete this major step? -->
+To develop a WebView2 app, you must download and install the WebView2 Runtime on your machine.  (If you were to distribute the app that results from this tutorial, you would need to distribute the WebView2 Runtime along with your app.  The WebView2 Runtime would then be automatically installed onto user machines.)
 
-<!-- todo: test the article without doing this step -->
+1. Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2), and then click the **Download Now** link.  The page scrolls down to the **Download the WebView2 Runtime** section.
 
-You and the users don't need to install the WebView2 Runtime on Windows 10 or Windows 11.
+<!--
+1. In the **Fixed Version** section, select a version and architecture, and then click the **Download** button.  A file such as `Microsoft.WebView2.FixedVersionRuntime.103.0.1264.71.x64.cab` is placed in your **Downloads** directory.
+-->
 
+1. Under **Evergreen Bootstrapper**, click the **Download** button.  The **Download the Evergreen WebView2 Runtime Bootstrapper** window opens.
 
-1. Optionally, install the WebView2 <!--Fixed Version--> Runtime.  Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2), click the **Download Now** link.  In the **Fixed Version** section, select a version and architecture, and then click the **Download** button.  A file such as `Microsoft.WebView2.FixedVersionRuntime.103.0.1264.71.x64.cab` is placed in your **Downloads** directory.  
+1. Click the **Accept and Download** button.  In Microsoft Edge, in the Downloads popup, the file is listed, such as `MicrosoftEdgeWebview2Setup.exe`.  This installer will detect the operating system.
 
-   If unsure, skip this step; you can use the Microsoft Edge preview channel from the previous step instead.
-  
-   If you want more information now, see [Understand the different WebView2 SDK versions](../concepts/versioning.md).
+1. In your downloads directory, double-click the downloaded file and follow the prompts.
 
-In a later step, you'll install the WebView2 SDK on your machine, if it's not installed already.
+   If the WebView2 Runtime is already installed, a message appears: "Installation failed.  The Microsoft Edge Webview2<!--lowercase v in UI--> Runtime is already installed for the system."  Click the **Close** button.
 
 Continue with the steps below.
 
@@ -544,7 +541,7 @@ In your project, when the WebView2 control navigates to a URL, it displays the U
 
    Next, for WebView2 to send and respond to the web message, after `CoreWebView2` is initialized, the host will inject a script in the web content to:
  
-  *  Send the URL to the host using `postMessage`.
+   *  Send the URL to the host using `postMessage`.
 
    *  Register an event handler to display a message sent from the host, in an alert box, before displaying webpage content.
 
@@ -584,15 +581,15 @@ In your project, when the WebView2 control navigates to a URL, it displays the U
 Congratulations, you built your first WebView2 app!
 
 
-<!-- ====================================================================== -->
-## Step 12 - Deploy the app
+#### Distributing a WebView2 app
 
-tbd - links
+If you were to distribute the app that results from this tutorial, you would need to distribute the WebView2 Runtime along with your app.  The WebView2 Runtime would then be automatically installed onto user machines.  For more information, see [Distribute your app and the WebView2 Runtime](../concepts/distribution.md).
 
 
 <!-- ====================================================================== -->
 ## See also
 
+* [Distribute your app and the WebView2 Runtime](../concepts/distribution.md)
 * [WinForms sample app](../samples/webview2windowsformsbrowser.md) - Demonstrates more WebView2 APIs than the present tutorial.
 * [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_ - Conceptual and how-to articles about building and deploying WebView2 apps.
 * [Microsoft.Web.WebView2.WinForms](/dotnet/api/microsoft.web.webview2.winforms) - API Reference.

--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -48,29 +48,7 @@ Microsoft Visual Studio is required.  Microsoft Visual Studio Code is not suppor
 
 
 <!-- ====================================================================== -->
-## Step 3 - Install the WebView2 Runtime
-
-To develop a WebView2 app, you must download and install the WebView2 Runtime on your machine.  (If you were to distribute the app that results from this tutorial, you would need to distribute the WebView2 Runtime along with your app.  The WebView2 Runtime would then be automatically installed onto user machines.)
-
-1. Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2), and then click the **Download Now** link.  The page scrolls down to the **Download the WebView2 Runtime** section.
-
-<!--
-1. In the **Fixed Version** section, select a version and architecture, and then click the **Download** button.  A file such as `Microsoft.WebView2.FixedVersionRuntime.103.0.1264.71.x64.cab` is placed in your **Downloads** directory.
--->
-
-1. Under **Evergreen Bootstrapper**, click the **Download** button.  The **Download the Evergreen WebView2 Runtime Bootstrapper** window opens.
-
-1. Click the **Accept and Download** button.  In Microsoft Edge, in the Downloads popup, the file is listed, such as `MicrosoftEdgeWebview2Setup.exe`.  This installer will detect the operating system.
-
-1. In your downloads directory, double-click the downloaded file and follow the prompts.
-
-   If the WebView2 Runtime is already installed, a message appears: "Installation failed.  The Microsoft Edge Webview2<!--lowercase v in UI--> Runtime is already installed for the system."  Click the **Close** button.
-
-Continue with the steps below.
-
-
-<!-- ====================================================================== -->
-## Step 4 - Create a single-window app
+## Step 3 - Create a single-window app
 
 Start with a basic desktop project that contains a single main window.
 
@@ -128,7 +106,7 @@ You now have an empty WinForms project that runs.  Next, set up the project to a
 [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
-## Step 5 - Install the WebView2 SDK
+## Step 4 - Install the WebView2 SDK
 
 For every WebView2 project, you use the NuGet package manager within Visual Studio to add the WebView2 SDK to the project.  You install the **Microsoft.Web.WebView2** SDK NuGet package for use by the current project.
 
@@ -176,7 +154,7 @@ You've added the WebView2 SDK to the project, but haven't added any WebView2 cod
 
 
 <!-- ====================================================================== -->
-## Step 6 - Create a single WebView2 control
+## Step 5 - Create a single WebView2 control
 
 Now that the WebView2 SDK is installed for the WinForms project, add a WebView2 control to the app, as follows:
 
@@ -236,7 +214,7 @@ If you're working on a high-resolution monitor, you may need to [configure your 
 
 
 <!-- ====================================================================== -->
-## Step 7 - Add controls and process window resize events
+## Step 6 - Add controls and process window resize events
 
 Add more controls to your Windows Forms form from the toolbox, and then process window resize events, as follows.
 
@@ -326,7 +304,7 @@ Add more controls to your Windows Forms form from the toolbox, and then process 
 
 
 <!-- ====================================================================== -->
-## Step 8 - Navigation
+## Step 7 - Navigation
 
 Enable users to change the URL that the WebView2 control displays, by reading the text entered in the text box, to serve as an address bar.
 
@@ -374,7 +352,7 @@ Enable users to change the URL that the WebView2 control displays, by reading th
 
 
 <!-- ====================================================================== -->
-## Step 9 - Navigation events
+## Step 8 - Navigation events
 
 <!--
 maintenance link (keep)
@@ -447,7 +425,7 @@ To demonstrate how to use the events, start by registering a handler for `Naviga
 
 
 <!-- ====================================================================== -->
-## Step 10 - Scripting
+## Step 9 - Scripting
 
 You can use host apps to inject JavaScript code into WebView2 controls at runtime. You can task WebView2 to run arbitrary JavaScript or add initialization scripts. The injected JavaScript applies to all new top-level documents and any child frames until the JavaScript is removed. The injected JavaScript runs with specific timing.
 
@@ -489,7 +467,7 @@ For example, add a script that sends an alert when a user navigates to a non-HTT
 
 
 <!-- ====================================================================== -->
-## Step 11 - Communication between host and web content
+## Step 10 - Communication between host and web content
 
 The host and web content can use `postMessage` to communicate with each other as follows:
 

--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -52,23 +52,14 @@ Microsoft Visual Studio is required.  Microsoft Visual Studio Code is not suppor
 
 
 <!-- ====================================================================== -->
-## Step 3 - Install a preview channel of Microsoft Edge
+## Step 3 - Install the WebView2 Runtime (optional)
 
 <!-- TODO: delete this major step? -->
 
-1. Install any [Microsoft Edge Insider (preview) Channel](https://www.microsoftedgeinsider.com/download) (Beta, Dev, or Canary) on a supported operating system (OS):
-   *  Windows 7
-   *  Windows 8.1
-   *  Windows 10
-   *  Windows 11
+<!-- todo: test the article without doing this step -->
 
-   We recommend using the Canary channel.  The minimum required version is 82.0.488.0.
+You and the users don't need to install the WebView2 Runtime on Windows 10 or Windows 11.
 
-
-<!-- ====================================================================== -->
-## Step 4 - Install the WebView2 Runtime (optional)
-
-<!-- TODO: delete this major step? -->
 
 1. Optionally, install the WebView2 <!--Fixed Version--> Runtime.  Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2), click the **Download Now** link.  In the **Fixed Version** section, select a version and architecture, and then click the **Download** button.  A file such as `Microsoft.WebView2.FixedVersionRuntime.103.0.1264.71.x64.cab` is placed in your **Downloads** directory.  
 
@@ -82,7 +73,7 @@ Continue with the steps below.
 
 
 <!-- ====================================================================== -->
-## Step 5 - Create a single-window app
+## Step 4 - Create a single-window app
 
 Start with a basic desktop project that contains a single main window.
 
@@ -140,7 +131,7 @@ You now have an empty WinForms project that runs.  Next, set up the project to a
 [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
-## Step 6 - Install the WebView2 SDK
+## Step 5 - Install the WebView2 SDK
 
 For every WebView2 project, you use the NuGet package manager within Visual Studio to add the WebView2 SDK to the project.  You install the **Microsoft.Web.WebView2** SDK NuGet package for use by the current project.
 
@@ -188,7 +179,7 @@ You've added the WebView2 SDK to the project, but haven't added any WebView2 cod
 
 
 <!-- ====================================================================== -->
-## Step 7 - Create a single WebView2 control
+## Step 6 - Create a single WebView2 control
 
 Now that the WebView2 SDK is installed for the WinForms project, add a WebView2 control to the app, as follows:
 
@@ -248,7 +239,7 @@ If you're working on a high-resolution monitor, you may need to [configure your 
 
 
 <!-- ====================================================================== -->
-## Step 8 - Add controls and process window resize events
+## Step 7 - Add controls and process window resize events
 
 Add more controls to your Windows Forms form from the toolbox, and then process window resize events, as follows.
 
@@ -338,7 +329,7 @@ Add more controls to your Windows Forms form from the toolbox, and then process 
 
 
 <!-- ====================================================================== -->
-## Step 9 - Navigation
+## Step 8 - Navigation
 
 Enable users to change the URL that the WebView2 control displays, by reading the text entered in the text box, to serve as an address bar.
 
@@ -386,7 +377,7 @@ Enable users to change the URL that the WebView2 control displays, by reading th
 
 
 <!-- ====================================================================== -->
-## Step 10 - Navigation events
+## Step 9 - Navigation events
 
 <!--
 maintenance link (keep)
@@ -459,7 +450,7 @@ To demonstrate how to use the events, start by registering a handler for `Naviga
 
 
 <!-- ====================================================================== -->
-## Step 11 - Scripting
+## Step 10 - Scripting
 
 You can use host apps to inject JavaScript code into WebView2 controls at runtime. You can task WebView2 to run arbitrary JavaScript or add initialization scripts. The injected JavaScript applies to all new top-level documents and any child frames until the JavaScript is removed. The injected JavaScript runs with specific timing.
 
@@ -501,7 +492,7 @@ For example, add a script that sends an alert when a user navigates to a non-HTT
 
 
 <!-- ====================================================================== -->
-## Step 12 - Communication between host and web content
+## Step 11 - Communication between host and web content
 
 The host and web content can use `postMessage` to communicate with each other as follows:
 
@@ -594,8 +585,16 @@ Congratulations, you built your first WebView2 app!
 
 
 <!-- ====================================================================== -->
+## Step 12 - Deploy the app
+
+tbd - links
+
+
+<!-- ====================================================================== -->
 ## See also
 
 * [WinForms sample app](../samples/webview2windowsformsbrowser.md) - Demonstrates more WebView2 APIs than the present tutorial.
 * [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_ - Conceptual and how-to articles about building and deploying WebView2 apps.
 * [Microsoft.Web.WebView2.WinForms](/dotnet/api/microsoft.web.webview2.winforms) - API Reference.
+
+<!-- todo: remove "[see also]" link, replace by direct links -->

--- a/microsoft-edge/webview2/how-to/machine-setup.md
+++ b/microsoft-edge/webview2/how-to/machine-setup.md
@@ -40,7 +40,7 @@ The preview channels of Microsoft Edge are required in order to use a prerelease
 <!-- ====================================================================== -->
 ## Install the WebView2 Runtime
 
-1. Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) 
+1. Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2).
 
 1. Scroll down to the section **Download the WebView2 Runtime**.
 

--- a/microsoft-edge/webview2/how-to/machine-setup.md
+++ b/microsoft-edge/webview2/how-to/machine-setup.md
@@ -37,47 +37,6 @@ We recommend using the Canary channel.  The minimum required version is 82.0.488
 The preview channels of Microsoft Edge are required in order to use a prerelease version of the WebView2 SDK.  A prerelease SDK enables testing your app against the latest APIs, and trying out the latest APIs.
 
 
-<!-- ====================================================================== -->
-## Install the WebView2 Runtime
-
-1. Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2).
-
-1. Scroll down to the section **Download the WebView2 Runtime**.
-
-Generally, the Evergreen Runtime is recommended rather than the Fixed Version Runtime.  To install the Evergreen Runtime, you can either:
-*  Download and run the small Evergreen Bootstrapper.
-*  Download and run the full-sized, OS-specific Evergreen Standalone Installer.
-
-
-#### If downloading the Evergreen Bootstrapper
-
-<!-- Example filesize: 1,560 KB. -->
-
-1. Under **Evergreen Bootstrapper**, click the **Download** button.  The **Download the Evergreen WebView2 Runtime Bootstrapper** window opens.
-
-1. Click the **Accept and Download** button.  In Microsoft Edge, in the Downloads popup, the file is listed, such as `MicrosoftEdgeWebview2Setup.exe`.  This installer will detect the operating system.
-
-1. In your downloads directory, double-click the downloaded file and follow the prompts.
-
-   If the WebView2 Runtime is already installed, a message appears: "Installation failed.  The Microsoft Edge Webview2<!--lowercase v in UI--> Runtime is already installed for the system."  Click the **Close** button.
-
-
-#### If downloading the Evergreen Standalone Installer
-
-<!-- Example filesize: 135,584 KB. -->
-
-1. Under **Evergreen Standalone Installer**, click the download button for your development operating system.  The **Download the Evergreen WebView2 Runtime Standalone Installer** window opens.
-
-1. Click the **Accept and Download** button.  In Microsoft Edge, in the Downloads popup, the file is listed, such as `MicrosoftEdgeWebView2RuntimeInstallerX64.exe`.
-
-1. In your downloads directory, double-click the downloaded file and follow the prompts.
-
-   If the WebView2 Runtime is already installed, a message appears: "Installation failed.  The Microsoft Edge WebView2 Runtime is already installed for the system."  Click the **Close** button.
-
-See also:
-* [Understand the different WebView2 SDK versions](../concepts/versioning.md)
-
-
 <!-- The h3 section [Clone or download the WebView2Samples repo](../get-started/win32.md#download-or-clone-the-webview2samples-repo) in _Get started with WebView2 in Win32 apps_ links to here -->
 <!-- ====================================================================== -->
 ## Download the WebView2Samples repo

--- a/microsoft-edge/webview2/how-to/machine-setup.md
+++ b/microsoft-edge/webview2/how-to/machine-setup.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 07/27/2022
+ms.date: 10/26/2022
 ---
 # Set up your Dev environment for WebView2
 
@@ -34,15 +34,48 @@ This article covers general-purpose setup of your development environment for We
 
 We recommend using the Canary channel.  The minimum required version is 82.0.488.0.
 
+The preview channels of Microsoft Edge are required in order to use a prerelease version of the WebView2 SDK.  A prerelease SDK enables testing your app against the latest APIs, and trying out the latest APIs.
+
 
 <!-- ====================================================================== -->
 ## Install the WebView2 Runtime
 
-1. Optionally, install the WebView2 Runtime.  To do that, go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2).
+1. Go to [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) 
 
-If unsure, skip this step; you can use the Microsoft Edge preview channel from the previous step instead.
+1. Scroll down to the section **Download the WebView2 Runtime**.
 
-See [Understand the different WebView2 SDK versions](../concepts/versioning.md).
+Generally, the Evergreen Runtime is recommended rather than the Fixed Version Runtime.  To install the Evergreen Runtime, you can either:
+*  Download and run the small Evergreen Bootstrapper.
+*  Download and run the full-sized, OS-specific Evergreen Standalone Installer.
+
+
+#### If downloading the Evergreen Bootstrapper
+
+<!-- Example filesize: 1,560 KB. -->
+
+1. Under **Evergreen Bootstrapper**, click the **Download** button.  The **Download the Evergreen WebView2 Runtime Bootstrapper** window opens.
+
+1. Click the **Accept and Download** button.  In Microsoft Edge, in the Downloads popup, the file is listed, such as `MicrosoftEdgeWebview2Setup.exe`.  This installer will detect the operating system.
+
+1. In your downloads directory, double-click the downloaded file and follow the prompts.
+
+   If the WebView2 Runtime is already installed, a message appears: "Installation failed.  The Microsoft Edge Webview2<!--lowercase v in UI--> Runtime is already installed for the system."  Click the **Close** button.
+
+
+#### If downloading the Evergreen Standalone Installer
+
+<!-- Example filesize: 135,584 KB. -->
+
+1. Under **Evergreen Standalone Installer**, click the download button for your development operating system.  The **Download the Evergreen WebView2 Runtime Standalone Installer** window opens.
+
+1. Click the **Accept and Download** button.  In Microsoft Edge, in the Downloads popup, the file is listed, such as `MicrosoftEdgeWebView2RuntimeInstallerX64.exe`.
+
+1. In your downloads directory, double-click the downloaded file and follow the prompts.
+
+   If the WebView2 Runtime is already installed, a message appears: "Installation failed.  The Microsoft Edge WebView2 Runtime is already installed for the system."  Click the **Close** button.
+
+See also:
+* [Understand the different WebView2 SDK versions](../concepts/versioning.md)
 
 
 <!-- The h3 section [Clone or download the WebView2Samples repo](../get-started/win32.md#download-or-clone-the-webview2samples-repo) in _Get started with WebView2 in Win32 apps_ links to here -->


### PR DESCRIPTION
**Rendered article for review:**
* https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/get-started/winforms?branch=pr-en-us-2262 ([before](https://learn.microsoft.com/en-us/microsoft-edge/webview2/get-started/winforms))
* https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/machine-setup?branch=pr-en-us-2262 - removed "Install Runtime" section.  ([before](https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/machine-setup#install-the-webview2-runtime))

This PR fixes issue https://github.com/MicrosoftDocs/edge-developer/issues/2055.