### PR TITLE
Fixed Lighthouse tool landing page links

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/lighthouse/lighthouse-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/lighthouse/lighthouse-tool.md
@@ -14,5 +14,5 @@ Use the Lighthouse tool to identify and fix common problems that affect your sit
 The Lighthouse tool was previously called the _Audits_ tool.
 
 See:
+* [Optimize website speed using Lighthouse](../speed/get-started.md)
 * [Test accessibility using Lighthouse](../accessibility/lighthouse.md)
-* [Establish a baseline](../speed/get-started.md#establish-a-baseline) in _Optimize website speed using Lighthouse_


### PR DESCRIPTION
Listed main article first.
Linked to whole article not h2 anchor section.

Rendered page for review:
https://review.learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/lighthouse/lighthouse-tool?branch=pr-en-us-2459 [[gh rendered](https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/lighthouse-landing/microsoft-edge/devtools-guide-chromium/lighthouse/lighthouse-tool.md)]

AB#43482321