### PR TITLE
Relnotes fine-tuning

### DIFF
--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 11/01/2022
+ms.date: 11/03/2022
 ---
 # Release Notes for the WebView2 SDK
 
@@ -15,6 +15,7 @@ The WebView2 team updates the [WebView2 SDK](https://www.nuget.org/packages/Micr
 Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).
 
 WebView2 bug fixes, such as the fixes listed below, are either Runtime-specific or SDK-specific.
+
 
 #### Recommended browser channel and Runtime
 
@@ -26,26 +27,26 @@ Make sure to re-compile your WebView2 app after updating the WebView2 SDK NuGet 
 
 For more information, see [Matching the Runtime version with the SDK version](concepts/versioning.md#matching-the-runtime-version-with-the-sdk-version).
 
+
 #### Minimum version of the browser or Runtime to load WebView2
 
 To load WebView2, the minimum version of Microsoft Edge or the WebView2 Runtime is 86.0.616.0.  The minimum version to load WebView2 only changes when a breaking change occurs in the web platform.
 
 To use a prerelease SDK along with a Microsoft Edge preview channel, see [Test upcoming APIs and features](how-to/set-preview-channel.md).
 
+
 <!-- ====================================================================== -->
 ## 1.0.1418.22
 
-Release Date: October 31, 2022 
+Release Date: October 31, 2022
 
 [NuGet package for WebView2 SDK 1.0.1418.22](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.1418.22)
 
 For full API compatibility, this version of the WebView2 SDK requires WebView2 Runtime version 107.0.1418.22 or higher.
 
-### General 
+### General
 
 This WebView2 SDK release has the same bug fixes that are in WebView2 SDK 1.0.1466-prerelease. See **Bug fixes** in the following section.
-
----
 
 
 <!-- ====================================================================== -->
@@ -62,27 +63,37 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 #### Experimental features
 
 * Added support for creating a shared memory based buffer with a specified size:
-    *  `close`
-    *  `get_Buffer`
-    *  `get_FileMappingHandle`
-    *  `get_Size`
-    *  `OpenStream`  
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2SharedBuffer Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer?view=webview2-dotnet-1.0.1466-prerelease&preserve-view=true)
+    * `Buffer`
+    * `FileMappingHandle`
+    * `Size`
+    * `Close`
+    * `Dispose`
+    * `OpenStream`
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease&preserve-view=true)
+* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true)
+    * `Buffer`
+    * `Size`
+    * `Close`
+    * `OpenStream`
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true)
+* [ICoreWebView2ExperimentalSharedBuffer interface](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsharedbuffer?view=webview2-1.0.1466-prerelease&preserve-view=true)
+    * `Close`
+    * `get_Buffer`
+    * `get_FileMappingHandle`
+    * `get_Size`
+    * `OpenStream`
 
 ---
 
-*  Added support for accessing a shared buffer object from the script of the main frame or `iframe`.
+*  Added support for accessing a shared buffer object from the script of the main frame or `iframe`:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -102,34 +113,45 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 ---
 
 *  Added support for running JavaScript code from the `JavaScript` parameter in the current top-level document:
-    *  `ColumnNumber`
-    *  `LineNumber`
-    *  `Message`
-    *  `Name`
-    *  `ToJson`
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2ScriptException Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptexception?view=webview2-dotnet-1.0.1466-prerelease&preserve-view=true)
+   * `ColumnNumber`
+   * `LineNumber`
+   * `Message`
+   * `Name`
+   * `ToJson`
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2ScriptException Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptexception?view=webview2-winrt-1.0.1466-prerelease&preserve-view=true)
+   * `ColumnNumber`
+   * `LineNumber`
+   * `Message`
+   * `Name`
+   * `ToJson`
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2ExperimentalScriptException interface](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalscriptexception?view=webview2-1.0.1466-prerelease&preserve-view=true)
+   * `get_ColumnNumber`
+   * `get_LineNumber`
+   * `get_Message`
+   * `get_Name`
+   * `get_ToJson`
 
 ---
 
 #### Bug fixes
 
 *   Fixed a bug in which the custom header title in print settings could be wrong. ([Issue #2093](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2093))
-*   Display `AllowedCertificateAuthorities` in `add_ClientCertificateRequested` event as a `Base64` string. (Runtime)([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
+*   Display `AllowedCertificateAuthorities` in `add_ClientCertificateRequested` event as a `Base64` string. (Runtime) ([Issue #2346](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2346))
 *   Fixed a bug in which the default footer URI in print settings is missing. ([Issue #2851](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2851))
-*   Fixed a bug that produces a null pointer exception that's related to print settings. (Runtime)([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
+*   Fixed a bug that produces a null pointer exception that's related to print settings. (Runtime) ([Issue #2858](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2858))
 *   Fixed a bug that reports navigation failure when redirecting to a server that has been configured with Client Certificate Authentication and when the `WebResourceRequested` event is subscribed to. (Runtime)
 *   Fixed an `AddHostObjectToScript` bug in which, when JavaScript calls an async method and then a synchronous method, the async method call might fail.
+
 
 <!-- ====================================================================== -->
 ## 1.0.1370.28
@@ -147,10 +169,6 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 The following items are now stable:
 
 *  The drag and drop API:
-   * `DragEnter`
-   * `DragLeave`
-   * `DragOver`
-   * `Drop`
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -283,7 +301,6 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 *   Fixed a bug where it wasn't possible to dismiss the download popup after minimizing the window. (Runtime)
 
 
-
 <!-- ====================================================================== -->
 ## 1.0.1343.22
 
@@ -314,10 +331,6 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 The following items are now stable:
 
 *  The drag and drop API:
-   * `DragEnter`
-   * `DragLeave`
-   * `DragOver`
-   * `Drop`
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -325,6 +338,10 @@ The following items are now stable:
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
+* [ICoreWebView2CompositionControllerInterop2.DragEnter Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2?view=webview2-winrt-1.0.1369-prerelease&preserve-view=true#dragenter)
+* [ICoreWebView2CompositionControllerInterop2.DragLeave Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2?view=webview2-winrt-1.0.1369-prerelease&preserve-view=true#dragleave)
+* [ICoreWebView2CompositionControllerInterop2.DragOver Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2?view=webview2-winrt-1.0.1369-prerelease&preserve-view=true#dragover)
+* [ICoreWebView2CompositionControllerInterop2.Drop Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2?view=webview2-winrt-1.0.1369-prerelease&preserve-view=true#drop)
 * [CoreWebView2CompositionController.DragLeave Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller?view=webview2-winrt-1.0.1369-prerelease&preserve-view=true#dragleave)
 
 ##### [Win32/C++](#tab/win32cpp)


### PR DESCRIPTION
Rendered page for review:
https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes?branch=pr-en-us-2287

Changes made by this PR:
* Swapped Win32 & WinRT links.  Fixed Win32 link text.
* Removed spurious horizontal rule.
* Moved member lists into tabs & customized them per framework.
* Added space between )(
* Added WinRT 1369-prerelease drag/drop interop links.
* Normalized whitespace.

Before:
https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes?tabs=win32cpp#experimental-features
In the first tab-set in this section, the link is swapped and has incorrect link text in WinRT vs. Win32 tabs