### PR TITLE
New subheading "About WinUI and WebView2"

### DIFF
--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -27,6 +27,7 @@ The **Microsoft.UI.Xaml** (WinUI 2) package is part of the Windows UI Library.  
 WinUI 2 supports UWP only.  These controls are backward-compatible.
 
 
+<!-- ------------------------------ -->
 #### Completed project
 
 Unlike some of the other tutorials, there isn't a completed version of this Getting Started tutorial in the WebView2Samples repo.
@@ -37,6 +38,18 @@ Unlike some of the other tutorials, there isn't a completed version of this Gett
 -->
 
 Follow the major Step sections in sequence, below.
+
+
+<!-- ------------------------------ -->
+#### About WinUI and WebView2
+
+In WinUI 2 or WinUI 3 apps, WebView2 is exposed as a XAML control.  After you embed the XAML control in your app as a named control, you can then refer to that XAML control within C# files.
+
+Only a subset of WebView2 interfaces/functions are exposed in WinUI:
+* The `WebView2` XAML object exposes the `CoreWebView2` interface, along with the most important functionality.
+* Interfaces such as `CoreWebView2Controller` are hidden, because WinUI takes care of the environment and window creation behind the scenes.
+
+See also [Xbox, HoloLens, and XAML limitations](#xbox-hololens-and-xaml-limitations) below.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -43,10 +43,12 @@ Follow the major Step sections in sequence, below.
 <!-- ------------------------------ -->
 #### About WinUI and WebView2
 
-In WinUI 2 or WinUI 3 apps, WebView2 is exposed as a XAML control.  After you embed the XAML control in your app as a named control, you can then refer to that XAML control within C# files.
+In WinUI 2 (UWP) apps, WebView2 is exposed as a XAML control.  After you embed the XAML control in your app as a named control, you can then refer to that XAML control within C# files.
 
 Only a subset of WebView2 interfaces/functions are exposed in WinUI:
+
 * The `WebView2` XAML object exposes the `CoreWebView2` interface, along with the most important functionality.
+
 * Interfaces such as `CoreWebView2Controller` are hidden, because WinUI takes care of the environment and window creation behind the scenes.
 
 See also [Xbox, HoloLens, and XAML limitations](#xbox-hololens-and-xaml-limitations) below.


### PR DESCRIPTION
Rendered article section for review, section "About WinUI and WebView2" at top:
https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/get-started/winui2?branch=pr-en-us-2364

GitHub's rendering:
https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/winui-and-wv2/microsoft-edge/webview2/get-started/winui2.md#about-winui-and-webview2