### PR TITLE
update WPF and WinForms sample doc

### DIFF
--- a/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
@@ -38,7 +38,7 @@ Microsoft Visual Studio is required.  Microsoft Visual Studio Code is not suppor
 
 1. If a preview channel of Microsoft Edge (Beta, Dev, or Canary) is not already installed, in a separate window or tab, see [Install a preview channel of Microsoft Edge](../how-to/machine-setup.md#install-a-preview-channel-of-microsoft-edge) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue the steps below.
 
-2. To test the experimental APIs ahead of time and ensure WebView2 app's forward-compatibility, see [Approaches to making your app use a specific browser channel](../how-to/set-preview-channel.md#approaches-to-making-your-app-use-a-specific-browser-channel) in _Test upcoming APIs and features_. Follow the steps in that section, and then return to this page and continue the steps below.
+1. To test the experimental APIs ahead of time and ensure your WebView2 app's forward-compatibility, see [Approaches to making your app use a specific browser channel](../how-to/set-preview-channel.md#approaches-to-making-your-app-use-a-specific-browser-channel) in _Test upcoming APIs and features_. Follow the steps in that section, and then return to this page and continue the steps below.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
@@ -38,6 +38,8 @@ Microsoft Visual Studio is required.  Microsoft Visual Studio Code is not suppor
 
 1. If a preview channel of Microsoft Edge (Beta, Dev, or Canary) is not already installed, in a separate window or tab, see [Install a preview channel of Microsoft Edge](../how-to/machine-setup.md#install-a-preview-channel-of-microsoft-edge) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue the steps below.
 
+2. To test the experimental APIs ahead of time and ensure WebView2 app's forward-compatibility, see [Approaches to making your app use a specific browser channel](../how-to/set-preview-channel.md#approaches-to-making-your-app-use-a-specific-browser-channel) in _Test upcoming APIs and features_. Follow the steps in that section, and then return to this page and continue the steps below.
+
 
 <!-- ====================================================================== -->
 ## Step 3 - Clone or download the WebView2Samples repo

--- a/microsoft-edge/webview2/samples/webview2wpfbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2wpfbrowser.md
@@ -40,7 +40,7 @@ For more information about events and API Handlers in WebView2, see [WebView2 AP
 
 1. If a preview channel of Microsoft Edge (Beta, Dev, or Canary) is not already installed, in a separate window or tab, see [Install a preview channel of Microsoft Edge](../how-to/machine-setup.md#install-a-preview-channel-of-microsoft-edge) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue the steps below.
 
-2. To test the experimental APIs ahead of time and ensure WebView2 app's forward-compatibility, see [Approaches to making your app use a specific browser channel](../how-to/set-preview-channel.md#approaches-to-making-your-app-use-a-specific-browser-channel) in _Test upcoming APIs and features_. Follow the steps in that section, and then return to this page and continue the steps below.
+1. To test the experimental APIs ahead of time and ensure your WebView2 app's forward-compatibility, see [Approaches to making your app use a specific browser channel](../how-to/set-preview-channel.md#approaches-to-making-your-app-use-a-specific-browser-channel) in _Test upcoming APIs and features_. Follow the steps in that section, and then return to this page and continue the steps below.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/samples/webview2wpfbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2wpfbrowser.md
@@ -40,6 +40,8 @@ For more information about events and API Handlers in WebView2, see [WebView2 AP
 
 1. If a preview channel of Microsoft Edge (Beta, Dev, or Canary) is not already installed, in a separate window or tab, see [Install a preview channel of Microsoft Edge](../how-to/machine-setup.md#install-a-preview-channel-of-microsoft-edge) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue the steps below.
 
+2. To test the experimental APIs ahead of time and ensure WebView2 app's forward-compatibility, see [Approaches to making your app use a specific browser channel](../how-to/set-preview-channel.md#approaches-to-making-your-app-use-a-specific-browser-channel) in _Test upcoming APIs and features_. Follow the steps in that section, and then return to this page and continue the steps below.
+
 
 <!-- ====================================================================== -->
 ## Step 2 - Install Visual Studio 2019 with .NET support


### PR DESCRIPTION
In WPF and WinForms sample intro documentations, give an instruction to switch prerelease SDK for testing experimental APIs.