### PR TITLE
Fixing a typo in the PWA widgets article

### DIFF
--- a/microsoft-edge/progressive-web-apps-chromium/how-to/widgets.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/widgets.md
@@ -447,7 +447,7 @@ The service worker global object also defines the `widgetclick` event that's fir
 
 Each widget is represented as a `widget` object, which contains the following properties:
 
-* `installable`: A Boolean indicating wether the widget is installable.
+* `installable`: A Boolean indicating whether the widget is installable.
 * `definition`: A [widgetDefinition object](#widgetdefinition-object).
 * `instances`: An array of [widgetInstance objects](#widgetinstance-object) representing the current state of each instance of the widget.
 

--- a/microsoft-edge/progressive-web-apps-chromium/how-to/widgets.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/widgets.md
@@ -447,7 +447,7 @@ The service worker global object also defines the `widgetclick` event that's fir
 
 Each widget is represented as a `widget` object, which contains the following properties:
 
-* `installable`: A Boolean indicating wither the widget is installable.
+* `installable`: A Boolean indicating wether the widget is installable.
 * `definition`: A [widgetDefinition object](#widgetdefinition-object).
 * `instances`: An array of [widgetInstance objects](#widgetinstance-object) representing the current state of each instance of the widget.
 


### PR DESCRIPTION
This is a follow-up PR to fix a typo in the new PWA Widgets article that I merged last week.