### PR TITLE
Removed EdgeHTML VM link from "Emulate and test other browsers"

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
+++ b/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
@@ -5,7 +5,7 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
-ms.date: 05/04/2021
+ms.date: 02/24/2023
 ---
 <!-- Copyright Meggin Kearney and Paul Bakaus
 
@@ -24,7 +24,9 @@ ms.date: 05/04/2021
 
 Your job doesn't end with making sure your site runs great across Microsoft Edge and Android.  Even though the [Device Emulation](index.md) tool can simulate a range of other devices such as smart phones, we encourage you to check out solutions for emulation provided by other browsers.
 
-### Summary
+
+<!-- ------------------------------ -->
+#### Summary
 
 *  When you don't have a particular device, or want to do a spot check on something, the best option is to emulate the device right inside your browser.
 
@@ -38,11 +40,15 @@ Your job doesn't end with making sure your site runs great across Microsoft Edge
 
 Browser emulators are great for testing the responsiveness of a site.  But a browser emulator doesn't emulate differences in API, CSS support, and certain behaviors that manifest only on a mobile browser on an actual device.  Test your site on browsers running on real devices, to be certain everything behaves as expected.
 
-### Firefox Responsive Design View
+
+<!-- ------------------------------ -->
+#### Firefox Responsive Design View
 
 Firefox has a [responsive design view](https://developer.mozilla.org/docs/Tools/Responsive_Design_View) that encourages you to stop thinking in terms of specific devices and instead explore how your design changes at common screen sizes, or on your own screen size by dragging the edges of the window.
 
-### EdgeHTML emulation
+
+<!-- ------------------------------ -->
+#### EdgeHTML emulation
 
 To emulate Windows Phones, use the Microsoft Edge (EdgeHTML) [built-in emulation](/archive/microsoft-edge/legacy/developer/devtools-guide/emulation).
 
@@ -54,7 +60,9 @@ Use [IE 11 Emulation](/previous-versions/windows/internet-explorer/ie-developer/
 
 Device simulators and emulators simulate not just the browser environment but the entire device.  Each simulator is useful to test things that require OS integration, such as form input with virtual keyboards.
 
-### Android emulator
+
+<!-- ------------------------------ -->
+#### Android emulator
 
 <!--
 ![Stock Browser in Android Emulator](../media/device-mode-android-emulator-stock-browser.msft.png)
@@ -65,7 +73,7 @@ At the moment, there is no way to install Microsoft Edge on an Android emulator.
 The Android emulator comes with the Android SDK which you need to download as part of [Android Studio](https://developer.android.com/sdk/installing/studio.html).  Then follow the instructions to [set up a virtual device](https://developer.android.com/tools/devices/managing-avds.html) and [start the emulator](https://developer.android.com/tools/devices/emulator.html).
 After your emulator is booted, select the **Browser** icon, and test your site on the old Stock Browser for Android.
 
-#### Chromium content shell on Android
+###### Chromium content shell on Android
 
 <!--
 ![Android Emulator Content Shell](../media/device-mode-android-avd-contentshell.msft.png)
@@ -81,7 +89,7 @@ chmod u+x ./chromium-android-installer/*.sh
 
 Now you can test your site with the Chromium Content Shell.
 
-#### Firefox on Android
+###### Firefox on Android
 
 <!--
 ![Firefox Icon on Android Emulator](../media/device-mode-ff-on-android-emulator.msft.png)
@@ -97,7 +105,9 @@ To install the file onto an open emulator or connected Android device, run the f
 adb install <path_to_APK>/fennec-XX.X.XX.android-arm.apk
 ```
 
-### iOS simulator
+
+<!-- ------------------------------ -->
+#### iOS simulator
 
 The iOS simulator for Mac OS X comes with Xcode, which you [install from the App Store](https://itunes.apple.com/app/xcode/id497799835).
 
@@ -106,11 +116,11 @@ When you are done, learn how to work with the simulator through [Apple Developer
 > [!NOTE]
 > To avoid having to open Xcode every time you want to use the iOS Simulator, open <!--Xcode, or iOS Simulator?-->it, right-click the iOS Simulator icon in your dock, and then select **Keep in Dock**.  Now just click the icon whenever you need it.
 
-### Microsoft Edge (EdgeHTML)
 
-![modern.IE VM](../media/device-mode-modern-ie-vm.msft.png)
+<!-- ------------------------------ -->
+#### Microsoft Edge (EdgeHTML)
 
-Microsoft Edge (EdgeHTML) Virtual Machines (VMs) enable you to access different versions of EdgeHTML and Internet Explorer on your computer through VirtualBox (or VMWare).  Select a [virtual machine on the download page](https://developer.microsoft.com/microsoft-edge/tools/vms).
+If you need to test your website or app with Microsoft browsers and don't have the necessary versions of Windows to do so, you can use BrowserStack, which supports testing of many combinations of Microsoft browsers and operating systems both past and present.  Testing of Microsoft Edge is free on BrowserStack.  For more information, see [Microsoft Edge Browser Testing](https://www.browserstack.com/test-on-microsoft-edge-browser) at BrowserStack.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
+++ b/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
@@ -120,7 +120,7 @@ When you are done, learn how to work with the simulator through [Apple Developer
 <!-- ------------------------------ -->
 #### Microsoft Edge (EdgeHTML)
 
-If you need to test your website or app with Microsoft browsers and don't have the necessary versions of Windows to do so, you can use BrowserStack, which supports testing of many combinations of Microsoft browsers and operating systems both past and present.  Testing of Microsoft Edge is free on BrowserStack.  For more information, see [Microsoft Edge Browser Testing](https://www.browserstack.com/test-on-microsoft-edge-browser) at BrowserStack.
+If you need to test your website or app with Microsoft browsers and don't have the necessary versions of Windows to do so, you can use BrowserStack, which supports testing of many combinations of Microsoft browsers and operating systems both past and present.  For example, you can test all versions of Microsoft Edge (Chromium) from version 80 onwards, and Microsoft Edge (EdgeHTML) versions 15 through 18.  Testing of Microsoft Edge is free on BrowserStack.  For more information, see [Microsoft Edge Browser Testing](https://www.browserstack.com/test-on-microsoft-edge-browser) at BrowserStack.
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
This PR fixes https://github.com/MicrosoftDocs/edge-developer/issues/2468 by removing the screenshot and link, and adding some of the info from the archive of the removed VM download page.

Info:
https://web.archive.org/web/20230112030225/https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/

Rendered page section for review:
https://review.learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers?branch=pr-en-us-2469#microsoft-edge-edgehtml [[gh rendered](https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/vm/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md#microsoft-edge-edgehtml)]

AB#43508860