### PR TITLE
WebView2 JS Doc: Fix malformat

### DIFF
--- a/microsoft-edge/webview2/reference/javascript/sharedbufferreceivedevent.yml
+++ b/microsoft-edge/webview2/reference/javascript/sharedbufferreceivedevent.yml
@@ -13,7 +13,7 @@ remarks: >-
 
   The following example sends data to script for one-time, read-only consumption.
 
-  First, in the native host app code, set data into the shared memory:
+  "First, in the native host app code, set data into the shared memory:"
 
   ```cpp
   wil::com_ptr<ICoreWebView2ExperimentalEnvironment10> environment;
@@ -44,7 +44,7 @@ remarks: >-
   ```
 
   In the HTML document, subscribe to and handle sharedbufferreceived event.Next, in the HTML document, subscribe to and
-  then handle the `sharedbufferreceived` event:
+  "then handle the `sharedbufferreceived` event:"
 
   ```html
   window.chrome.webview.addEventListener("sharedbufferreceived", e => {

--- a/microsoft-edge/webview2/reference/javascript/sharedbufferreceivedevent.yml
+++ b/microsoft-edge/webview2/reference/javascript/sharedbufferreceivedevent.yml
@@ -6,14 +6,13 @@ fullName: SharedBufferReceivedEvent
 summary: >-
   Event object for the `chrome.webview.sharedbufferreceived` event. This event is dispatched when
   `CoreWebView2.PostSharedBufferToScript` is successfully called.
-remarks: >-
-
+remarks: |-
 
   #### Examples
 
   The following example sends data to script for one-time, read-only consumption.
 
-  First, in the native host app code, set data into the shared memory.
+  First, in the native host app code, set data into the shared memory:
 
   ```cpp
   wil::com_ptr<ICoreWebView2ExperimentalEnvironment10> environment;
@@ -45,8 +44,7 @@ remarks: >-
 
   In the HTML document, subscribe to and handle sharedbufferreceived event.
   
-  Next, in the HTML document, subscribe to and
-  then handle the `sharedbufferreceived` event.
+  Next, in the HTML document, subscribe to and then handle the `sharedbufferreceived` event:
 
   ```html
   window.chrome.webview.addEventListener("sharedbufferreceived", e => {

--- a/microsoft-edge/webview2/reference/javascript/sharedbufferreceivedevent.yml
+++ b/microsoft-edge/webview2/reference/javascript/sharedbufferreceivedevent.yml
@@ -13,7 +13,7 @@ remarks: >-
 
   The following example sends data to script for one-time, read-only consumption.
 
-  "First, in the native host app code, set data into the shared memory:"
+  First, in the native host app code, set data into the shared memory.
 
   ```cpp
   wil::com_ptr<ICoreWebView2ExperimentalEnvironment10> environment;
@@ -43,8 +43,10 @@ remarks: >-
   sharedBuffer->Close();
   ```
 
-  In the HTML document, subscribe to and handle sharedbufferreceived event.Next, in the HTML document, subscribe to and
-  "then handle the `sharedbufferreceived` event:"
+  In the HTML document, subscribe to and handle sharedbufferreceived event.
+  
+  Next, in the HTML document, subscribe to and
+  then handle the `sharedbufferreceived` event.
 
   ```html
   window.chrome.webview.addEventListener("sharedbufferreceived", e => {


### PR DESCRIPTION
Use `|-` instead of `>-` to fix missing linebreaks.

After the fix:
![image](https://user-images.githubusercontent.com/55165503/219310487-e8be9cb3-882d-4760-b4cc-a22153be0e25.png)


AB#43386857