### PR TITLE
Link to API Ref not Seealso, add tab-set in Ref nav page

### DIFF
--- a/microsoft-edge/webview2/concepts/navigation-events.md
+++ b/microsoft-edge/webview2/concepts/navigation-events.md
@@ -95,4 +95,3 @@ The WebView2 [Sample apps](../code-samples-links.md) also demonstrate handling n
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](/dotnet/api/microsoft.web.webview2.wpf.webview2)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/concepts/process-model.md
+++ b/microsoft-edge/webview2/concepts/process-model.md
@@ -98,4 +98,3 @@ All processes that are associated with the browser process of your WebView2 are 
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](/dotnet/api/microsoft.web.webview2.wpf.webview2)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/concepts/threading-model.md
+++ b/microsoft-edge/webview2/concepts/threading-model.md
@@ -152,4 +152,3 @@ private async void Button_Click(object sender, EventArgs e)
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](/dotnet/api/microsoft.web.webview2.wpf.webview2)
-* [See also](../index.md#see-also) - in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -569,7 +569,7 @@ If you were to distribute the app that results from this tutorial, you would nee
 
 * [Distribute your app and the WebView2 Runtime](../concepts/distribution.md)
 * [WinForms sample app](../samples/webview2windowsformsbrowser.md) - Demonstrates more WebView2 APIs than the present tutorial.
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_ - Conceptual and how-to articles about building and deploying WebView2 apps.
-* [Microsoft.Web.WebView2.WinForms](/dotnet/api/microsoft.web.webview2.winforms) - API Reference.
-
-<!-- todo: remove "[see also]" link, replace by direct links -->
+* [WebView2 API Reference](../webview2-api-reference.md)
+   * [Core](/dotnet/api/microsoft.web.webview2.core)
+   * [WPF](/dotnet/api/microsoft.web.webview2.wpf)
+   * [Windows Forms](/dotnet/api/microsoft.web.webview2.winforms)

--- a/microsoft-edge/webview2/get-started/winui.md
+++ b/microsoft-edge/webview2/get-started/winui.md
@@ -445,34 +445,18 @@ The following interfaces aren't accessible in WinUI 3:
 
 
 <!-- ====================================================================== -->
-## API Reference
-
-WinUI 3 API Reference (Windows App SDK):
-* [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.webview2) - in API reference for Windows desktop apps > WinRT APIs.
-
-All platforms/languages:
-* [WebView2 API Reference](../webview2-api-reference.md) - API Reference for each platform.
-
-
-<!-- ====================================================================== -->
 ## See also
 
-developer.microsoft.com:
-* [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2 features at developer.microsoft.com.
-
-Local pages:
+* [WebView2 API Reference](../webview2-api-reference.md)
 * [Introduction to Microsoft Edge WebView2](../index.md) - overview of features.
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.
 * [Manage user data folders](../concepts/user-data-folder.md)
 * [Sample Code for WebView2](../code-samples-links.md) - a guide to the `WebView2Samples` repo.
 * [Development best practices for WebView2 appsDevelopment best practices](../concepts/developer-guide.md)
+
+developer.microsoft.com:
+* [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2 features at developer.microsoft.com.
 
 GitHub:
 * [Getting Started with WebView2 in WinUI3](https://github.com/MicrosoftEdge/WebView2Samples/tree/main/GettingStartedGuides/WinUI3_GettingStarted#readme)
 * [Spec: The WebView2 Xaml control](https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/WebView2/WebView2_spec.md) - the WinUI 3.0 version of the WebView2 control.
 * [microsoft-ui-xaml repo > Issues](https://github.com/microsoft/microsoft-ui-xaml/issues) - to enter WinUI-specific feature requests or bugs.
-
-<!--
-state why this link is in this tutorial page and what its relevance is, or else delete:
-* [Windows Update: FAQ](https://support.microsoft.com/help/12373).
--->

--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -408,7 +408,6 @@ The following interfaces aren't accessible in WinUI 2:
 * [Manage user data folders](../concepts/user-data-folder.md)
 * [Sample Code for WebView2](../code-samples-links.md) - a guide to the `WebView2Samples` repo.
 * [Development best practices for WebView2 apps](../concepts/developer-guide.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_ - articles about building and deploying WebView2 apps.
 
 GitHub:
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples)

--- a/microsoft-edge/webview2/get-started/wpf.md
+++ b/microsoft-edge/webview2/get-started/wpf.md
@@ -562,6 +562,9 @@ Congratulations, you built your first WebView2 app!
 <!-- ====================================================================== -->
 ## See also
 
+* [WebView2 API Reference](../webview2-api-reference.md)
+   * [WPF](/dotnet/api/microsoft.web.webview2.wpf)
+
 developer.microsoft.com:
 * [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2) - initial introduction to WebView2 features at developer.microsoft.com.
 
@@ -570,11 +573,6 @@ Local pages:
 * [Manage user data folders](../concepts/user-data-folder.md)
 * [Sample Code for WebView2](../code-samples-links.md) - a guide to the `WebView2Samples` repo.
 * [Development best practices for WebView2 apps](../concepts/developer-guide.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.
-
-API Reference:
-* [API reference: WebView2 class in WebView2.Wpf namespace](/dotnet/api/microsoft.web.webview2.wpf.webview2)
-* [API reference: WebView2.Wpf namespace](/dotnet/api/microsoft.web.webview2.wpf)
 
 GitHub:
 * [WebView2Samples repo > WebView2WpfBrowser](https://github.com/MicrosoftEdge/WebView2Samples/tree/main/SampleApps/WebView2WpfBrowser)

--- a/microsoft-edge/webview2/how-to/debug-devtools.md
+++ b/microsoft-edge/webview2/how-to/debug-devtools.md
@@ -46,4 +46,3 @@ If none of the above approaches are available, you can add `--auto-open-devtools
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](../webview2-api-reference.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -235,4 +235,3 @@ To solve the issue, confirm that the WebView2 control opened the CDP port.  Make
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](../webview2-api-reference.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/how-to/debug-visual-studio.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio.md
@@ -106,4 +106,3 @@ Virtual source path mapping works when you use the debugger in <!-- Visual Studi
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](../webview2-api-reference.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/how-to/debug.md
+++ b/microsoft-edge/webview2/how-to/debug.md
@@ -25,4 +25,3 @@ WebView2 apps combine the best of web and native app development features and to
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](../webview2-api-reference.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/how-to/javascript.md
+++ b/microsoft-edge/webview2/how-to/javascript.md
@@ -150,5 +150,4 @@ To begin, explore the current functionality of the right-click menu:
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](../webview2-api-reference.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.
 * [Web/native interop](../concepts/overview-features-apis.md#webnative-interop) in _Overview of WebView2 features and APIs_.

--- a/microsoft-edge/webview2/how-to/static.md
+++ b/microsoft-edge/webview2/how-to/static.md
@@ -44,4 +44,3 @@ For an app that doesn't ship `WebView2Loader.dll`, do the following:
 * [Get started with WebView2](../get-started/get-started.md)
 * [WebView2Samples repo](https://github.com/MicrosoftEdge/WebView2Samples) - a comprehensive example of WebView2 capabilities.
 * [WebView2 API reference](../webview2-api-reference.md)
-* [See also](../index.md#see-also) in _Introduction to Microsoft Edge WebView2_.

--- a/microsoft-edge/webview2/samples/webview2-winui3-sample.md
+++ b/microsoft-edge/webview2/samples/webview2-winui3-sample.md
@@ -37,3 +37,11 @@ This sample was created using Visual Studio 2022.  To build and run this sample,
 1. Press `F5`.  A dialog might open, saying "There were deployment errors.  Continue?"  Click the **No** button.
 
 1. Right-click the **WebView2_WinUI3_Sample** project, and then select **Debug > Start New Instance**. -->
+
+
+<!-- ====================================================================== -->
+## See also
+
+* [WebView2 API Reference](../webview2-api-reference.md)
+* [Get started with WebView2 in WinUI 3 (Windows App SDK) apps](../get-started/winui.md)
+* [Call native-side WinRT code from web-side code](../how-to/winrt-from-js.md)

--- a/microsoft-edge/webview2/samples/webview2_sample_uwp.md
+++ b/microsoft-edge/webview2/samples/webview2_sample_uwp.md
@@ -198,4 +198,5 @@ Now that the NuGet packages have been updated, build and run the project again:
 <!-- ====================================================================== -->
 ## See also
 
+* [WebView2 API Reference](../webview2-api-reference.md)
 * [Get started with WebView2 in WinUI 2 (UWP) apps](../get-started/winui2.md)

--- a/microsoft-edge/webview2/samples/webview2apissample.md
+++ b/microsoft-edge/webview2/samples/webview2apissample.md
@@ -561,4 +561,5 @@ window.chrome.webview.addEventListener('message', arg => {
 <!-- ====================================================================== -->
 ## See also
 
+* [WebView2 API Reference](../webview2-api-reference.md)
 * [Get started with WebView2 in Win32 apps](../get-started/win32.md)

--- a/microsoft-edge/webview2/samples/webview2browser.md
+++ b/microsoft-edge/webview2/samples/webview2browser.md
@@ -875,3 +875,9 @@ function addHistoryItem(item, callback) {
 ## Handling JSON and URIs
 
 WebView2Browser uses Microsoft's [cpprestsdk (Casablanca)](https://github.com/Microsoft/cpprestsdk) to handle all JSON in the C++ side of things. IUri and CreateUri are also used to parse file paths into URIs and can be used to for other URIs as well.
+
+
+<!-- ====================================================================== -->
+## See also
+
+* [WebView2 API Reference](../webview2-api-reference.md)

--- a/microsoft-edge/webview2/samples/webview2samplewincomp.md
+++ b/microsoft-edge/webview2/samples/webview2samplewincomp.md
@@ -184,4 +184,4 @@ This step is optional.  The sample has preinstalled:
 ## See also
 
 * [Get started with WebView2 in Win32 apps](../get-started/win32.md)
-* [WebView2 Reference Documentation](/microsoft-edge/webview2/webview2-api-reference)
+* [WebView2 API Reference](../webview2-api-reference.md)

--- a/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
@@ -181,4 +181,5 @@ At the top of Visual Studio, set the build target, as follows:
 <!-- ====================================================================== -->
 ## See also
 
+* [WebView2 API Reference](../webview2-api-reference.md)
 * [Get started with WebView2 in WinForms apps](../get-started/winforms.md)

--- a/microsoft-edge/webview2/samples/webview2wpfbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2wpfbrowser.md
@@ -125,4 +125,5 @@ At the top of Visual Studio, set the build target, as follows:
 <!-- ====================================================================== -->
 ## See also
 
+* [WebView2 API Reference](../webview2-api-reference.md)
 * [Get started with WebView2 in WPF apps](../get-started/wpf.md)

--- a/microsoft-edge/webview2/samples/wv2cdpextensionwpfsample.md
+++ b/microsoft-edge/webview2/samples/wv2cdpextensionwpfsample.md
@@ -182,4 +182,5 @@ For more information, see [WebView2 CDP Extension](https://aka.ms/webviewcdpnuge
 <!-- ====================================================================== -->
 ## See also
 
+* [WebView2 API Reference](../webview2-api-reference.md)
 * [Get started with WebView2 in WinUI 2 (UWP) apps](../get-started/winui2.md)

--- a/microsoft-edge/webview2/webview2-api-reference.md
+++ b/microsoft-edge/webview2/webview2-api-reference.md
@@ -12,12 +12,18 @@ ms.date: 08/03/2022
 
 The Microsoft Edge WebView2 control enables you to host web content in your application using Chromium-based Microsoft Edge as the rendering engine.
 
-WebView2 is available for the following frameworks (or platforms) and programming languages:
+WebView2 is available for the following frameworks or platforms:
+
+
+##### [.NET](#tab/dotnet)
 
 *  .NET
    * [Core](/dotnet/api/microsoft.web.webview2.core)
    * [WPF](/dotnet/api/microsoft.web.webview2.wpf)
    * [Windows Forms](/dotnet/api/microsoft.web.webview2.winforms)
+
+
+##### [WinRT](#tab/winrt)
 
 *  WinRT
    * [Microsoft.Web.WebView2.Core](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/index) - Common to all WinRT frameworks.
@@ -27,7 +33,12 @@ WebView2 is available for the following frameworks (or platforms) and programmin
    *  WinUI 3 (Windows App SDK)
       * [Microsoft.UI.Xaml.Controls.WebView2 Class](/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.webview2)
 
-* [Win32/C++](/microsoft-edge/webview2/reference/win32/index)
+
+##### [Win32](#tab/win32)
+
+* [API Reference for WebView2 Win32 C++](/microsoft-edge/webview2/reference/win32)
+
+---
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
Changes made in this PR:
* From GetStart & Sample articles, linked to API Ref nav page instead of to See Also of Intro article.
* Added a tab-set in the API Ref nav page.

Some rendered pages:
* https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/webview2-api-reference?branch=pr-en-us-2426
* https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/get-started/wpf?branch=pr-en-us-2426#see-also

GH rendered:
* https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/see-also/microsoft-edge/webview2/webview2-api-reference.md
* https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/see-also/microsoft-edge/webview2/get-started/wpf.md#see-also

AB#43105593