### PR TITLE
Release Note for WebView2 with Stable 107 and Pre-release 109

### DIFF
--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -93,7 +93,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=&preserve-view=truewebview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
-* [CoreWebView2Frame.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame?view&preserve-view=true=webview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
+* [CoreWebView2Frame.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true#postsharedbuffertoscript)
 
 ##### [Win32/C++](#tab/win32cpp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -128,7 +128,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 *   Display `AllowedCertificateAuthorities` in `add_ClientCertificateRequested` event as a `Base64` string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
 *   Fixed a bug in which the default footer URI in print settings is missing. ([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
 *   Fixed a bug that produces a null pointer exception that's related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
-*   Fixed a bug that reports failure navigation when redirecting to a server that has configured with Client Certificate Authentication and when add_WebResourceRequested is subscribed. (Runtime)
+*   Fixed a bug that reports navigation failure when redirecting to a server that has been configured with Client Certificate Authentication and when the `WebResourceRequested` event is subscribed to. (Runtime)
 *   Fixed an `AddHostObjectToScript` bug in which, when JavaScript calls an async method and then a synchronous method, the async method call might fail.
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -70,17 +70,15 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease)
-
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease)
-
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease
 )
 
 
@@ -115,7 +113,6 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2ExperimentalScriptException interface](#)
-
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -62,11 +62,11 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 #### Experimental features
 
 *  Added support to create a shared memory based buffer with the specified size:
-    *      `Close`
-    *      `get_Buffer`
-    *      `get_FileMappingHandle`
-    *      `get_Size`
-    *      `OpenStream`
+    *      Close
+    *      get_Buffer
+    *      get_FileMappingHandle
+    *      get_Size
+    *      OpenStream
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -61,7 +61,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 #### Experimental features
 
-* Added support to create a shared memory based buffer with the specified size:
+* Added support for creating a shared memory based buffer with a specified size:
     *  `close`
     *  `get_Buffer`
     *  `get_FileMappingHandle`

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -101,7 +101,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ---
 
-*  Added support by adding these properties to run JavaScript code from the JavaScript parameter in the current top-level document:
+*  Added support for running JavaScript code from the `JavaScript` parameter in the current top-level document:
     *  `ColumnNumber`
     *  `LineNumber`
     *  `Message`

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -82,7 +82,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ---
 
-*  Added support to share a shared buffer object with script of the main-frame/iframe
+*  Added support for accessing a shared buffer object from the script of the main frame or `iframe`.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -111,7 +111,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2ScriptException Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease)
+* [CoreWebView2ScriptException Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view=webview2-dotnet-1.0.1466-prerelease&preserve-view=true)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -74,7 +74,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view&preserve-view=true=webview2-1.0.1466-prerelease)
+* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease&preserve-view=true)
 
 ##### [Win32/C++](#tab/win32cpp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -92,7 +92,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=&preserve-view=truewebview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
+* [CoreWebView2.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true#postsharedbuffertoscript)
 * [CoreWebView2Frame.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true#postsharedbuffertoscript)
 
 ##### [Win32/C++](#tab/win32cpp)

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -35,13 +35,13 @@ To use a prerelease SDK along with a Microsoft Edge preview channel, see [Test u
 <!-- ====================================================================== -->
 ## 1.0.1418.22
 
-Release Date: October 31, 2022
+Release Date: October 31, 2022 
 
-[NuGet package for WebView2 SDK 1.0.1418.28](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1418.22)
+[NuGet package for WebView2 SDK 22](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1418.22)
 
 For full API compatibility, this version of the WebView2 SDK requires WebView2 Runtime version 107.0.1418.22 or higher.
 
-### General
+### General 
 
 This WebView2 SDK release has the same bug fixes that are in WebView2 SDK 1.0.1466-prerelease. See Bug fixes in the following section.
 
@@ -70,17 +70,17 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ExperimentalSharedBuffer interface](#)
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease&viewFallbackFrom=webview2-dotnet-1.0.1418.22)
 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ExperimentalSharedBuffer interface](#)
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease)
 
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2ExperimentalSharedBuffer interface](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease&preserve-view=true)
+* [CoreWebView2SharedBuffer Class](x)
 
 
 ---
