### PR TITLE
Runtimeclass names for API limitations

### DIFF
--- a/microsoft-edge/webview2/get-started/winui.md
+++ b/microsoft-edge/webview2/get-started/winui.md
@@ -447,11 +447,10 @@ WinUI 3 doesn't support transparent backgrounds.  See [Transparent background su
 <!-- ------------------------------ -->
 #### API limitations
 
-The following interfaces aren't accessible in WinUI 3:
+The following classes aren't accessible in WinUI 3:
 
-* `ICoreWebView2Environment`
-* `ICoreWebView2EnvironmentOptions` and `ICoreWebView2EnvironmentOptions2`
-* `ICoreWebView2ControllerOptions`
+* `CoreWebView2EnvironmentOptions`
+* `CoreWebView2ControllerOptions`
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
Switch to using the WinRT runtime class names for the inaccessible APIs rather than the COM interface names which aren't really available through our WinRT APIs. This is a subset of the change just made to the WinUI2 docs.