### PR TITLE
Renamed "Web platform" TOC bucket to "Development tips for Microsoft Edge"

### DIFF
--- a/microsoft-edge/develop-web-microsoft-edge.md
+++ b/microsoft-edge/develop-web-microsoft-edge.md
@@ -157,7 +157,7 @@ See [The Web We Want initiative](web-we-want/index.md).
 <!-- ============================================================================================================================================ -->
 ## How to use this documentation
 
-These are tips for using the documentation UI of Microsoft Learn.
+The following sections are tips for using the Microsoft Learn website.
 
 
 <!-- ====================================================================== -->
@@ -169,8 +169,8 @@ To see details of a screenshot or diagram:
 
 1. Close the image tab to return to the article.
 
-<!-- ====================================================================== -->
 
+<!-- ====================================================================== -->
 ## Look up key words and terms in "Filter by title" text box
 
 The multi-purpose **Filter by title** text box supports:
@@ -191,8 +191,8 @@ The full-text search page initially searches all _Microsoft Edge_ documentation.
 
 ![The full-text search page initially searches all Microsoft Edge documentation, or you can click the link 'View all results' for a broader search.](media/full-text-search-page.png)
 
-<!-- ====================================================================== -->
 
+<!-- ====================================================================== -->
 ## Provide feedback or report issues in the Microsoft Edge Developer documentation
 
 To provide feedback or enter issues:

--- a/microsoft-edge/develop-web-microsoft-edge.md
+++ b/microsoft-edge/develop-web-microsoft-edge.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: devtools
-ms.date: 02/14/2022
+ms.date: 01/17/2023
 ---
 # Develop for the web with Microsoft Edge
 