@@ -89,8 +89,8 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Experimental18.PostSharedBufferToScript Method](#)
-* [CoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](#)
+* [CoreWebView2Experimental18.PostSharedBufferToScript Method](x)
+* [CoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](x)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -87,7 +87,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postsharedbuffertoscript?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
+* [CoreWebView2.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postsharedbuffertoscript?view=webview2-dotnet-1.0.1466-prerelease&preserve-view=true)
 * [CoreWebView2Frame.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postsharedbuffertoscript?view=webview2-dotnet-1.0.1466-prerelease&preserve-view=true)
 
 ##### [WinRT/C#](#tab/winrtcsharp)

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -127,7 +127,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 *   Fixed a bug in which the custom header title in print settings could be wrong. ([Issue #2093](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2093))
 *   Display AllowedCertificateAuthorities in add_ClientCertificateRequested event as Base64 string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
-*   Fixed a bug which default footer URI in print settings is missing.([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
+*   Fixed a bug in which the default footer URI in print settings is missing. ([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
 *   Fixed a bug that brings null poiner exception related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
 *   Fixed a bug that reports failure navigation when redirecting to a server that has configured with Client Certificate Authentication and when add_WebResourceRequested is subscribed. (Runtime)
 *   Fixed AddHostObjectToScript bug in which JS calling an async method and then a sync method, the async method call might fail.  

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -115,7 +115,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2ScriptException Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view&preserve-view=true=webview2-winrt-1.0.1466-prerelease)
+* [CoreWebView2ScriptException Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true)
 
 ##### [Win32/C++](#tab/win32cpp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -43,7 +43,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ### General 
 
-This WebView2 SDK release has the same bug fixes that are in WebView2 SDK 1.0.1466-prerelease. See Bug fixes in the following section.
+This WebView2 SDK release has the same bug fixes that are in WebView2 SDK 1.0.1466-prerelease. See **Bug fixes** in the following section.
 
 ---
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -37,7 +37,7 @@ To use a prerelease SDK along with a Microsoft Edge preview channel, see [Test u
 
 Release Date: October 31, 2022 
 
-[NuGet package for WebView2 SDK 22](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1418.22)
+[NuGet package for WebView2 SDK 1.0.1418.22](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1418.22)
 
 For full API compatibility, this version of the WebView2 SDK requires WebView2 Runtime version 107.0.1418.22 or higher.
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -126,7 +126,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 #### Bug fixes
 
 *   Fixed a bug in which the custom header title in print settings could be wrong. ([Issue #2093](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2093))
-*   Display AllowedCertificateAuthorities in add_ClientCertificateRequested event as Base64 string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
+*   Display `AllowedCertificateAuthorities` in `add_ClientCertificateRequested` event as a `Base64` string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
 *   Fixed a bug in which the default footer URI in print settings is missing. ([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
 *   Fixed a bug that brings null poiner exception related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
 *   Fixed a bug that reports failure navigation when redirecting to a server that has configured with Client Certificate Authentication and when add_WebResourceRequested is subscribed. (Runtime)

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -129,7 +129,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 *   Fixed a bug in which the default footer URI in print settings is missing. ([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
 *   Fixed a bug that produces a null pointer exception that's related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
 *   Fixed a bug that reports failure navigation when redirecting to a server that has configured with Client Certificate Authentication and when add_WebResourceRequested is subscribed. (Runtime)
-*   Fixed AddHostObjectToScript bug in which JS calling an async method and then a sync method, the async method call might fail.  
+*   Fixed an `AddHostObjectToScript` bug in which, when JavaScript calls an async method and then a synchronous method, the async method call might fail.
 
 <!-- ====================================================================== -->
 ## 1.0.1370.28

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -62,11 +62,11 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 #### Experimental features
 
 *  Added support to create a shared memory based buffer with the specified size:
-    *      Close
-    *      get_Buffer
-    *      get_FileMappingHandle
-    *      get_Size
-    *      OpenStream
+    *     Close
+    *     get_Buffer
+    *     get_FileMappingHandle
+    *     get_Size
+    *     OpenStream
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -70,17 +70,18 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease&viewFallbackFrom=webview2-dotnet-1.0.1418.22)
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease)
 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease)
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease)
 
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [CoreWebView2SharedBuffer Class](x)
+* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease
+)
 
 
 ---

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -33,6 +33,109 @@ To load WebView2, the minimum version of Microsoft Edge or the WebView2 Runtime 
 To use a prerelease SDK along with a Microsoft Edge preview channel, see [Test upcoming APIs and features](how-to/set-preview-channel.md).
 
 <!-- ====================================================================== -->
+## 1.0.1418.22
+
+Release Date: October 31, 2022
+
+[NuGet package for WebView2 SDK 1.0.1418.28](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1418.22)
+
+For full API compatibility, this version of the WebView2 SDK requires WebView2 Runtime version 107.0.1418.22 or higher.
+
+### General
+
+This WebView2 SDK release has the same bug fixes that are in WebView2 SDK 1.0.1466-prerelease. See Bug fixes in the following section.
+
+---
+
+
+<!-- ====================================================================== -->
+## 1.0.1466-prerelease
+
+Release Date: October 31, 2022
+
+[NuGet package for WebView2 SDK 1.0.1466-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1466-prerelease)
+
+For full API compatibility, this version of the WebView2 SDK requires Microsoft Edge version 109.0.1466.0 or higher.
+
+### General
+
+#### Experimental features
+
+*  Added support to create a shared memory based buffer with the specified size:
+	*  	`Close`
+	*  	`get_Buffer`
+	*  	`get_FileMappingHandle`
+	*  	`get_Size`
+	*  	`OpenStream`
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2.ExperimentalSharedBuffer interface](#)
+
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2.ExperimentalSharedBuffer interface](#)
+
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2ExperimentalSharedBuffer interface](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease&preserve-view=true)
+
+
+---
+
+*  Added support to share a shared buffer object with script of the main-frame/iframe
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2Experimental18.PostSharedBufferToScript Method](#)
+* [CoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](#)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2Experimental18.PostSharedBufferToScript Method](#)
+* [CoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](#)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2Experimental18.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/win32/icorewebview2experimental18?view=webview2-1.0.1466-prerelease#postsharedbuffertoscript&preserve-view=true)
+* [ICoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalframe4?view=webview2-1.0.1466-prerelease#postsharedbuffertoscript&preserve-view=true)
+
+---
+
+*  Added support to run JavaScript code from the JavaScript parameter in the current top-level document:
+	*  	`get_ColumnNumber`
+	*  	`get_LineNumber`
+	*  `get_Message`
+	*  `get_Name`
+	*  `get_ToJson`
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2ExperimentalScriptException interface](#)
+
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2ExperimentalScriptException interface](#)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2ExperimentalScriptException interface](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalscriptexception?view=webview2-1.0.1466-prerelease&preserve-view=true)
+
+---
+
+#### Bug fixes
+
+*   Fixed a bug which custom header title in print settings could be wrong([Issue #2093](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2093))
+*   Display AllowedCertificateAuthorities in add_ClientCertificateRequested event as Base64 string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
+*   Fixed a bug which default footer URI in print settings is missing.([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
+*   Fixed a bug that brings null poiner exception related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
+*   Fixed a bug that reports failure navigation when redirecting to a server that has configured with Client Certificate Authentication and when add_WebResourceRequested is subscribed. (Runtime)
+*   Fixed AddHostObjectToScript bug in which JS calling an async method and then a sync method, the async method call might fail.  
+
+<!-- ====================================================================== -->
 ## 1.0.1370.28
 
 Release Date: October 11, 2022

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -74,7 +74,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease)
+* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view&preserve-view=true=webview2-1.0.1466-prerelease)
 
 ##### [Win32/C++](#tab/win32cpp)
 
@@ -87,8 +87,8 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postsharedbuffertoscript?view=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
-* [CoreWebView2Frame.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postsharedbuffertoscript?view=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2frame-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
+* [CoreWebView2.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postsharedbuffertoscript?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
+* [CoreWebView2Frame.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postsharedbuffertoscript?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2frame-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
@@ -111,7 +111,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2ScriptException Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view=webview2-dotnet-1.0.1466-prerelease)
+* [CoreWebView2ScriptException Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -81,42 +81,41 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 * [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease
 )
 
-
 ---
 
 *  Added support to share a shared buffer object with script of the main-frame/iframe
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Experimental18.PostSharedBufferToScript Method](x)
-* [CoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](x)
+* [CoreWebView2.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postsharedbuffertoscript?view=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
+* [CoreWebView2Frame.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postsharedbuffertoscript?view=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2frame-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Experimental18.PostSharedBufferToScript Method](#)
-* [CoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](#)
+* [CoreWebView2.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
+* [CoreWebView2Frame.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame?view=webview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Experimental18.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/win32/icorewebview2experimental18?view=webview2-1.0.1466-prerelease#postsharedbuffertoscript&preserve-view=true)
-* [ICoreWebView2ExperimentalFrame4.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalframe4?view=webview2-1.0.1466-prerelease#postsharedbuffertoscript&preserve-view=true)
+* [ICoreWebView2Experimental18::PostSharedBufferToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2experimental18?view=webview2-1.0.1466-prerelease&preserve-view=true#postsharedbuffertoscript)
+* [ICoreWebView2ExperimentalFrame4::PostSharedBufferToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalframe4?view=webview2-1.0.1466-prerelease&preserve-view=true#postsharedbuffertoscript)
 
 ---
 
-*  Added support to run JavaScript code from the JavaScript parameter in the current top-level document:
-    *  `get_ColumnNumber`
-    *  `get_LineNumber`
-    *  `get_Message`
-    *  `get_Name`
-    *  `get_ToJson`
+*  Added support by adding these properties to run JavaScript code from the JavaScript parameter in the current top-level document:
+    *  `ColumnNumber`
+    *  `LineNumber`
+    *  `Message`
+    *  `Name`
+    *  `ToJson`
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2ExperimentalScriptException interface](#)
+* [CoreWebView2ScriptException Class](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view=webview2-dotnet-1.0.1466-prerelease)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2ExperimentalScriptException interface](#)
+* [CoreWebView2ScriptException Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view=webview2-winrt-1.0.1466-prerelease)
 
 ##### [Win32/C++](#tab/win32cpp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -125,7 +125,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 #### Bug fixes
 
-*   Fixed a bug which custom header title in print settings could be wrong([Issue #2093](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2093))
+*   Fixed a bug in which the custom header title in print settings could be wrong. ([Issue #2093](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2093))
 *   Display AllowedCertificateAuthorities in add_ClientCertificateRequested event as Base64 string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
 *   Fixed a bug which default footer URI in print settings is missing.([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
 *   Fixed a bug that brings null poiner exception related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -78,7 +78,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease
+* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view&preserve-view=true=webview2-winrt-1.0.1466-prerelease
 )
 
 ---
@@ -92,8 +92,8 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=webview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
-* [CoreWebView2Frame.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame?view=webview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
+* [CoreWebView2.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2?view=&preserve-view=truewebview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
+* [CoreWebView2Frame.PostSharedBufferToScript method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame?view&preserve-view=true=webview2-winrt-1.0.1466-prerelease#postsharedbuffertoscript)
 
 ##### [Win32/C++](#tab/win32cpp)
 
@@ -115,7 +115,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2ScriptException Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view=webview2-winrt-1.0.1466-prerelease)
+* [CoreWebView2ScriptException Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view&preserve-view=true=webview2-winrt-1.0.1466-prerelease)
 
 ##### [Win32/C++](#tab/win32cpp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -70,7 +70,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2SharedBuffer Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease)
+* [CoreWebView2SharedBuffer Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease&preserve-view=true)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -70,15 +70,15 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease)
+* [CoreWebView2SharedBuffer Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease)
+* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [CoreWebView2SharedBuffer Class](https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease
+* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease
 )
 
 ---

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -128,7 +128,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 *   Fixed a bug in which the custom header title in print settings could be wrong. ([Issue #2093](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2093))
 *   Display `AllowedCertificateAuthorities` in `add_ClientCertificateRequested` event as a `Base64` string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
 *   Fixed a bug in which the default footer URI in print settings is missing. ([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
-*   Fixed a bug that brings null poiner exception related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
+*   Fixed a bug that produces a null pointer exception that's related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
 *   Fixed a bug that reports failure navigation when redirecting to a server that has configured with Client Certificate Authentication and when add_WebResourceRequested is subscribed. (Runtime)
 *   Fixed AddHostObjectToScript bug in which JS calling an async method and then a sync method, the async method call might fail.  
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -61,12 +61,12 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 #### Experimental features
 
-*  Added support to create a shared memory based buffer with the specified size:
-    *     Close
-    *     get_Buffer
-    *     get_FileMappingHandle
-    *     get_Size
-    *     OpenStream
+* Added support to create a shared memory based buffer with the specified size:
+    *  `close`
+    *  `get_Buffer`
+    *  `get_FileMappingHandle`
+    *  `get_Size`
+    *  `OpenStream`  
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -106,8 +106,8 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 ---
 
 *  Added support to run JavaScript code from the JavaScript parameter in the current top-level document:
-    *      `get_ColumnNumber`
-    *      `get_LineNumber`
+    *  `get_ColumnNumber`
+    *  `get_LineNumber`
     *  `get_Message`
     *  `get_Name`
     *  `get_ToJson`

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -111,11 +111,11 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2ScriptException Class](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view=webview2-dotnet-1.0.1466-prerelease)
+* [CoreWebView2ScriptException Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view=webview2-dotnet-1.0.1466-prerelease)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2ScriptException Class](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view=webview2-winrt-1.0.1466-prerelease)
+* [CoreWebView2ScriptException Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view=webview2-winrt-1.0.1466-prerelease)
 
 ##### [Win32/C++](#tab/win32cpp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -70,7 +70,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2SharedBuffer Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease)
+* [CoreWebView2SharedBuffer Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -78,8 +78,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view&preserve-view=true=webview2-winrt-1.0.1466-prerelease
-)
+* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true)
 
 ---
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 10/07/2022
+ms.date: 11/01/2022
 ---
 # Release Notes for the WebView2 SDK
 
@@ -62,11 +62,11 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 #### Experimental features
 
 *  Added support to create a shared memory based buffer with the specified size:
-	*  	`Close`
-	*  	`get_Buffer`
-	*  	`get_FileMappingHandle`
-	*  	`get_Size`
-	*  	`OpenStream`
+    *      `Close`
+    *      `get_Buffer`
+    *      `get_FileMappingHandle`
+    *      `get_Size`
+    *      `OpenStream`
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -105,11 +105,11 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 ---
 
 *  Added support to run JavaScript code from the JavaScript parameter in the current top-level document:
-	*  	`get_ColumnNumber`
-	*  	`get_LineNumber`
-	*  `get_Message`
-	*  `get_Name`
-	*  `get_ToJson`
+    *      `get_ColumnNumber`
+    *      `get_LineNumber`
+    *  `get_Message`
+    *  `get_Name`
+    *  `get_ToJson`
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -88,7 +88,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postsharedbuffertoscript?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
-* [CoreWebView2Frame.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postsharedbuffertoscript?view&preserve-view=true=webview2-dotnet-1.0.1466-prerelease#microsoft-web-webview2-core-corewebview2frame-postsharedbuffertoscript(microsoft-web-webview2-core-corewebview2sharedbuffer-microsoft-web-webview2-core-corewebview2sharedbufferaccess-system-string))
+* [CoreWebView2Frame.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postsharedbuffertoscript?view=webview2-dotnet-1.0.1466-prerelease&preserve-view=true)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 


### PR DESCRIPTION
Release Note for WebView2 with Stable 107 and prerelease 109 draft (.NET and WinRT doc links need to be updated once it's public)

Rendered: https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes?branch=pr-en-us-2277&tabs=dotnetcsharp