### PR TITLE
Update winui2.md to note unsupported custom CSS cursors

### DIFF
--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -378,6 +378,12 @@ On WinUI 2, transparency is achieved by setting the color to `00FFFFFF`.
 
 
 <!-- ------------------------------ -->
+#### Custom cursors
+
+On WinUI 2, you cannot use [CSS cursors](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) with a URL of an image as the cursor. You can use CSS cursors to change the cursor to a predefined cursor such as `cursor: wait;` or `cursor: crosshair;`, just not a value where you specify your own image via URL such as `cursor: url(https://example.com/cursor.png), pointer;`. See [CSS - cursor loaded from URL doesn't work](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1925).
+
+
+<!-- ------------------------------ -->
 #### Microsoft Edge Developer Tools
 
 On WinUI 2, Microsoft Edge DevTools cannot be launched inside a store-signed WebView2 WinUI 2 (UWP) app.  However, you can work around this by using remote debugging.  See [Remote debugging WebView2 WinUI 2 (UWP) apps with Remote Tools for Microsoft Edge](../how-to/remote-debugging.md).
@@ -386,11 +392,10 @@ On WinUI 2, Microsoft Edge DevTools cannot be launched inside a store-signed Web
 <!-- ------------------------------ -->
 #### API limitations
 
-The following interfaces aren't accessible in WinUI 2:
+The following classes aren't accessible in WinUI 2:
 
-* `ICoreWebView2Environment`
-* `ICoreWebView2EnvironmentOptions` and `ICoreWebView2EnvironmentOptions2`
-* `ICoreWebView2ControllerOptions`
+* `CoreWebView2EnvironmentOptions`
+* `CoreWebView2ControllerOptions`
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -380,7 +380,7 @@ On WinUI 2, transparency is achieved by setting the color to `00FFFFFF`.
 <!-- ------------------------------ -->
 #### Custom cursors
 
-On WinUI 2, you cannot use [CSS cursors](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) with a URL of an image as the cursor. You can use CSS cursors to change the cursor to a predefined cursor such as `cursor: wait;` or `cursor: crosshair;`, just not a value where you specify your own image via URL such as `cursor: url(https://example.com/cursor.png), pointer;`. See [CSS - cursor loaded from URL doesn't work](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1925).
+On WinUI 2, you cannot use [CSS cursors](https://developer.mozilla.org/docs/Web/CSS/cursor) by specifying a URL of an image as the cursor. You can use CSS cursors to change the cursor to a predefined cursor, such as `cursor: wait;` or `cursor: crosshair;`, but not to an image URL, such as `cursor: url(https://contoso.com/cursor.png), pointer;`. See [CSS - cursor loaded from URL doesn't work](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1925).
 
 
 <!-- ------------------------------ -->


### PR DESCRIPTION
I added a note that CSS cursors with custom images aren't supported in UWP apps. 

I've also updated the section at the end. It was talking about inaccessible interfaces, but WinUI2 uses WinRT which uses primarily our runtime classes not really our interfaces, so updated to the class names not interfaces. Also removed CoreWebView2Environment since that is accessible via the `CoreWebView2.Environment` property.