--- a/microsoft-edge/develop-web-microsoft-edge.md
+++ b/microsoft-edge/develop-web-microsoft-edge.md
@@ -101,7 +101,7 @@ See [Test and automation in Microsoft Edge](test-and-automation/test-and-automat
 
 
 <!-- ====================================================================== -->
-## Web platform
+## Development tips for Microsoft Edge
 
 Considerations for developing websites and products for the web platform include the following:
 
@@ -112,7 +112,7 @@ Considerations for developing websites and products for the web platform include
 *  Customizing the Password Reveal button.
 *  Detecting Windows 11 by using User-Agent Client Hints.
 
-See [Web platform](web-platform/web-platform.md).
+See [Web platform overview](web-platform/web-platform.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/develop-web-microsoft-edge.md
+++ b/microsoft-edge/develop-web-microsoft-edge.md
@@ -103,7 +103,7 @@ See [Test and automation in Microsoft Edge](test-and-automation/test-and-automat
 <!-- ====================================================================== -->
 ## Development tips for Microsoft Edge
 
-There are many tips and tricks to be aware of when building on the web platform, including:
+There are many tips and tricks to be aware of when building websites or web apps that work in Microsoft Edge, including:
 
 *  Testing for coming changes that could impact compatibility of your website with Microsoft Edge.
 *  Moving users to Microsoft Edge from Internet Explorer.

--- a/microsoft-edge/develop-web-microsoft-edge.md
+++ b/microsoft-edge/develop-web-microsoft-edge.md
@@ -103,7 +103,7 @@ See [Test and automation in Microsoft Edge](test-and-automation/test-and-automat
 <!-- ====================================================================== -->
 ## Development tips for Microsoft Edge
 
-Considerations for developing websites and products for the web platform include the following:
+There are many tips and tricks to be aware of when building on the web platform, including:
 
 *  Testing for coming changes that could impact compatibility of your website with Microsoft Edge.
 *  Moving users to Microsoft Edge from Internet Explorer.

--- a/microsoft-edge/develop-web-microsoft-edge.md
+++ b/microsoft-edge/develop-web-microsoft-edge.md
@@ -112,7 +112,7 @@ There are many tips and tricks to be aware of when building websites or web apps
 *  Customizing the Password Reveal button.
 *  Detecting Windows 11 by using User-Agent Client Hints.
 
-See [Web platform overview](web-platform/web-platform.md).
+See [Development tips for Microsoft Edge](web-platform/web-platform.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -179,7 +179,7 @@ landingContent:
     linkLists:
       - linkListType: how-to-guide
         links:
-          - text: Web platform overview  # new firstchild article
+          - text: Development tips for Microsoft Edge
             url: /microsoft-edge/web-platform/web-platform
 
           - text: Site compatibility-impacting changes

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -175,7 +175,7 @@ landingContent:
             url: /microsoft-edge/webview2/webview2-api-reference
 # =============================================================================
 # Card r2c3
-  - title: Web platform
+  - title: Development tips for Microsoft Edge
     linkLists:
       - linkListType: how-to-guide
         links:

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -307,7 +307,7 @@ conceptualContent:
         # Card
         - title: Development tips for Microsoft Edge
           links:
-            - text: Web platform overview
+            - text: Development tips for Microsoft Edge
               url: /microsoft-edge/web-platform/web-platform  # new firstchild article
               itemType: overview
 

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -305,7 +305,7 @@ conceptualContent:
               itemType: how-to-guide
               text: webhint extension for Visual Studio Code
         # Card
-        - title: Web platform
+        - title: Development tips for Microsoft Edge
           links:
             - text: Web platform overview
               url: /microsoft-edge/web-platform/web-platform  # new firstchild article

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1419,7 +1419,7 @@
 # if top-of-page title is longer, add it to displayName comma-delimited list of lookup keywords
     - name: Development tips for Microsoft Edge
       items:
-        - name: Web platform overview # new firstchild article
+        - name: Development tips for Microsoft Edge
           href: web-platform/web-platform.md
           displayName: 
 

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1417,7 +1417,7 @@
 
 # =============================================================================
 # if top-of-page title is longer, add it to displayName comma-delimited list of lookup keywords
-    - name: Web platform
+    - name: Development tips for Microsoft Edge
       items:
         - name: Web platform overview # new firstchild article
           href: web-platform/web-platform.md

--- a/microsoft-edge/web-platform/web-platform.md
+++ b/microsoft-edge/web-platform/web-platform.md
@@ -1,5 +1,5 @@
 ---
-title: Web platform overview
+title: Development tips for Microsoft Edge
 description: Testing for coming changes that could impact compatibility of your site with Microsoft Edge.  Moving users from Internet Explorer.  Setting up tracking prevention.  Detecting Microsoft Edge from your website. Detecting Windows 11 via User-Agent Client Hints.
 author: MSEdgeTeam
 ms.author: msedgedevrel
@@ -8,7 +8,7 @@ ms.prod: microsoft-edge
 ms.technology: devtools
 ms.date: 11/28/2022
 ---
-# Web platform overview
+# Development tips for Microsoft Edge
 
 There are many tips and tricks to be aware of when building websites or web apps that work in Microsoft Edge, including:
 

--- a/microsoft-edge/web-platform/web-platform.md
+++ b/microsoft-edge/web-platform/web-platform.md
@@ -10,7 +10,7 @@ ms.date: 11/28/2022
 ---
 # Web platform overview
 
-The following are considerations for developing websites and products for the web platform, specifically for Microsoft Edge:
+There are many tips and tricks to be aware of when building websites or web apps that work in Microsoft Edge, including:
 
 *  Testing for coming changes that could impact compatibility of your website with Microsoft Edge.
 *  Moving users to Microsoft Edge from Internet Explorer.


### PR DESCRIPTION
Rendered articles for review:
* Topmost article, see 'web platform' h2 section renamed "devmt tips":
   * https://review.learn.microsoft.com/en-us/microsoft-edge/develop-web-microsoft-edge?branch=pr-en-us-2400#development-tips-for-microsoft-edge
* The top-level article for 'web platform' TOC bucket, retitled:
   * https://review.learn.microsoft.com/en-us/microsoft-edge/web-platform/web-platform?branch=pr-en-us-2400
* Landing card title: 
   * https://review.learn.microsoft.com/en-us/microsoft-edge/developer/index?branch=pr-en-us-2400
* Hub card title:
   * https://review.learn.microsoft.com/en-us/microsoft-edge/index?branch=pr-en-us-2400

GitHub rendered version of the above:
* https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/webplat-toc/microsoft-edge/develop-web-microsoft-edge.md#development-tips-for-microsoft-edge
* https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/webplat-toc/microsoft-edge/web-platform/web-platform.md
* Landing: Line 177: "Card r2c3" "title: Development tips for Microsoft Edge"  https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/webplat-toc/microsoft-edge/developer/index.yml
* Hub: Line 308: card title "Development tips for Microsoft Edge"  https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/webplat-toc/microsoft-edge/index.yml