### PR TITLE
Reformat API Ref links in "Overview of APIs", clarify Stable in Release/Prerelease

### DIFF
--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -31,7 +31,7 @@ When hosting the WebView2 control, your app has access to the following features
 
 <!-- maintenance notes: add table rows for any new h2 sections -->
 
-This page only lists Release APIs; it doesn't list Experimental APIs or Prerelease-stable APIs (that is, APIs which reached Stable status in a Prerelease SDK, but haven't yet been included in a Release SDK).  For Experimental APIs and Prerelease-stable APIs, see [Release Notes for the WebView2 SDK](../release-notes.md).
+This page only lists APIs that are in Release SDKs; it doesn't list Experimental APIs, or Stable APIs which are not yet available in Release SDKs.  For a comprehensive list of APIs including Experimental APIs, see [Release Notes for the WebView2 SDK](../release-notes.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -125,8 +125,8 @@ Host objects can be projected into JavaScript, so that you can call native objec
    * [ICoreWebView2::AddHostObjectToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#addhostobjecttoscript)
    * [ICoreWebView2::RemoveHostObjectFromScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#removehostobjectfromscript)
 * `ICoreWebView2Settings` interface:
-   * [ICoreWebView2Settings::get_AreHostObjectsAllowed property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_arehostobjectsallowed)
-   * [ICoreWebView2Settings::put_AreHostObjectsAllowed property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_arehostobjectsallowed)
+   * [ICoreWebView2Settings::get_AreHostObjectsAllowed method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_arehostobjectsallowed)
+   * [ICoreWebView2Settings::put_AreHostObjectsAllowed method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_arehostobjectsallowed)
 * `ICoreWebView2Frame` interface:
    * [ICoreWebView2Frame::AddHostObjectToScriptWithOrigins method](/microsoft-edge/webview2/reference/win32/icorewebview2frame#addhostobjecttoscriptwithorigins)
 
@@ -167,8 +167,8 @@ Allows host app to add JavaScript in the web content within the WebView2 control
    * [ICoreWebView2::ExecuteScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#executescript)
    * [ICoreWebView2::RemoveScriptToExecuteOnDocumentCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2#removescripttoexecuteondocumentcreated)
 * `ICoreWebView2Settings` interface:
-   * [ICoreWebView2Settings::get_IsScriptEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isscriptenabled)
-   * [ICoreWebView2Settings::put_IsScriptEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isscriptenabled)
+   * [ICoreWebView2Settings::get_IsScriptEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isscriptenabled)
+   * [ICoreWebView2Settings::put_IsScriptEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isscriptenabled)
 * `ICoreWebView2Frame2` interface:
    * [ICoreWebView2Frame2::ExecuteScript method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#executescript)
 
@@ -248,8 +248,8 @@ When hosting WebView2, your app can manage different JavaScript dialogs, to supp
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_ScriptDialogOpening event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_scriptdialogopening)
-   * [ICoreWebView2::remove_ScriptDialogOpening event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_scriptdialogopening)
+   * [ICoreWebView2::add_ScriptDialogOpening method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_scriptdialogopening)
+   * [ICoreWebView2::remove_ScriptDialogOpening method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_scriptdialogopening)
 * [ICoreWebView2ScriptDialogOpeningEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventargs)
 
 ---
@@ -307,11 +307,11 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_17 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_17)
+* `ICoreWebView2_17` interface:
    * [ICoreWebView2_17::PostSharedBufferToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2_17#postsharedbuffertoscript)
-* [ICoreWebView2Environment12 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment12)
+* `ICoreWebView2Environment12` interface:
    * [ICoreWebView2Environment12::CreateSharedBuffer method](/microsoft-edge/webview2/reference/win32/icorewebview2environment12#createsharedbuffer)
-* [ICoreWebView2Frame4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame4)
+* `ICoreWebView2Frame4` interface:
    * [ICoreWebView2Frame4::PostSharedBufferToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2frame4#postsharedbuffertoscript)
 * [ICoreWebView2SharedBuffer interface](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer)
    * [ICoreWebView2SharedBuffer::OpenStream method](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer#openstream)
@@ -368,13 +368,13 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_7 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_7)
+* `ICoreWebView2_7` interface:
    * [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7#printtopdf)
-* [ICoreWebView2_16 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_16)
+* `ICoreWebView2_16` interface:
    * [ICoreWebView2_16::ShowPrintUI method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#showprintui)
    * [ICoreWebView2_16::Print method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#print)
    * [ICoreWebView2_16::PrintToPdfStream method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#printtopdfstream)
-* [ICoreWebView2Environment6 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment6)
+* `ICoreWebView2Environment6` interface:
    * [ICoreWebView2Environment6::CreatePrintSettings method](/microsoft-edge/webview2/reference/win32/icorewebview2environment6#createprintsettings)
 * [ICoreWebView2PrintCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2printcompletedhandler)
 * [ICoreWebView2PrintSettings interface](/microsoft-edge/webview2/reference/win32/icorewebview2printsettings)
@@ -419,7 +419,7 @@ https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_we
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2_2` interface:
-   * [ICoreWebView2_2.get_CookieManager property method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#get_cookiemanager)<!--no put-->
+   * [ICoreWebView2_2.get_CookieManager method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#get_cookiemanager)<!--no put-->
 * [ICoreWebView2Cookie interface](/microsoft-edge/webview2/reference/win32/icorewebview2cookie)
 * [ICoreWebView2CookieList interface](/microsoft-edge/webview2/reference/win32/icorewebview2cookielist)
 * [ICoreWebView2CookieManager interface](/microsoft-edge/webview2/reference/win32/icorewebview2cookiemanager)
@@ -507,26 +507,26 @@ Custom Download Experience:
 
 General:
 * `ICoreWebView2_9` interface:
-   * [ICoreWebView2_9::get_IsDefaultDownloadDialogOpen property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_isdefaultdownloaddialogopen)<!--no put-->
+   * [ICoreWebView2_9::get_IsDefaultDownloadDialogOpen method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_isdefaultdownloaddialogopen)<!--no put-->
    * [ICoreWebView2_9::OpenDefaultDownloadDialog method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#opendefaultdownloaddialog)
-   * [ICoreWebView2_9::add_IsDefaultDownloadDialogOpenChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#add_isdefaultdownloaddialogopenchanged)
-   * [ICoreWebView2_9::remove_IsDefaultDownloadDialogOpenChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#remove_isdefaultdownloaddialogopenchanged)
+   * [ICoreWebView2_9::add_IsDefaultDownloadDialogOpenChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#add_isdefaultdownloaddialogopenchanged)
+   * [ICoreWebView2_9::remove_IsDefaultDownloadDialogOpenChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#remove_isdefaultdownloaddialogopenchanged)
    * [ICoreWebView2_9::CloseDefaultDownloadDialog method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#closedefaultdownloaddialog)
 
 Modify Default Experience:
 * `ICoreWebView2_9` interface:
-   * [ICoreWebView2_9::get_DefaultDownloadDialogCornerAlignment property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogcorneralignment)
-   * [ICoreWebView2_9::put_DefaultDownloadDialogCornerAlignment property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogcorneralignment)
-   * [ICoreWebView2_9::get_DefaultDownloadDialogMargin property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogmargin)
-   * [ICoreWebView2_9::put_DefaultDownloadDialogMargin property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogmargin)
+   * [ICoreWebView2_9::get_DefaultDownloadDialogCornerAlignment method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogcorneralignment)
+   * [ICoreWebView2_9::put_DefaultDownloadDialogCornerAlignment method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogcorneralignment)
+   * [ICoreWebView2_9::get_DefaultDownloadDialogMargin method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogmargin)
+   * [ICoreWebView2_9::put_DefaultDownloadDialogMargin method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogmargin)
 * `ICoreWebView2Profile` interface:
-   * [ICoreWebView2Profile::get_DefaultDownloadFolderPath property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_defaultdownloadfolderpath)
-   * [ICoreWebView2Profile::put_DefaultDownloadFolderPath property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_defaultdownloadfolderpath)
+   * [ICoreWebView2Profile::get_DefaultDownloadFolderPath method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_defaultdownloadfolderpath)
+   * [ICoreWebView2Profile::put_DefaultDownloadFolderPath method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_defaultdownloadfolderpath)
 
 Custom Download Experience:
 * `ICoreWebView2_4` interface:
-   * [ICoreWebView2_4::add_DownloadStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_downloadstarting)
-   * [ICoreWebView2_4::remove_DownloadStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_downloadstarting)
+   * [ICoreWebView2_4::add_DownloadStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_downloadstarting)
+   * [ICoreWebView2_4::remove_DownloadStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_downloadstarting)
 * [ICoreWebView2DownloadStartingEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2downloadstartingeventargs)
 * [ICoreWebView2DownloadOperation interface](/microsoft-edge/webview2/reference/win32/icorewebview2downloadoperation)
 
@@ -586,11 +586,11 @@ See also:
    * [ICoreWebView2::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#add_permissionrequested)
    * [ICoreWebView2::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_permissionrequested)
 * [ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2getnondefaultpermissionsettingscompletedhandler)
-* [ICoreWebView2Frame3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame3)
+* `ICoreWebView2Frame3` interface:
    * [ICoreWebView2Frame3::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#add_permissionrequested)
    * [ICoreWebView2Frame3::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#remove_permissionrequested)
 * [ICoreWebView2PermissionRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs)
-* [ICoreWebView2PermissionRequestedEventArgs3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3)
+* `ICoreWebView2PermissionRequestedEventArgs3` interface:
    * [ICoreWebView2PermissionRequestedEventArgs3::get_SavesInProfile](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3#get_savesinprofile)
    * [ICoreWebView2PermissionRequestedEventArgs3::put_SavesInProfile](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3#put_savesinprofile)
 * [ICoreWebView2PermissionSetting interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsetting)
@@ -600,7 +600,7 @@ See also:
 * [ICoreWebView2PermissionSettingCollectionView interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsettingcollectionview)
    * [ICoreWebView2PermissionSettingCollectionView::GetValueAtIndex method](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsettingcollectionview#getvalueatindex)
    * [ICoreWebView2PermissionSettingCollectionView::get_Count method](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsettingcollectionview#get_count)
-* [ICoreWebView2Profile4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile4)
+* `ICoreWebView2Profile4` interface:
    * [ICoreWebView2Profile4::GetNonDefaultPermissionSettings method](/microsoft-edge/webview2/reference/win32/icorewebview2profile4#getnondefaultpermissionsettings)
    * [ICoreWebView2Profile4::SetPermissionState method](/microsoft-edge/webview2/reference/win32/icorewebview2profile4#setpermissionstate)
 * [ICoreWebView2SetPermissionStateCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2setpermissionstatecompletedhandler)
@@ -648,13 +648,13 @@ See also:
    * [ICoreWebView2_11::remove_ContextMenuRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_11#remove_contextmenurequested)
 * [ICoreWebView2ContextMenuRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenurequestedeventargs)
 * [ICoreWebView2ContextMenuItem interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenuitem)
-   * [ICoreWebView2ContextMenuItemCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenuitemcollection)
+* [ICoreWebView2ContextMenuItemCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenuitemcollection)
 * [ICoreWebView2ContextMenuTarget interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenutarget)
 * `ICoreWebView2Environment9` interface:
    * [ICoreWebView2Environment9::CreateContextMenuItem method](/microsoft-edge/webview2/reference/win32/icorewebview2environment9#createcontextmenuitem)
 * `ICoreWebView2Settings` interface:
-   * [ICoreWebView2Settings::get_AreDefaultContextMenusEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredefaultcontextmenusenabled)
-   * [ICoreWebView2Settings::put_AreDefaultContextMenusEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredefaultcontextmenusenabled)
+   * [ICoreWebView2Settings::get_AreDefaultContextMenusEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredefaultcontextmenusenabled)
+   * [ICoreWebView2Settings::put_AreDefaultContextMenusEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredefaultcontextmenusenabled)
 
 ---
 
@@ -686,7 +686,7 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_12 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_12)
+* `ICoreWebView2_12` interface:
    * [ICoreWebView2_12::add_StatusBarTextChanged](/microsoft-edge/webview2/reference/win32/icorewebview2_12#add_statusbartextchanged)
    * [ICoreWebView2_12::get_StatusBarText](/microsoft-edge/webview2/reference/win32/icorewebview2_12#get_statusbartext)
    * [ICoreWebView2_12::remove_StatusBarTextChanged](/microsoft-edge/webview2/reference/win32/icorewebview2_12#remove_statusbartextchanged)
@@ -746,11 +746,11 @@ Your app can independently control whether the browser's autofill functionality 
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings4)
-   * [ICoreWebView2Settings4::get_IsGeneralAutofillEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_isgeneralautofillenabled)
-   * [ICoreWebView2Settings4::get_IsPasswordAutosaveEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_ispasswordautosaveenabled)
-   * [ICoreWebView2Settings4::put_IsGeneralAutofillEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_isgeneralautofillenabled)
-   * [ICoreWebView2Settings4::put_IsPasswordAutosaveEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_ispasswordautosaveenabled)
+* `ICoreWebView2Settings4` interface:
+   * [ICoreWebView2Settings4::get_IsGeneralAutofillEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_isgeneralautofillenabled)
+   * [ICoreWebView2Settings4::get_IsPasswordAutosaveEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_ispasswordautosaveenabled)
+   * [ICoreWebView2Settings4::put_IsGeneralAutofillEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_isgeneralautofillenabled)
+   * [ICoreWebView2Settings4::put_IsPasswordAutosaveEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_ispasswordautosaveenabled)
 
 ---
 
@@ -778,14 +778,14 @@ Your app can mute and unmute all audio, and find out when audio is playing.
    
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_8 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_8)
-   * [ICoreWebView2_8::add_IsDocumentPlayingAudioChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_isdocumentplayingaudiochanged)
-   * [ICoreWebView2_8::add_IsMutedChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_ismutedchanged)
-   * [ICoreWebView2_8::get_IsDocumentPlayingAudio property method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_isdocumentplayingaudio)
-   * [ICoreWebView2_8::get_IsMuted property method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_ismuted)
-   * [ICoreWebView2_8::put_IsMuted property method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#put_ismuted)
-   * [ICoreWebView2_8::remove_IsDocumentPlayingAudioChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_isdocumentplayingaudiochanged)
-   * [ICoreWebView2_8::remove_IsMutedChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_ismutedchanged)
+* `ICoreWebView2_8` interface:
+   * [ICoreWebView2_8::add_IsDocumentPlayingAudioChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_isdocumentplayingaudiochanged)
+   * [ICoreWebView2_8::add_IsMutedChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_ismutedchanged)
+   * [ICoreWebView2_8::get_IsDocumentPlayingAudio method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_isdocumentplayingaudio)
+   * [ICoreWebView2_8::get_IsMuted method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_ismuted)
+   * [ICoreWebView2_8::put_IsMuted method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#put_ismuted)
+   * [ICoreWebView2_8::remove_IsDocumentPlayingAudioChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_isdocumentplayingaudiochanged)
+   * [ICoreWebView2_8::remove_IsMutedChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_ismutedchanged)
 
 ---
 
@@ -816,11 +816,11 @@ This feature is currently disabled by default in the browser.  To enable this fe
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2Settings6` interface:
-   * [ICoreWebView2Settings6::get_IsSwipeNavigationEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#get_isswipenavigationenabled)
-   * [ICoreWebView2Settings6::put_IsSwipeNavigationEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#put_isswipenavigationenabled)
+   * [ICoreWebView2Settings6::get_IsSwipeNavigationEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#get_isswipenavigationenabled)
+   * [ICoreWebView2Settings6::put_IsSwipeNavigationEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#put_isswipenavigationenabled)
 * `ICoreWebView2EnvironmentOptions` interface:
-   * [ICoreWebView2EnvironmentOptions::get_AdditionalBrowserArguments property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_additionalbrowserarguments)
-   * [ICoreWebView2EnvironmentOptions::put_AdditionalBrowserArguments property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_additionalbrowserarguments)
+   * [ICoreWebView2EnvironmentOptions::get_AdditionalBrowserArguments method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_additionalbrowserarguments)
+   * [ICoreWebView2EnvironmentOptions::put_AdditionalBrowserArguments method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_additionalbrowserarguments)
 
 ---
 
@@ -844,9 +844,9 @@ In WebView2, you can find out when an HTML element enters or leaves full-screen 
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::get_ContainsFullScreenElement property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_containsfullscreenelement)<!--no put-->
-   * [ICoreWebView2::add_ContainsFullScreenElementChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_containsfullscreenelementchanged)
-   * [ICoreWebView2::remove_ContainsFullScreenElementChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_containsfullscreenelementchanged)
+   * [ICoreWebView2::get_ContainsFullScreenElement method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_containsfullscreenelement)<!--no put-->
+   * [ICoreWebView2::add_ContainsFullScreenElementChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_containsfullscreenelementchanged)
+   * [ICoreWebView2::remove_ContainsFullScreenElementChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_containsfullscreenelementchanged)
 
 ---
 
@@ -867,9 +867,9 @@ In the browser PDF viewer, there's a PDF-specific toolbar along the top.  In Web
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings7 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings7)
-   * [ICoreWebView2Settings7::get_HiddenPdfToolbarItems property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#get_hiddenpdftoolbaritems)
-   * [ICoreWebView2Settings7::put_HiddenPdfToolbarItems property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#put_hiddenpdftoolbaritems)
+* `ICoreWebView2Settings7` interface:
+   * [ICoreWebView2Settings7::get_HiddenPdfToolbarItems method](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#get_hiddenpdftoolbaritems)
+   * [ICoreWebView2Settings7::put_HiddenPdfToolbarItems method](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#put_hiddenpdftoolbaritems)
 
 ---
 
@@ -891,8 +891,8 @@ In WebView2, you can customize the color theme as system, light, or dark.
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2Profile` interface:
-   * [ICoreWebView2Profile::get_PreferredColorScheme property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_preferredcolorscheme)
-   * [ICoreWebView2Profile::put_PreferredColorScheme property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_preferredcolorscheme)
+   * [ICoreWebView2Profile::get_PreferredColorScheme method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_preferredcolorscheme)
+   * [ICoreWebView2Profile::put_PreferredColorScheme method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_preferredcolorscheme)
 
 ---
 
@@ -920,11 +920,11 @@ The `ScriptLocale` property allows the host app to set the default locale for al
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2EnvironmentOptions` interface:
-   * [ICoreWebView2EnvironmentOptions::get_Language property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_language)
-   * [ICoreWebView2EnvironmentOptions::put_Language property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_language)
-* [ICoreWebView2ControllerOptions2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2)
-   * [ICoreWebView2ControllerOptions2::get_ScriptLocale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#get_scriptlocale)
-   * [ICoreWebView2ControllerOptions2::put_ScriptLocale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#put_scriptlocale)
+   * [ICoreWebView2EnvironmentOptions::get_Language method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_language)
+   * [ICoreWebView2EnvironmentOptions::put_Language method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_language)
+* `ICoreWebView2ControllerOptions2` interface:
+   * [ICoreWebView2ControllerOptions2::get_ScriptLocale method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#get_scriptlocale)
+   * [ICoreWebView2ControllerOptions2::put_ScriptLocale method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#put_scriptlocale)
 
 ---
 
@@ -951,8 +951,8 @@ WebView2 provides functionality to handle the JavaScript function `window.open()
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_NewWindowRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_newwindowrequested)
-   * [ICoreWebView2::remove_NewWindowRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_newwindowrequested)
+   * [ICoreWebView2::add_NewWindowRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_newwindowrequested)
+   * [ICoreWebView2::remove_NewWindowRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_newwindowrequested)
 * [ICoreWebView2NewWindowRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs)
 * [ICoreWebView2WindowFeatures interface](/microsoft-edge/webview2/reference/win32/icorewebview2windowfeatures)
 
@@ -980,8 +980,8 @@ WebView2 provides functionality to handle the JavaScript function `window.close(
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_WindowCloseRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_windowcloserequested)
-   * [ICoreWebView2::remove_WindowCloseRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_windowcloserequested)
+   * [ICoreWebView2::add_WindowCloseRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_windowcloserequested)
+   * [ICoreWebView2::remove_WindowCloseRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_windowcloserequested)
 * `ICoreWebView2Controller` interface:
    * [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
 
@@ -1007,9 +1007,9 @@ Your app can detect when the title of the current top-level document has changed
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::get_DocumentTitle property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_documenttitle)<!--no put-->
-   * [ICoreWebView2::add_DocumentTitleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_documenttitlechanged)
-   * [ICoreWebView2::remove_DocumentTitleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_documenttitlechanged)
+   * [ICoreWebView2::get_DocumentTitle method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_documenttitle)<!--no put-->
+   * [ICoreWebView2::add_DocumentTitleChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_documenttitlechanged)
+   * [ICoreWebView2::remove_DocumentTitleChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_documenttitlechanged)
 
 ---
 
@@ -1033,9 +1033,9 @@ In WebView2, you can set a [Favicon](https://developer.mozilla.org/docs/Glossary
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2_15` interface:
-   * [ICoreWebView2_15::add_FaviconChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#add_faviconchanged)
-   * [ICoreWebView2_15::remove_FaviconChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#remove_faviconchanged)
-   * [ICoreWebView2_15::get_FaviconUri property method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#get_faviconuri)<!--no put-->
+   * [ICoreWebView2_15::add_FaviconChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#add_faviconchanged)
+   * [ICoreWebView2_15::remove_FaviconChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#remove_faviconchanged)
+   * [ICoreWebView2_15::get_FaviconUri method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#get_faviconuri)<!--no put-->
 
 ---
 
@@ -1080,12 +1080,12 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2EnvironmentOptions5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5)
-   * [ICoreWebView2EnvironmentOptions5::get_EnableTrackingPrevention property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#get_enabletrackingprevention)
-   * [ICoreWebView2EnvironmentOptions5::put_EnableTrackingPrevention property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#put_enabletrackingprevention)
-* [ICoreWebView2Profile3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile3)
-   * [ICoreWebView2Profile3::get_PreferredTrackingPreventionLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#get_preferredtrackingpreventionlevel)
-   * [ICoreWebView2Profile3::put_PreferredTrackingPreventionLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#put_preferredtrackingpreventionlevel)
+* `ICoreWebView2EnvironmentOptions5` interface:
+   * [ICoreWebView2EnvironmentOptions5::get_EnableTrackingPrevention method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#get_enabletrackingprevention)
+   * [ICoreWebView2EnvironmentOptions5::put_EnableTrackingPrevention method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#put_enabletrackingprevention)
+* `ICoreWebView2Profile3` interface:
+   * [ICoreWebView2Profile3::get_PreferredTrackingPreventionLevel method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#get_preferredtrackingpreventionlevel)
+   * [ICoreWebView2Profile3::put_PreferredTrackingPreventionLevel method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#put_preferredtrackingpreventionlevel)
 * [COREWEBVIEW2_TRACKING_PREVENTION_LEVEL enum](/microsoft-edge/webview2/reference/win32/webview2-idl#corewebview2_tracking_prevention_level)
   * `COREWEBVIEW2_TRACKING_PREVENTION_LEVEL_NONE`
   * `COREWEBVIEW2_TRACKING_PREVENTION_LEVEL_BASIC`
@@ -1117,9 +1117,9 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings8 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings8)
-   * [ICoreWebView2Settings8::get_IsReputationCheckingRequired property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#get_isreputationcheckingrequired)
-   * [ICoreWebView2Settings8::put_IsReputationCheckingRequired property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#put_isreputationcheckingrequired)
+* `ICoreWebView2Settings8` interface:
+   * [ICoreWebView2Settings8::get_IsReputationCheckingRequired method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#get_isreputationcheckingrequired)
+   * [ICoreWebView2Settings8::put_IsReputationCheckingRequired method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#put_isreputationcheckingrequired)
 ---
 
 
@@ -1158,17 +1158,17 @@ Get information about running WebView2 processes, exiting processes, and failed 
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::get_BrowserProcessId property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_browserprocessid)<!--no put-->
-   * [ICoreWebView2::add_ProcessFailed event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_processfailed)
-   * [ICoreWebView2::remove_ProcessFailed event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_processfailed)
+   * [ICoreWebView2::get_BrowserProcessId method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_browserprocessid)<!--no put-->
+   * [ICoreWebView2::add_ProcessFailed method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_processfailed)
+   * [ICoreWebView2::remove_ProcessFailed method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_processfailed)
 * [ICoreWebView2BrowserProcessExitedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2browserprocessexitedeventargs)
-* [ICoreWebView2Environment8 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment8)
+* `ICoreWebView2Environment8` interface:
    * [ICoreWebView2Environment8::GetProcessInfos method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#getprocessinfos)
-   * [ICoreWebView2Environment8::add_ProcessInfosChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#add_processinfoschanged)
-   * [ICoreWebView2Environment8::remove_ProcessInfosChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#remove_processinfoschanged)
-* [ICoreWebView2Environment5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment5)
-   * [ICoreWebView2Environment5::add_BrowserProcessExited event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#add_browserprocessexited)
-   * [ICoreWebView2Environment5::remove_BrowserProcessExited event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#remove_browserprocessexited)
+   * [ICoreWebView2Environment8::add_ProcessInfosChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#add_processinfoschanged)
+   * [ICoreWebView2Environment8::remove_ProcessInfosChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#remove_processinfoschanged)
+* `ICoreWebView2Environment5` interface:
+   * [ICoreWebView2Environment5::add_BrowserProcessExited method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#add_browserprocessexited)
+   * [ICoreWebView2Environment5::remove_BrowserProcessExited method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#remove_browserprocessexited)
 * [ICoreWebView2ProcessFailedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs)
 * [ICoreWebView2ProcessInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2processinfo)
 * [ICoreWebView2ProcessInfoCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2processinfocollection)
@@ -1225,8 +1225,8 @@ See also:
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested)
-   * [ICoreWebView2::remove_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
+   * [ICoreWebView2::add_WebResourceRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested)
+   * [ICoreWebView2::remove_WebResourceRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
    * [ICoreWebView2::Navigate method](/microsoft-edge/webview2/reference/win32/icorewebview2#navigate)
    * [ICoreWebView2::NavigateToString method](/microsoft-edge/webview2/reference/win32/icorewebview2#navigatetostring)
    * [ICoreWebView2::Reload method](/microsoft-edge/webview2/reference/win32/icorewebview2#reload)
@@ -1237,8 +1237,8 @@ See also:
    * [ICoreWebView2_3::ClearVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#clearvirtualhostnametofoldermapping)
    * [ICoreWebView2_3::SetVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#setvirtualhostnametofoldermapping)
 * `ICoreWebView2Settings` interface:
-   * [ICoreWebView2Settings::get_IsBuiltInErrorPageEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isbuiltinerrorpageenabled)
-   * [ICoreWebView2Settings::put_IsBuiltInErrorPageEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isbuiltinerrorpageenabled)
+   * [ICoreWebView2Settings::get_IsBuiltInErrorPageEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isbuiltinerrorpageenabled)
+   * [ICoreWebView2Settings::put_IsBuiltInErrorPageEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isbuiltinerrorpageenabled)
 
 ---
 
@@ -1275,15 +1275,15 @@ The history methods allow back and forward navigation in WebView2, and the histo
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_HistoryChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_historychanged)
-   * [ICoreWebView2::add_SourceChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_sourcechanged)
-   * [ICoreWebView2::get_CanGoBack property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoback)<!--no put-->
-   * [ICoreWebView2::get_CanGoForward property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoforward)<!--no put-->
-   * [ICoreWebView2::get_Source property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_source)<!--no put-->
+   * [ICoreWebView2::add_HistoryChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_historychanged)
+   * [ICoreWebView2::add_SourceChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_sourcechanged)
+   * [ICoreWebView2::get_CanGoBack method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoback)<!--no put-->
+   * [ICoreWebView2::get_CanGoForward method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoforward)<!--no put-->
+   * [ICoreWebView2::get_Source method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_source)<!--no put-->
    * [ICoreWebView2::GoBack method](/microsoft-edge/webview2/reference/win32/icorewebview2#goback)
    * [ICoreWebView2::GoForward method](/microsoft-edge/webview2/reference/win32/icorewebview2#goforward)
-   * [ICoreWebView2::remove_HistoryChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_historychanged)
-   * [ICoreWebView2::remove_SourceChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_sourcechanged)
+   * [ICoreWebView2::remove_HistoryChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_historychanged)
+   * [ICoreWebView2::remove_SourceChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_sourcechanged)
 * [ICoreWebView2SourceChangedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs)
 
 ---
@@ -1315,13 +1315,13 @@ The `NavigationStarting` event allows the app to cancel navigating to specified 
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationstarting)
-   * [ICoreWebView2::remove_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationstarting)
-   * [ICoreWebView2::add_FrameNavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationstarting) - superseded; use `ICoreWebView2Frame.add_NavigationStarting` instead
-   * [ICoreWebView2::remove_FrameNavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationstarting) - superseded; use `ICoreWebView2Frame.remove_NavigationStarting` instead
+   * [ICoreWebView2::add_NavigationStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationstarting)
+   * [ICoreWebView2::remove_NavigationStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationstarting)
+   * [ICoreWebView2::add_FrameNavigationStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationstarting) - superseded; use `ICoreWebView2Frame.add_NavigationStarting` instead
+   * [ICoreWebView2::remove_FrameNavigationStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationstarting) - superseded; use `ICoreWebView2Frame.remove_NavigationStarting` instead
 * `ICoreWebView2Frame2` interface:
-   * [ICoreWebView2Frame2::add_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationstarting)
-   * [ICoreWebView2Frame2::remove_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationstarting)
+   * [ICoreWebView2Frame2::add_NavigationStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationstarting)
+   * [ICoreWebView2Frame2::remove_NavigationStarting method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationstarting)
 * [ICoreWebView2NavigationStartingEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2)<!--v2-->
 
 ---
@@ -1368,22 +1368,22 @@ See also:
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_contentloading)
-   * [ICoreWebView2::add_FrameNavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationcompleted) - superseded; use `ICoreWebView2Frame::add_NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
-   * [ICoreWebView2::add_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationcompleted)
-   * [ICoreWebView2::remove_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_contentloading)
-   * [ICoreWebView2::remove_FrameNavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationcompleted) - superseded; use `ICoreWebView2Frame::remove_NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
-   * [ICoreWebView2::remove_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationcompleted)
+   * [ICoreWebView2::add_ContentLoading method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_contentloading)
+   * [ICoreWebView2::add_FrameNavigationCompleted method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationcompleted) - superseded; use `ICoreWebView2Frame::add_NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
+   * [ICoreWebView2::add_NavigationCompleted method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationcompleted)
+   * [ICoreWebView2::remove_ContentLoading method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_contentloading)
+   * [ICoreWebView2::remove_FrameNavigationCompleted method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationcompleted) - superseded; use `ICoreWebView2Frame::remove_NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
+   * [ICoreWebView2::remove_NavigationCompleted method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationcompleted)
 * `ICoreWebView2_2` interface:
-   * [ICoreWebView2_2::add_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_domcontentloaded)
-   * [ICoreWebView2_2::remove_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_domcontentloaded)
+   * [ICoreWebView2_2::add_DOMContentLoaded method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_domcontentloaded)
+   * [ICoreWebView2_2::remove_DOMContentLoaded method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_domcontentloaded)
 * `ICoreWebView2Frame2` interface:
-   * [ICoreWebView2Frame2::add_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_contentloading)
-   * [ICoreWebView2Frame2::add_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_domcontentloaded)
-   * [ICoreWebView2Frame2::add_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationcompleted)
-   * [ICoreWebView2Frame2::remove_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_contentloading)
-   * [ICoreWebView2Frame2::remove_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_domcontentloaded)
-   * [ICoreWebView2Frame2::remove_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationcompleted)
+   * [ICoreWebView2Frame2::add_ContentLoading method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_contentloading)
+   * [ICoreWebView2Frame2::add_DOMContentLoaded method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_domcontentloaded)
+   * [ICoreWebView2Frame2::add_NavigationCompleted method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationcompleted)
+   * [ICoreWebView2Frame2::remove_ContentLoading method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_contentloading)
+   * [ICoreWebView2Frame2::remove_DOMContentLoaded method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_domcontentloaded)
+   * [ICoreWebView2Frame2::remove_NavigationCompleted method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationcompleted)
 * [ICoreWebView2ContentLoadingEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs)
 * [ICoreWebView2DOMContentLoadedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2domcontentloadedeventargs)
 * [ICoreWebView2NavigationCompletedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs)
@@ -1419,11 +1419,11 @@ See also:
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2` interface:
-   * [ICoreWebView2::add_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested)
-   * [ICoreWebView2::remove_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
+   * [ICoreWebView2::add_WebResourceRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested)
+   * [ICoreWebView2::remove_WebResourceRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
 * `ICoreWebView2_2` interface:
-   * [ICoreWebView2_2::add_WebResourceResponseReceived event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_webresourceresponsereceived)
-   * [ICoreWebView2_2::remove_WebResourceResponseReceived event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_webresourceresponsereceived)
+   * [ICoreWebView2_2::add_WebResourceResponseReceived method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_webresourceresponsereceived)
+   * [ICoreWebView2_2::remove_WebResourceResponseReceived method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_webresourceresponsereceived)
 * [ICoreWebView2WebResourceRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs)
 * [ICoreWebView2WebResourceResponseReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponsereceivedeventargs)
 
@@ -1449,7 +1449,7 @@ The `CustomSchemeRegistration` allows registration of custom schemes in WebView2
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2CustomSchemeRegistration interface](/microsoft-edge/webview2/reference/win32/icorewebview2customschemeregistration)
-* [ICoreWebView2EnvironmentOptions4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4)
+* `ICoreWebView2EnvironmentOptions4` interface:
    * [ICoreWebView2EnvironmentOptions4::GetCustomSchemeRegistrations method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4#getcustomschemeregistrations)
    * [ICoreWebView2EnvironmentOptions4::SetCustomSchemeRegistrations method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4#setcustomschemeregistrations)
    
@@ -1481,9 +1481,9 @@ In WebView2, you can use the Client Certificate API to select the client certifi
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_5)
-   * [ICoreWebView2_5::add_ClientCertificateRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#add_clientcertificaterequested)
-   * [ICoreWebView2_5::remove_ClientCertificateRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#remove_clientcertificaterequested)
+* `ICoreWebView2_5` interface:
+   * [ICoreWebView2_5::add_ClientCertificateRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#add_clientcertificaterequested)
+   * [ICoreWebView2_5::remove_ClientCertificateRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#remove_clientcertificaterequested)
 * [ICoreWebView2ClientCertificate interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificate)
 * [ICoreWebView2ClientCertificateCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificatecollection)<!--n/a for c#-->
 * [ICoreWebView2ClientCertificateRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificaterequestedeventargs)
@@ -1509,9 +1509,9 @@ In WebView2, you can use the Server Certificate API to trust the server's TLS ce
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_14 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_14)
-   * [ICoreWebView2_14::add_ServerCertificateErrorDetected event method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#add_servercertificateerrordetected)
-   * [ICoreWebView2_14::remove_ServerCertificateErrorDetected event method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#remove_servercertificateerrordetected)
+* `ICoreWebView2_14` interface:
+   * [ICoreWebView2_14::add_ServerCertificateErrorDetected method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#add_servercertificateerrordetected)
+   * [ICoreWebView2_14::remove_ServerCertificateErrorDetected method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#remove_servercertificateerrordetected)
    * [ICoreWebView2_14::ClearServerCertificateErrorActions method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#clearservercertificateerroractions)
 
 ---
@@ -1551,8 +1551,8 @@ See also:
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2_4` interface:
-   * [ICoreWebView2_4::add_FrameCreated event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_framecreated)
-   * [ICoreWebView2_4::remove_FrameCreated event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_framecreated)
+   * [ICoreWebView2_4::add_FrameCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_framecreated)
+   * [ICoreWebView2_4::remove_FrameCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_framecreated)
 * [ICoreWebView2Frame interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame)
 * [ICoreWebView2FrameCreatedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2framecreatedeventargs)
 * [ICoreWebView2FrameInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfo)
@@ -1596,9 +1596,9 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_10)
-   * [ICoreWebView2_10::add_BasicAuthenticationRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#add_basicauthenticationrequested)
-   * [ICoreWebView2_10::remove_BasicAuthenticationRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#remove_basicauthenticationrequested)
+* `ICoreWebView2_10` interface:
+   * [ICoreWebView2_10::add_BasicAuthenticationRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#add_basicauthenticationrequested)
+   * [ICoreWebView2_10::remove_BasicAuthenticationRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#remove_basicauthenticationrequested)
 * [ICoreWebView2BasicAuthenticationRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2basicauthenticationrequestedeventargs)
 * [ICoreWebView2BasicAuthenticationResponse interface](/microsoft-edge/webview2/reference/win32/icorewebview2basicauthenticationresponse)
 * [ICoreWebView2HttpHeadersCollectionIterator interface](/microsoft-edge/webview2/reference/win32/icorewebview2httpheaderscollectioniterator)
@@ -1638,7 +1638,7 @@ Use these APIs to set up the WebView2 rendering system if your host app doesn't 
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2Controller` interface:
-   * [ICoreWebView2Controller::get_CoreWebView2 property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_corewebview2)<!--no put-->
+   * [ICoreWebView2Controller::get_CoreWebView2 method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_corewebview2)<!--no put-->
    * [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
 * `CoreWebView2Environment` Class:
    * [ICoreWebView2Environment::CreateCoreWebView2Controller method](/microsoft-edge/webview2/reference/win32/icorewebview2environment#createcorewebview2controller)
@@ -1669,10 +1669,10 @@ WebView2 gives your app access to window-specific attributes, such as positionin
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2Controller` interface:
-   * [ICoreWebView2Controller::get_Bounds property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_bounds)
-   * [ICoreWebView2Controller::put_Bounds property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_bounds)
-   * [ICoreWebView2Controller::get_IsVisible property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_isvisible)
-   * [ICoreWebView2Controller::put_IsVisible property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_isvisible)
+   * [ICoreWebView2Controller::get_Bounds method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_bounds)
+   * [ICoreWebView2Controller::put_Bounds method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_bounds)
+   * [ICoreWebView2Controller::get_IsVisible method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_isvisible)
+   * [ICoreWebView2Controller::put_IsVisible method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_isvisible)
 
 ---
 
@@ -1705,17 +1705,17 @@ WebView2 `ZoomFactor` is used to scale just the web content of the window.  UI s
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2Controller` interface:
-   * [ICoreWebView2Controller::get_ZoomFactor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_zoomfactor)
-   * [ICoreWebView2Controller::put_ZoomFactor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_zoomfactor)
-   * [ICoreWebView2Controller::add_ZoomFactorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_zoomfactorchanged)
-   * [ICoreWebView2Controller::remove_ZoomFactorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_zoomfactorchanged)
+   * [ICoreWebView2Controller::get_ZoomFactor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_zoomfactor)
+   * [ICoreWebView2Controller::put_ZoomFactor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_zoomfactor)
+   * [ICoreWebView2Controller::add_ZoomFactorChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_zoomfactorchanged)
+   * [ICoreWebView2Controller::remove_ZoomFactorChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_zoomfactorchanged)
    * [ICoreWebView2Controller::SetBoundsAndZoomFactor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#setboundsandzoomfactor)
 * `ICoreWebView2Settings` interface:
-   * [ICoreWebView2Settings::get_IsZoomControlEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iszoomcontrolenabled)
-   * [ICoreWebView2Settings::put_IsZoomControlEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iszoomcontrolenabled)
-* [ICoreWebView2Settings5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings5)
-   * [ICoreWebView2Settings5::get_IsPinchZoomEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#get_ispinchzoomenabled)
-   * [ICoreWebView2Settings5::put_IsPinchZoomEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#put_ispinchzoomenabled)
+   * [ICoreWebView2Settings::get_IsZoomControlEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iszoomcontrolenabled)
+   * [ICoreWebView2Settings::put_IsZoomControlEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iszoomcontrolenabled)
+* `ICoreWebView2Settings5` interface:
+   * [ICoreWebView2Settings5::get_IsPinchZoomEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#get_ispinchzoomenabled)
+   * [ICoreWebView2Settings5::put_IsPinchZoomEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#put_ispinchzoomenabled)
 
 ---
 
@@ -1743,15 +1743,15 @@ The RasterizationScale API scales all WebView2 UI including context menus, toolt
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2controller3)
-   * [ICoreWebView2Controller3::add_RasterizationScaleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#add_rasterizationscalechanged)
-   * [ICoreWebView2Controller3::get_BoundsMode property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_boundsmode)
-   * [ICoreWebView2Controller3::get_RasterizationScale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_rasterizationscale)
-   * [ICoreWebView2Controller3::get_ShouldDetectMonitorScaleChanges property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_shoulddetectmonitorscalechanges)
-   * [ICoreWebView2Controller3::put_BoundsMode property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_boundsmode)
-   * [ICoreWebView2Controller3::put_RasterizationScale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_rasterizationscale)
-   * [ICoreWebView2Controller3::put_ShouldDetectMonitorScaleChanges property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_shoulddetectmonitorscalechanges)
-   * [ICoreWebView2Controller3::remove_RasterizationScaleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#remove_rasterizationscalechanged)
+* `ICoreWebView2Controller3` interface:
+   * [ICoreWebView2Controller3::add_RasterizationScaleChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#add_rasterizationscalechanged)
+   * [ICoreWebView2Controller3::get_BoundsMode method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_boundsmode)
+   * [ICoreWebView2Controller3::get_RasterizationScale method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_rasterizationscale)
+   * [ICoreWebView2Controller3::get_ShouldDetectMonitorScaleChanges method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_shoulddetectmonitorscalechanges)
+   * [ICoreWebView2Controller3::put_BoundsMode method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_boundsmode)
+   * [ICoreWebView2Controller3::put_RasterizationScale method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_rasterizationscale)
+   * [ICoreWebView2Controller3::put_ShouldDetectMonitorScaleChanges method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_shoulddetectmonitorscalechanges)
+   * [ICoreWebView2Controller3::remove_RasterizationScaleChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#remove_rasterizationscalechanged)
 
 ---
 
@@ -1782,13 +1782,13 @@ The WebView2 control raises events to let the app know when the control gains fo
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebview2Controller` interface:
-   * [ICoreWebview2Controller::add_GotFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_gotfocus)
-   * [ICoreWebview2Controller::add_LostFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_lostfocus)
-   * [ICoreWebview2Controller::add_MoveFocusRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_movefocusrequested)
+   * [ICoreWebview2Controller::add_GotFocus method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_gotfocus)
+   * [ICoreWebview2Controller::add_LostFocus method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_lostfocus)
+   * [ICoreWebview2Controller::add_MoveFocusRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_movefocusrequested)
    * [ICoreWebview2Controller::MoveFocus method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#movefocus)
-   * [ICoreWebview2Controller::remove_GotFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_gotfocus)
-   * [ICoreWebview2Controller::remove_LostFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_lostfocus)
-   * [ICoreWebview2Controller::remove_MoveFocusRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_movefocusrequested)
+   * [ICoreWebview2Controller::remove_GotFocus method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_gotfocus)
+   * [ICoreWebview2Controller::remove_LostFocus method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_lostfocus)
+   * [ICoreWebview2Controller::remove_MoveFocusRequested method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_movefocusrequested)
 * [ICoreWebView2MoveFocusRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs)
 
 ---
@@ -1814,9 +1814,9 @@ WebView2 can be reparented to a different parent window handle (`HWND`).  WebVie
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebview2Controller` interface:
-   * [ICoreWebview2Controller::get_ParentWindow property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_parentwindow)
+   * [ICoreWebview2Controller::get_ParentWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_parentwindow)
    * [ICoreWebview2Controller::NotifyParentWindowPositionChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#notifyparentwindowpositionchanged)
-   * [ICoreWebview2Controller::put_ParentWindow property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_parentwindow)
+   * [ICoreWebview2Controller::put_ParentWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_parentwindow)
 
 ---
 
@@ -1846,11 +1846,11 @@ When WebView2 has focus, it directly receives input from the user. An app may wa
 
 * [ICoreWebView2AcceleratorKeyPressedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs)
 * `ICoreWebView2Controller` interface:
-   * [ICoreWebView2Controller::add_AcceleratorKeyPressed event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_acceleratorkeypressed)
-   * [ICoreWebView2Controller::remove_AcceleratorKeyPressed event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_acceleratorkeypressed)
-* [ICoreWebView2Settings3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings3)
-   * [ICoreWebView2Settings3::get_AreBrowserAcceleratorKeysEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#get_arebrowseracceleratorkeysenabled)
-   * [ICoreWebView2Settings3::put_AreBrowserAcceleratorKeysEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#put_arebrowseracceleratorkeysenabled)
+   * [ICoreWebView2Controller::add_AcceleratorKeyPressed method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_acceleratorkeypressed)
+   * [ICoreWebView2Controller::remove_AcceleratorKeyPressed method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_acceleratorkeypressed)
+* `ICoreWebView2Settings3` interface:
+   * [ICoreWebView2Settings3::get_AreBrowserAcceleratorKeysEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#get_arebrowseracceleratorkeysenabled)
+   * [ICoreWebView2Settings3::put_AreBrowserAcceleratorKeysEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#put_arebrowseracceleratorkeysenabled)
 
 ---
 
@@ -1872,9 +1872,9 @@ WebView2 can specify a default background color.  The color can be any opaque co
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2controller2)
-   * [ICoreWebView2Controller2::get_DefaultBackgroundColor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#get_defaultbackgroundcolor)
-   * [ICoreWebView2Controller2::put_DefaultBackgroundColor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#put_defaultbackgroundcolor)
+* `ICoreWebView2Controller2` interface:
+   * [ICoreWebView2Controller2::get_DefaultBackgroundColor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#get_defaultbackgroundcolor)
+   * [ICoreWebView2Controller2::put_DefaultBackgroundColor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#put_defaultbackgroundcolor)
 
 ---
 
@@ -1923,8 +1923,8 @@ WebView2 can connect its composition tree to an [IDCompositionVisual](/windows/w
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2CompositionController` interface:
-   * [ICoreWebView2CompositionController::get_RootVisualTarget property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_rootvisualtarget)
-   * [ICoreWebView2CompositionController::put_RootVisualTarget property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#put_rootvisualtarget)
+   * [ICoreWebView2CompositionController::get_RootVisualTarget method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_rootvisualtarget)
+   * [ICoreWebView2CompositionController::put_RootVisualTarget method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#put_rootvisualtarget)
 
 ---
 
@@ -1968,10 +1968,10 @@ https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_we
 ##### [Win32/C++](#tab/win32cpp)
 
 * `CoreWebView2CompositionController` interface:
-   * [ICoreWebView2CompositionController::get_Cursor property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_cursor)<!--no put-->
-   * [ICoreWebView2CompositionController::add_CursorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#add_cursorchanged)
-   * [ICoreWebView2CompositionController::remove_CursorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#remove_cursorchanged)
-   * [ICoreWebView2CompositionController::get_SystemCursorId property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_systemcursorid)<!--no put-->
+   * [ICoreWebView2CompositionController::get_Cursor method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_cursor)<!--no put-->
+   * [ICoreWebView2CompositionController::add_CursorChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#add_cursorchanged)
+   * [ICoreWebView2CompositionController::remove_CursorChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#remove_cursorchanged)
+   * [ICoreWebView2CompositionController::get_SystemCursorId method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_systemcursorid)<!--no put-->
    * [ICoreWebView2CompositionController::SendMouseInput method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#sendmouseinput)
    * [ICoreWebView2CompositionController::SendPointerInput method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#sendpointerinput)
 * `ICoreWebView2Environment3` interface:
@@ -2005,7 +2005,7 @@ Use the following APIs to forward `IDropTarget` events from the system to the We
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2CompositionController3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3)
+* `ICoreWebView2CompositionController3` interface:
    * [ICoreWebView2CompositionController3::DragEnter method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragenter)
    * [ICoreWebView2CompositionController3::DragLeave method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragleave)
    * [ICoreWebView2CompositionController3::DragOver method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragover)
@@ -2029,8 +2029,8 @@ Not applicable.
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2CompositionController2` interface:
-   * [ICoreWebView2CompositionController2::get_AutomationProvider property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller2#get_automationprovider)<!--no put-->
-* [ICoreWebView2Environment4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment4)
+   * [ICoreWebView2CompositionController2::get_AutomationProvider method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller2#get_automationprovider)<!--no put-->
+* `ICoreWebView2Environment4` interface:
    * [ICoreWebView2Environment4::GetAutomationProviderForWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2environment4#getautomationproviderforwindow)<!--C++ only-->
 
 ---
@@ -2070,16 +2070,16 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Environment7 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment7)
-   * [ICoreWebView2Environment7::get_UserDataFolder property method](/microsoft-edge/webview2/reference/win32/icorewebview2environment7#get_userdatafolder)<!--no put-->
-* [ICoreWebView2Environment10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment10)
+* `ICoreWebView2Environment7` interface:
+   * [ICoreWebView2Environment7::get_UserDataFolder method](/microsoft-edge/webview2/reference/win32/icorewebview2environment7#get_userdatafolder)<!--no put-->
+* `ICoreWebView2Environment10` interface:
    * [ICoreWebView2Environment10::CreateCoreWebView2CompositionControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2compositioncontrollerwithoptions)<!-- c#: might ~=CreateCoreWebView2CompositionControllerAsync -->
    * [ICoreWebView2Environment10::CreateCoreWebView2ControllerOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controlleroptions)
    * [ICoreWebView2Environment10::CreateCoreWebView2ControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controllerwithoptions)
-* [ICoreWebView2EnvironmentOptions2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2)
-   * [ICoreWebView2EnvironmentOptions2::get_ExclusiveUserDataFolderAccess property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#get_exclusiveuserdatafolderaccess)
-   * [ICoreWebView2EnvironmentOptions2::put_ExclusiveUserDataFolderAccess property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#put_exclusiveuserdatafolderaccess)
-* [ICoreWebView2Profile2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile2)
+* `ICoreWebView2EnvironmentOptions2` interface:
+   * [ICoreWebView2EnvironmentOptions2::get_ExclusiveUserDataFolderAccess method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#get_exclusiveuserdatafolderaccess)
+   * [ICoreWebView2EnvironmentOptions2::put_ExclusiveUserDataFolderAccess method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#put_exclusiveuserdatafolderaccess)
+* `ICoreWebView2Profile2` interface:
    * [ICoreWebView2Profile2::ClearBrowsingData method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdata)
    * [ICoreWebView2Profile2::ClearBrowsingDataAll method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdataall)
    * [ICoreWebView2Profile2::ClearBrowsingDataInTimeRange method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdataintimerange)
@@ -2146,13 +2146,13 @@ Create an options object that defines a profile:
 
 <!-- Ref topic breakout: small dedicated iface.  link to iface to bring up overview, and link to methods to show method names -->
 Create a WebView2 control that uses the profile:
-* [ICoreWebView2Environment10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment10)
+* `ICoreWebView2Environment10` interface:
    * [ICoreWebView2Environment10::CreateCoreWebView2ControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controllerwithoptions)
    * [ICoreWebView2Environment10::CreateCoreWebView2CompositionControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2compositioncontrollerwithoptions)
 
 Access and manipulate the profile:
-* [ICoreWebView2_13 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_13)
-   * [ICoreWebView2_13::get_Profile property method](/microsoft-edge/webview2/reference/win32/icorewebview2_13#get_profile)<!--no put-->
+* `ICoreWebView2_13` interface:
+   * [ICoreWebView2_13::get_Profile method](/microsoft-edge/webview2/reference/win32/icorewebview2_13#get_profile)<!--no put-->
 * [ICoreWebView2Profile interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile)
 * [ICoreWebView2Profile2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile2) - Methods to clear browsing data.<!--keep text-->
 
@@ -2184,7 +2184,7 @@ Analyze and debug performance, handle performance-related events, and manage mem
 
 * `ICoreWebView2_3` interface:
    * [ICoreWebView2_3::TrySuspend method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#trysuspend)
-   * [ICoreWebView2_3::get_IsSuspended property method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#get_issuspended)<!--no put-->
+   * [ICoreWebView2_3::get_IsSuspended method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#get_issuspended)<!--no put-->
    * [ICoreWebView2_3::Resume method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#resume)
 * `ICoreWebView2_6` interface:
    * [ICoreWebView2_6::OpenTaskManagerWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2_6#opentaskmanagerwindow)
@@ -2244,8 +2244,8 @@ Receiver:
 
 Open:
 * `ICoreWebView2Settings` interface:
-   * [ICoreWebView2Settings::get_AreDevToolsEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredevtoolsenabled)
-   * [ICoreWebView2Settings::put_AreDevToolsEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredevtoolsenabled)
+   * [ICoreWebView2Settings::get_AreDevToolsEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredevtoolsenabled)
+   * [ICoreWebView2Settings::put_AreDevToolsEnabled method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredevtoolsenabled)
 * `ICoreWebView2` interface:
    * [ICoreWebView2::OpenDevToolsWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2#opendevtoolswindow)
 

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/17/2023
+ms.date: 04/19/2023
 ---
 # Overview of WebView2 features and APIs
 
@@ -101,31 +101,32 @@ Host objects can be projected into JavaScript, so that you can call native objec
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.AddHostObjectToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.addhostobjecttoscript)
    * [CoreWebView2.RemoveHostObjectFromScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.removehostobjectfromscript)
-
-* [CoreWebView2Settings.AreHostObjectsAllowed Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.arehostobjectsallowed)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreHostObjectsAllowed Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.arehostobjectsallowed)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.AddHostObjectToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#addhostobjecttoscript)
    * [CoreWebView2.RemoveHostObjectFromScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#removehostobjectfromscript)
-
-* [CoreWebView2Settings.AreHostObjectsAllowed Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arehostobjectsallowed)
-
-* [CoreWebView2Frame.RemoveHostObjectFromScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#removehostobjectfromscript)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreHostObjectsAllowed Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arehostobjectsallowed)
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.RemoveHostObjectFromScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#removehostobjectfromscript)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2` interface
+* `ICoreWebView2` interface:
    * [ICoreWebView2::AddHostObjectToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#addhostobjecttoscript)
    * [ICoreWebView2::RemoveHostObjectFromScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#removehostobjectfromscript)
-
-* [ICoreWebView2Settings::AreHostObjectsAllowed property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_arehostobjectsallowed), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_arehostobjectsallowed)
-
-* [ICoreWebView2Frame::AddHostObjectToScriptWithOrigins method](/microsoft-edge/webview2/reference/win32/icorewebview2frame#addhostobjecttoscriptwithorigins)
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_AreHostObjectsAllowed property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_arehostobjectsallowed)
+   * [ICoreWebView2Settings::put_AreHostObjectsAllowed property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_arehostobjectsallowed)
+* `ICoreWebView2Frame` interface:
+   * [ICoreWebView2Frame::AddHostObjectToScriptWithOrigins method](/microsoft-edge/webview2/reference/win32/icorewebview2frame#addhostobjecttoscriptwithorigins)
 
 ---
 
@@ -137,36 +138,37 @@ Allows host app to add JavaScript in the web content within the WebView2 control
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.addscripttoexecuteondocumentcreatedasync)
    * [CoreWebView2.ExecuteScriptAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.executescriptasync)
    * [CoreWebView2.RemoveScriptToExecuteOnDocumentCreated Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.removescripttoexecuteondocumentcreated)
-
-* [CoreWebView2Settings.IsScriptEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isscriptenabled)
-
-* [CoreWebView2Frame.ExecuteScriptAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.executescriptasync)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsScriptEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isscriptenabled)
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.ExecuteScriptAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.executescriptasync)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#addscripttoexecuteondocumentcreatedasync)
    * [CoreWebView2.ExecuteScriptAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#executescriptasync)
    * [CoreWebView2.RemoveScriptToExecuteOnDocumentCreated Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#removescripttoexecuteondocumentcreated)
-
-* [CoreWebView2Settings.IsScriptEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isscriptenabled)
-
-* [CoreWebView2Frame.ExecuteScriptAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#executescriptasync)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsScriptEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isscriptenabled)
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.ExecuteScriptAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#executescriptasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2` interface
+* `ICoreWebView2` interface:
    * [ICoreWebView2::AddScriptToExecuteOnDocumentCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2#addscripttoexecuteondocumentcreated)
    * [ICoreWebView2::ExecuteScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#executescript)
    * [ICoreWebView2::RemoveScriptToExecuteOnDocumentCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2#removescripttoexecuteondocumentcreated)
-
-* [ICoreWebView2Settings::IsScriptEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isscriptenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isscriptenabled)
-
-* [ICoreWebView2Frame2::ExecuteScript method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#executescript)
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_IsScriptEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isscriptenabled)
+   * [ICoreWebView2Settings::put_IsScriptEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isscriptenabled)
+* `ICoreWebView2Frame2` interface:
+   * [ICoreWebView2Frame2::ExecuteScript method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#executescript)
 
 ---
 
@@ -178,47 +180,44 @@ Your app can send messages to the web content that's within the WebView2 control
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.PostWebMessageAsJson Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postwebmessageasjson)
    * [CoreWebView2.PostWebMessageAsString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postwebmessageasstring)
    * [CoreWebView2.WebMessageReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webmessagereceived)
-      * [CoreWebView2WebMessageReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs)
-
-* [CoreWebView2Settings.IsWebMessageEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.iswebmessageenabled)
-
-* `CoreWebView2Frame` Class
+* [CoreWebView2WebMessageReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsWebMessageEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.iswebmessageenabled)
+* `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.PostWebMessageAsJson Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postwebmessageasjson)
    * [CoreWebView2Frame.PostWebMessageAsString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postwebmessageasstring)
    * [CoreWebView2Frame.WebMessageReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.webmessagereceived)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.PostWebMessageAsJson Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#postwebmessageasjson)
    * [CoreWebView2.PostWebMessageAsString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#postwebmessageasstring)
    * [CoreWebView2.WebMessageReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webmessagereceived)
-      * [CoreWebView2WebMessageReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webmessagereceivedeventargs)
-   
-* [CoreWebView2Settings.IsWebMessageEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#iswebmessageenabled)
-
-* `CoreWebView2Frame` Class
+* [CoreWebView2WebMessageReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webmessagereceivedeventargs)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsWebMessageEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#iswebmessageenabled)
+* `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.PostWebMessageAsJson Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#postwebmessageasjson)
    * [CoreWebView2Frame.PostWebMessageAsString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#postwebmessageasstring)
    * [CoreWebView2Frame.WebMessageReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#webmessagereceived)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2` interface
+* `ICoreWebView2` interface:
    * [ICoreWebView2::PostWebMessageAsJson method](/microsoft-edge/webview2/reference/win32/icorewebview2#postwebmessageasjson)
    * [ICoreWebView2::PostWebMessageAsString method](/microsoft-edge/webview2/reference/win32/icorewebview2#postwebmessageasstring)
    * [ICoreWebView2::add_WebMessageReceived](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webmessagereceived)
-      * [ICoreWebView2WebMessageReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs)
    * [ICoreWebView2::remove_WebMessageReceived](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webmessagereceived)
-
-* [ICoreWebView2Settings::get_IsWebMessageEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iswebmessageenabled)
-* [ICoreWebView2Settings::put_IsWebMessageEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iswebmessageenabled)
-
-* `ICoreWebView2Frame2` interface
+* [ICoreWebView2WebMessageReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs)
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_IsWebMessageEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iswebmessageenabled)
+   * [ICoreWebView2Settings::put_IsWebMessageEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iswebmessageenabled)
+* `ICoreWebView2Frame2` interface:
    * [ICoreWebView2Frame2::PostWebMessageAsJson method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#postwebmessageasjson)
    * [ICoreWebView2Frame2::PostWebMessageAsString method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#postwebmessageasstring)
    * [ICoreWebView2Frame2::add_WebMessageReceived](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_webmessagereceived)
@@ -234,18 +233,22 @@ When hosting WebView2, your app can manage different JavaScript dialogs, to supp
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ScriptDialogOpening Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.scriptdialogopening)
-   * [CoreWebView2ScriptDialogOpeningEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptdialogopeningeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ScriptDialogOpening Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.scriptdialogopening)
+* [CoreWebView2ScriptDialogOpeningEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2scriptdialogopeningeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ScriptDialogOpening Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#scriptdialogopening)
-   * [CoreWebView2ScriptDialogOpeningEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptdialogopeningeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ScriptDialogOpening Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#scriptdialogopening)
+* [CoreWebView2ScriptDialogOpeningEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2scriptdialogopeningeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::ScriptDialogOpening event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_scriptdialogopening), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_scriptdialogopening)
-   * [ICoreWebView2ScriptDialogOpeningEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventargs)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_ScriptDialogOpening event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_scriptdialogopening)
+   * [ICoreWebView2::remove_ScriptDialogOpening event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_scriptdialogopening)
+* [ICoreWebView2ScriptDialogOpeningEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2scriptdialogopeningeventargs)
 
 ---
 
@@ -266,15 +269,12 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postsharedbuffertoscript)
-
-* `CoreWebView2Environment` Class
+* `CoreWebView2Environment` Class:
    * [ICoreWebView2Environment.CreateSharedBuffer Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createsharedbuffer)
-
-* `CoreWebView2Frame` Class
+* `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.PostSharedBufferToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postsharedbuffertoscript)
-
 * [CoreWebView2SharedBuffer Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer)
    * [CoreWebView2SharedBuffer.Buffer Property](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer.buffer)
    * [CoreWebView2SharedBuffer.FileMappingHandle Property](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer.filemappinghandle)
@@ -282,28 +282,23 @@ See also:
    * [CoreWebView2SharedBuffer.Close Method](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer.close)
    * [CoreWebView2SharedBuffer.Dispose Method](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer.dispose)
    * [CoreWebView2SharedBuffer.OpenStream Method](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbuffer.openstream)
-
 * [CoreWebView2SharedBufferAccess Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2sharedbufferaccess)
    * `ReadOnly`
    * `ReadWrite`
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#postsharedbuffertoscript)
-
-* `CoreWebView2Environment` Class
+* `CoreWebView2Environment` Class:
    * [ICoreWebView2Environment.CreateSharedBuffer Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createsharedbuffer)
-
-* `CoreWebView2Frame` Class
+* `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.PostSharedBufferToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#postsharedbuffertoscript)
-
 * [CoreWebView2SharedBuffer Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer)
    * [CoreWebView2SharedBuffer.Buffer Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer#buffer)
    * [CoreWebView2SharedBuffer.Size Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer#size)
    * [CoreWebView2SharedBuffer.Close Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer#close)
    * [CoreWebView2SharedBuffer.OpenStream Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbuffer#openstream)
-
 * [CoreWebView2SharedBufferAccess Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sharedbufferaccess)
    * `ReadOnly`
    * `ReadWrite`
@@ -312,20 +307,16 @@ See also:
 
 * [ICoreWebView2_17 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_17)
    * [ICoreWebView2_17::PostSharedBufferToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2_17#postsharedbuffertoscript)
-
 * [ICoreWebView2Environment12 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment12)
    * [ICoreWebView2Environment12::CreateSharedBuffer method](/microsoft-edge/webview2/reference/win32/icorewebview2environment12#createsharedbuffer)
-
 * [ICoreWebView2Frame4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame4)
    * [ICoreWebView2Frame4::PostSharedBufferToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2frame4#postsharedbuffertoscript)
-
 * [ICoreWebView2SharedBuffer interface](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer)
    * [ICoreWebView2SharedBuffer::OpenStream method](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer#openstream)
    * [ICoreWebView2SharedBuffer::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer#close)
    * [ICoreWebView2SharedBuffer::get_Size method](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer#get_size)
    * [ICoreWebView2SharedBuffer::get_Buffer method](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer#get_buffer)
    * [ICoreWebView2SharedBuffer::get_FileMappingHandle method](/microsoft-edge/webview2/reference/win32/icorewebview2sharedbuffer#get_filemappinghandle)
-
 * [COREWEBVIEW2_SHARED_BUFFER_ACCESS](/microsoft-edge/webview2/reference/win32/webview2-idl#corewebview2_shared_buffer_access)
    * `COREWEBVIEW2_SHARED_BUFFER_ACCESS_READ_ONLY`
    * `COREWEBVIEW2_SHARED_BUFFER_ACCESS_READ_WRITE`
@@ -349,61 +340,47 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.ShowPrintUI Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.showprintui#microsoft-web-webview2-core-corewebview2-showprintui)
    * [CoreWebView2.PrintAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printasync#microsoft-web-webview2-core-corewebview2-printasync)
    * [CoreWebView2.PrintToPdfAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync)
    * [CoreWebView2.PrintToPdfStreamAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfstreamasync#microsoft-web-webview2-core-corewebview2-printtopdfstreamasync)
-
-* [CoreWebView2Environment.CreatePrintSettings Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createprintsettings)
-
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreatePrintSettings Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createprintsettings)
 * [CoreWebView2PrintSettings Class](/dotnet/api/microsoft.web.webview2.core.corewebview2printsettings)
-
 * [CoreWebView2PrintDialogKind Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2printdialogkind)
-
 * [CoreWebView2PrintStatus Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2printstatus)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2` Class
+* `CoreWebView2` Class:
    * [CoreWebView2.ShowPrintUI Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#showprintui)
    * [CoreWebView2.PrintAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printasync)
    * [CoreWebView2.PrintToPdfAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printtopdfasync)
    * [CoreWebView2.PrintToPdfStreamAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printtopdfstreamasync)
-
-* [CoreWebView2Environment.CreatePrintSettings Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createprintsettings)
-
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreatePrintSettings Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createprintsettings)
 * [CoreWebView2PrintSettings Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2printsettings)
-
 * [CoreWebView2PrintDialogKind Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2printdialogkind)
-
 * [CoreWebView2PrintStatus Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2printstatus)
-
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7#printtopdf)
-
-* `ICoreWebView2_16` interface
+* [ICoreWebView2_7 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_7)
+   * [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7#printtopdf)
+* [ICoreWebView2_16 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_16)
    * [ICoreWebView2_16::ShowPrintUI method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#showprintui)
    * [ICoreWebView2_16::Print method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#print)
    * [ICoreWebView2_16::PrintToPdfStream method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#printtopdfstream)
-
-* [ICoreWebView2Environment6::CreatePrintSettings method](/microsoft-edge/webview2/reference/win32/icorewebview2environment6#createprintsettings)
-
-* `PrintSettings`
-   * [ICoreWebView2PrintSettings interface](/microsoft-edge/webview2/reference/win32/icorewebview2printsettings)
-   * [ICoreWebView2PrintSettings2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2printsettings2)
-
-* [COREWEBVIEW2_PRINT_DIALOG_KIND enum](/microsoft-edge/webview2/reference/win32/icorewebview2_16#corewebview2_print_dialog_kind)
-
-* [COREWEBVIEW2_PRINT_STATUS enum](/microsoft-edge/webview2/reference/win32/icorewebview2_16#corewebview2_print_status)
-
+* [ICoreWebView2Environment6 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment6)
+   * [ICoreWebView2Environment6::CreatePrintSettings method](/microsoft-edge/webview2/reference/win32/icorewebview2environment6#createprintsettings)
 * [ICoreWebView2PrintCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2printcompletedhandler)
-
+* [ICoreWebView2PrintSettings interface](/microsoft-edge/webview2/reference/win32/icorewebview2printsettings)
+* [ICoreWebView2PrintSettings2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2printsettings2)
 * [ICoreWebView2PrintToPdfCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2printtopdfcompletedhandler)
-
 * [ICoreWebView2PrintToPdfStreamCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2printtopdfstreamcompletedhandler)
+* [COREWEBVIEW2_PRINT_DIALOG_KIND enum](/microsoft-edge/webview2/reference/win32/icorewebview2_16#corewebview2_print_dialog_kind)
+* [COREWEBVIEW2_PRINT_STATUS enum](/microsoft-edge/webview2/reference/win32/icorewebview2_16#corewebview2_print_status)
 
 ---
 
@@ -418,20 +395,18 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.CookieManager Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.cookiemanager#microsoft-web-webview2-core-corewebview2-cookiemanager)
-
+* `CoreWebView2` Class:
+   * [CoreWebView2.CookieManager Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.cookiemanager#microsoft-web-webview2-core-corewebview2-cookiemanager)
 * [CoreWebView2Cookie Class](/dotnet/api/microsoft.web.webview2.core.corewebview2cookie)
+* [CoreWebView2CookieManager Class](/dotnet/api/microsoft.web.webview2.core.corewebview2cookiemanager)
 
 <!-- link deleted for CookieList Class. Goes to 674 prerelease: https://learn.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2cookielist?view=webview2-dotnet-1.0.674-prerelease -->
 
-* [CoreWebView2CookieManager Class](/dotnet/api/microsoft.web.webview2.core.corewebview2cookiemanager)
-
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.CookieManager Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#cookiemanager)
-
+* `CoreWebView2` Class:
+   * [CoreWebView2.CookieManager Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#cookiemanager)
 * [CoreWebView2Cookie Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2cookie)
-
 * [CoreWebView2CookieManager Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2cookiemanager)
 
 <!-- Link deleted for [CoreWebView2CookieList Class]()
@@ -441,12 +416,10 @@ https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_we
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_2.get_CookieManager method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#get_cookiemanager)<!--no put-->
-
+* `ICoreWebView2_2` interface:
+   * [ICoreWebView2_2.get_CookieManager property method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#get_cookiemanager)<!--no put-->
 * [ICoreWebView2Cookie interface](/microsoft-edge/webview2/reference/win32/icorewebview2cookie)
-
 * [ICoreWebView2CookieList interface](/microsoft-edge/webview2/reference/win32/icorewebview2cookielist)
-
 * [ICoreWebView2CookieManager interface](/microsoft-edge/webview2/reference/win32/icorewebview2cookiemanager)
 
 ---
@@ -459,15 +432,18 @@ By hosting WebView2, your app can capture screenshots and indicate which format 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.CapturePreviewAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.capturepreviewasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.CapturePreviewAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.capturepreviewasync)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.CapturePreviewAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#capturepreviewasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.CapturePreviewAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#capturepreviewasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2.CapturePreview method](/microsoft-edge/webview2/reference/win32/icorewebview2#capturepreview)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2.CapturePreview method](/microsoft-edge/webview2/reference/win32/icorewebview2#capturepreview)
 
 ---
 
@@ -484,58 +460,77 @@ Your app can manage the download experience in WebView2.  Your app can:
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 General:
-* [CoreWebView2.IsDefaultDownloadDialogOpenChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.isdefaultdownloaddialogopenchanged)
-* [CoreWebView2.IsDefaultDownloadDialogOpen Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.isdefaultdownloaddialogopen)
-* [CoreWebView2.OpenDefaultDownloadDialog Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.opendefaultdownloaddialog)
-* [CoreWebView2.CloseDefaultDownloadDialog Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.closedefaultdownloaddialog)
+* `CoreWebView2` Class:
+   * [CoreWebView2.IsDefaultDownloadDialogOpenChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.isdefaultdownloaddialogopenchanged)
+   * [CoreWebView2.IsDefaultDownloadDialogOpen Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.isdefaultdownloaddialogopen)
+   * [CoreWebView2.OpenDefaultDownloadDialog Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.opendefaultdownloaddialog)
+   * [CoreWebView2.CloseDefaultDownloadDialog Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.closedefaultdownloaddialog)
 
 Modify Default Experience:
-* [CoreWebView2.DefaultDownloadDialogCornerAlignment Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.defaultdownloaddialogcorneralignment)
-* [CoreWebView2.DefaultDownloadDialogMargin Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.defaultdownloaddialogmargin)
-* [CoreWebView2Profile.DefaultDownloadFolderPath Property](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.defaultdownloadfolderpath)
+* `CoreWebView2` Class:
+   * [CoreWebView2.DefaultDownloadDialogCornerAlignment Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.defaultdownloaddialogcorneralignment)
+   * [CoreWebView2.DefaultDownloadDialogMargin Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.defaultdownloaddialogmargin)
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.DefaultDownloadFolderPath Property](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.defaultdownloadfolderpath)
 
 Custom Download Experience:
-* [CoreWebView2.DownloadStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.downloadstarting)
-   * [CoreWebView2DownloadStartingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2downloadstartingeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.DownloadStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.downloadstarting)
+* [CoreWebView2DownloadStartingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2downloadstartingeventargs)
 * [CoreWebView2DownloadOperation Class](/dotnet/api/microsoft.web.webview2.core.corewebview2downloadoperation)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 General:
-* [CoreWebView2.IsDefaultDownloadDialogOpenChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#isdefaultdownloaddialogopenchanged)
-* [CoreWebView2.IsDefaultDownloadDialogOpen Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#isdefaultdownloaddialogopen)
-* [CoreWebView2.OpenDefaultDownloadDialog Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#opendefaultdownloaddialog)
-* [CoreWebView2.CloseDefaultDownloadDialog Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#closedefaultdownloaddialog)
+* `CoreWebView2` Class:
+   * [CoreWebView2.IsDefaultDownloadDialogOpenChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#isdefaultdownloaddialogopenchanged)
+   * [CoreWebView2.IsDefaultDownloadDialogOpen Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#isdefaultdownloaddialogopen)
+   * [CoreWebView2.OpenDefaultDownloadDialog Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#opendefaultdownloaddialog)
+   * [CoreWebView2.CloseDefaultDownloadDialog Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#closedefaultdownloaddialog)
 
 Modify Default Experience:
-* [CoreWebView2.DefaultDownloadDialogCornerAlignment Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#defaultdownloaddialogcorneralignment)
-* [CoreWebView2.DefaultDownloadDialogMargin Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#defaultdownloaddialogmargin)
-* [CoreWebView2Profile.DefaultDownloadFolderPath Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#defaultdownloadfolderpath)
+* `CoreWebView2` Class:
+   * [CoreWebView2.DefaultDownloadDialogCornerAlignment Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#defaultdownloaddialogcorneralignment)
+   * [CoreWebView2.DefaultDownloadDialogMargin Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#defaultdownloaddialogmargin)
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.DefaultDownloadFolderPath Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#defaultdownloadfolderpath)
 
 Custom Download Experience:
-* [CoreWebView2.DownloadStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#downloadstarting)
-   * [CoreWebView2DownloadStartingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2downloadstartingeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.DownloadStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#downloadstarting)
+* [CoreWebView2DownloadStartingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2downloadstartingeventargs)
 * [CoreWebView2DownloadOperation Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2downloadoperation)
 
 ##### [Win32/C++](#tab/win32cpp)
 
 General:
-* [ICoreWebView2_9::IsDefaultDownloadDialogOpen property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_isdefaultdownloaddialogopen)<!--no put-->
-* [ICoreWebView2_9::OpenDefaultDownloadDialog method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#opendefaultdownloaddialog)
-* [ICoreWebView2_9::IsDefaultDownloadDialogOpenChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_9#add_isdefaultdownloaddialogopenchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_9#remove_isdefaultdownloaddialogopenchanged)
-* [ICoreWebView2_9::CloseDefaultDownloadDialog method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#closedefaultdownloaddialog)
+* `ICoreWebView2_9` interface:
+   * [ICoreWebView2_9::get_IsDefaultDownloadDialogOpen property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_isdefaultdownloaddialogopen)<!--no put-->
+   * [ICoreWebView2_9::OpenDefaultDownloadDialog method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#opendefaultdownloaddialog)
+   * [ICoreWebView2_9::add_IsDefaultDownloadDialogOpenChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#add_isdefaultdownloaddialogopenchanged)
+   * [ICoreWebView2_9::remove_IsDefaultDownloadDialogOpenChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#remove_isdefaultdownloaddialogopenchanged)
+   * [ICoreWebView2_9::CloseDefaultDownloadDialog method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#closedefaultdownloaddialog)
 
 Modify Default Experience:
-* [ICoreWebView2_9::DefaultDownloadDialogCornerAlignment property (get](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogcorneralignment), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogcorneralignment)
-* [ICoreWebView2_9::DefaultDownloadDialogMargin property (get](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogmargin), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogmargin)
-* [ICoreWebView2Profile::DefaultDownloadFolderPath property (get](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_defaultdownloadfolderpath), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_defaultdownloadfolderpath)
+* `ICoreWebView2_9` interface:
+   * [ICoreWebView2_9::get_DefaultDownloadDialogCornerAlignment property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogcorneralignment)
+   * [ICoreWebView2_9::put_DefaultDownloadDialogCornerAlignment property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogcorneralignment)
+   * [ICoreWebView2_9::get_DefaultDownloadDialogMargin property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#get_defaultdownloaddialogmargin)
+   * [ICoreWebView2_9::put_DefaultDownloadDialogMargin property method](/microsoft-edge/webview2/reference/win32/icorewebview2_9#put_defaultdownloaddialogmargin)
+* `ICoreWebView2Profile` interface:
+   * [ICoreWebView2Profile::get_DefaultDownloadFolderPath property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_defaultdownloadfolderpath)
+   * [ICoreWebView2Profile::put_DefaultDownloadFolderPath property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_defaultdownloadfolderpath)
 
 Custom Download Experience:
-* [ICoreWebView2_4::DownloadStarting event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_downloadstarting), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_downloadstarting)
-   * [ICoreWebView2DownloadStartingEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2downloadstartingeventargs)
+* `ICoreWebView2_4` interface:
+   * [ICoreWebView2_4::add_DownloadStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_downloadstarting)
+   * [ICoreWebView2_4::remove_DownloadStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_downloadstarting)
+* [ICoreWebView2DownloadStartingEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2downloadstartingeventargs)
 * [ICoreWebView2DownloadOperation interface](/microsoft-edge/webview2/reference/win32/icorewebview2downloadoperation)
 
 ---
+
+<!-- todo: decide whether to re-add blank lines above (lines 1-533) -->
 
 
 <!-- ------------------------------ -->
@@ -551,14 +546,15 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.PermissionRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.permissionrequested)
-   * [CoreWebView2PermissionRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionrequestedeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.PermissionRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.permissionrequested)
 
-* [CoreWebView2Frame.PermissionRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.permissionrequested)
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.PermissionRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.permissionrequested)
 
 * [CoreWebView2PermissionKind Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionkind)
 
-* `CoreWebView2PermissionRequestedEventArgs` Event
+* `CoreWebView2PermissionRequestedEventArgs` Class:
    * [CoreWebView2PermissionRequestedEventArgs.SavesInProfile Property](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionrequestedeventargs.savesinprofile)   
 
 * [CoreWebView2PermissionSetting Class](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionsetting)
@@ -566,23 +562,22 @@ See also:
    * [CoreWebView2PermissionSetting.PermissionOrigin Property](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionsetting.permissionorigin)
    * [CoreWebView2PermissionSetting.PermissionState Property](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionsetting.permissionstate)
 
-* `CoreWebView2Profile` Class
+* `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.GetNonDefaultPermissionSettingsAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.getnondefaultpermissionsettingsasync)
    * [CoreWebView2Profile.SetPermissionStateAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.setpermissionstateasync)
 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.PermissionRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#permissionrequested)
-   * [CoreWebView2PermissionRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionrequestedeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.PermissionRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#permissionrequested)
 
-* [CoreWebView2Frame.PermissionRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#permissionrequested)
-
-<!-- from RelNotes 111: -->
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.PermissionRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#permissionrequested)
 
 * [CoreWebView2PermissionKind Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionkind)
 
-* `CoreWebView2PermissionRequestedEventArgs` Event
+* `CoreWebView2PermissionRequestedEventArgs` Class:
    * [CoreWebView2PermissionRequestedEventArgs.SavesInProfile Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionrequestedeventargs#savesinprofile)
 
 * [CoreWebView2PermissionSetting Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionsetting)
@@ -590,22 +585,23 @@ See also:
    * [CoreWebView2PermissionSetting.PermissionOrigin Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionsetting#permissionorigin)
    * [CoreWebView2PermissionSetting.PermissionState Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionsetting#permissionstate)
 
-* `CoreWebView2Profile` Class
+* `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.GetNonDefaultPermissionSettingsAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#getnondefaultpermissionsettingsasync)
    * [CoreWebView2Profile.SetPermissionStateAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#setpermissionstateasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#add_permissionrequested)
-   * [ICoreWebView2PermissionRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs)
-* [ICoreWebView2::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_permissionrequested)
-
-* [ICoreWebView2Frame3::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#add_permissionrequested)
-* [ICoreWebView2Frame3::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#remove_permissionrequested)
-
-<!-- from RelNotes 111: -->
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#add_permissionrequested)
+   * [ICoreWebView2::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_permissionrequested)
 
 * [ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2getnondefaultpermissionsettingscompletedhandler)
+
+* [ICoreWebView2Frame3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame3)
+   * [ICoreWebView2Frame3::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#add_permissionrequested)
+   * [ICoreWebView2Frame3::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#remove_permissionrequested)
+
+* [ICoreWebView2PermissionRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs)
 
 * [ICoreWebView2PermissionRequestedEventArgs3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3)
    * [ICoreWebView2PermissionRequestedEventArgs3::get_SavesInProfile](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3#get_savesinprofile)
@@ -641,43 +637,57 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ContextMenuRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.contextmenurequested)
-   * [CoreWebView2ContextMenuRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contextmenurequestedeventargs)
-
-* [CoreWebView2Environment.CreateContextMenuItem Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcontextmenuitem)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ContextMenuRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.contextmenurequested)
 
 * [CoreWebView2ContextMenuItem Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contextmenuitem)
 
+* [CoreWebView2ContextMenuRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contextmenurequestedeventargs)
+
 * [CoreWebView2ContextMenuTarget Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contextmenutarget)
 
-* [CoreWebView2Settings.AreDefaultContextMenusEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.aredefaultcontextmenusenabled)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateContextMenuItem Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcontextmenuitem)
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreDefaultContextMenusEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.aredefaultcontextmenusenabled)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ContextMenuRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#contextmenurequested)
-   * [CoreWebView2ContextMenuRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contextmenurequestedeventargs)
-
-* [CoreWebView2Environment.CreateContextMenuItem Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcontextmenuitem)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ContextMenuRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#contextmenurequested)
 
 * [CoreWebView2ContextMenuItem Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contextmenuitem)
 
+* [CoreWebView2ContextMenuRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contextmenurequestedeventargs)
+
 * [CoreWebView2ContextMenuTarget Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contextmenutarget)
 
-* [CoreWebView2Settings.AreDefaultContextMenusEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#aredefaultcontextmenusenabled)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateContextMenuItem Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcontextmenuitem)
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreDefaultContextMenusEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#aredefaultcontextmenusenabled)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_11::ContextMenuRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_11#add_contextmenurequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_11#remove_contextmenurequested)
-   * [ICoreWebView2ContextMenuRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenurequestedeventargs)
+* `ICoreWebView2_11` interface:
+   * [ICoreWebView2_11::add_ContextMenuRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_11#add_contextmenurequested)
+   * [ICoreWebView2_11::remove_ContextMenuRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_11#remove_contextmenurequested)
 
-* [ICoreWebView2Environment9::CreateContextMenuItem method](/microsoft-edge/webview2/reference/win32/icorewebview2environment9#createcontextmenuitem)
+* [ICoreWebView2ContextMenuRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenurequestedeventargs)
 
 * [ICoreWebView2ContextMenuItem interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenuitem)
    * [ICoreWebView2ContextMenuItemCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenuitemcollection)
 
 * [ICoreWebView2ContextMenuTarget interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenutarget)
 
-* [ICoreWebView2Settings::AreDefaultContextMenusEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredefaultcontextmenusenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredefaultcontextmenusenabled)
+* `ICoreWebView2Environment9` interface:
+   * [ICoreWebView2Environment9::CreateContextMenuItem method](/microsoft-edge/webview2/reference/win32/icorewebview2environment9#createcontextmenuitem)
+
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_AreDefaultContextMenusEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredefaultcontextmenusenabled)
+   * [ICoreWebView2Settings::put_AreDefaultContextMenusEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredefaultcontextmenusenabled)
 
 ---
 
@@ -693,30 +703,32 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2`
-   * [CoreWebView2.StatusBarTextChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.statusbartextchanged)
+* `CoreWebView2` Class:
    * [CoreWebView2.StatusBarText Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.statusbartext)
+   * [CoreWebView2.StatusBarTextChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.statusbartextchanged)
 
-* `CoreWebView2Settings`
+* `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsStatusBarEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isstatusbarenabled)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2`
-   * [CoreWebView2.StatusBarTextChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#statusbartextchanged)
+* `CoreWebView2` Class:
    * [CoreWebView2.StatusBarText Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#statusbartext)
+   * [CoreWebView2.StatusBarTextChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#statusbartextchanged)
 
-* `CoreWebView2Settings`
+* `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsStatusBarEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isstatusbarenabled)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2_12`
-   * [ICoreWebView2_12::StatusBarTextChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_12#add_statusbartextchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_12#remove_statusbartextchanged)
-   * [ICoreWebView2_12::StatusBarText property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_12#get_statusbartext)
+* [ICoreWebView2_12 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_12)
+   * [ICoreWebView2_12::add_StatusBarTextChanged](/microsoft-edge/webview2/reference/win32/icorewebview2_12#add_statusbartextchanged)
+   * [ICoreWebView2_12::get_StatusBarText](/microsoft-edge/webview2/reference/win32/icorewebview2_12#get_statusbartext)
+   * [ICoreWebView2_12::remove_StatusBarTextChanged](/microsoft-edge/webview2/reference/win32/icorewebview2_12#remove_statusbartextchanged)
 
-* `ICoreWebView2Settings`
-   * [ICoreWebView2Settings::IsStatusBarEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isstatusbarenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isstatusbarenabled)
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_IsStatusBarEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isstatusbarenabled)
+   * [ICoreWebView2Settings::put_IsStatusBarEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isstatusbarenabled)
 
 ---
 
@@ -734,15 +746,19 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Settings.UserAgent Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.useragent)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.UserAgent Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.useragent)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Settings.UserAgent Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#useragent)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.UserAgent Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#useragent)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings2::UserAgent property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings2#get_useragent), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings2#put_useragent)
+* [ICoreWebView2Settings2 Class](/microsoft-edge/webview2/reference/win32/icorewebview2settings2)
+    * [ICoreWebView2Settings2::get_UserAgent](/microsoft-edge/webview2/reference/win32/icorewebview2settings2#get_useragent)
+    * [ICoreWebView2Settings2::put_UserAgent](/microsoft-edge/webview2/reference/win32/icorewebview2settings2#put_useragent)
 
 ---
 
@@ -754,21 +770,23 @@ Your app can independently control whether the browser's autofill functionality 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2Settings`
+* `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsGeneralAutofillEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isgeneralautofillenabled)
    * [CoreWebView2Settings.IsPasswordAutosaveEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.ispasswordautosaveenabled)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2Settings`
+* `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsGeneralAutofillEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isgeneralautofillenabled)
    * [CoreWebView2Settings.IsPasswordAutosaveEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#ispasswordautosaveenabled)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2Settings4`
-   * [ICoreWebView2Settings4::IsGeneralAutofillEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_isgeneralautofillenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_isgeneralautofillenabled)
-   * [ICoreWebView2Settings4::IsPasswordAutosaveEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_ispasswordautosaveenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_ispasswordautosaveenabled)
+* [ICoreWebView2Settings4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings4)
+   * [ICoreWebView2Settings4::get_IsGeneralAutofillEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_isgeneralautofillenabled)
+   * [ICoreWebView2Settings4::get_IsPasswordAutosaveEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#get_ispasswordautosaveenabled)
+   * [ICoreWebView2Settings4::put_IsGeneralAutofillEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_isgeneralautofillenabled)
+   * [ICoreWebView2Settings4::put_IsPasswordAutosaveEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings4#put_ispasswordautosaveenabled)
 
 ---
 
@@ -780,7 +798,7 @@ Your app can mute and unmute all audio, and find out when audio is playing.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2`
+* `CoreWebView2` Class:
    * [CoreWebView2.IsDocumentPlayingAudioChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.isdocumentplayingaudiochanged)
    * [CoreWebView2.IsMutedChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.ismutedchanged)
    * [CoreWebView2.IsDocumentPlayingAudio Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.isdocumentplayingaudio)
@@ -788,7 +806,7 @@ Your app can mute and unmute all audio, and find out when audio is playing.
    
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2`
+* `CoreWebView2` Class:
    * [CoreWebView2.IsDocumentPlayingAudioChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#isdocumentplayingaudiochanged)
    * [CoreWebView2.IsMutedChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#ismutedchanged)
    * [CoreWebView2.IsDocumentPlayingAudio Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#isdocumentplayingaudio)
@@ -796,14 +814,14 @@ Your app can mute and unmute all audio, and find out when audio is playing.
    
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_8](/microsoft-edge/webview2/reference/win32/icorewebview2_8)
-   * [ICoreWebView2_8::add_IsDocumentPlayingAudioChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_isdocumentplayingaudiochanged)
-   * [ICoreWebView2_8::add_IsMutedChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_ismutedchanged)
-   * [ICoreWebView2_8::get_IsDocumentPlayingAudio method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_isdocumentplayingaudio)
-   * [ICoreWebView2_8::get_IsMuted method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_ismuted)
-   * [ICoreWebView2_8::put_IsMuted method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#put_ismuted)
-   * [ICoreWebView2_8::remove_IsDocumentPlayingAudioChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_isdocumentplayingaudiochanged)
-   * [ICoreWebView2_8::remove_IsMutedChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_ismutedchanged)
+* [ICoreWebView2_8 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_8)
+   * [ICoreWebView2_8::add_IsDocumentPlayingAudioChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_isdocumentplayingaudiochanged)
+   * [ICoreWebView2_8::add_IsMutedChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#add_ismutedchanged)
+   * [ICoreWebView2_8::get_IsDocumentPlayingAudio property method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_isdocumentplayingaudio)
+   * [ICoreWebView2_8::get_IsMuted property method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#get_ismuted)
+   * [ICoreWebView2_8::put_IsMuted property method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#put_ismuted)
+   * [ICoreWebView2_8::remove_IsDocumentPlayingAudioChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_isdocumentplayingaudiochanged)
+   * [ICoreWebView2_8::remove_IsMutedChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_8#remove_ismutedchanged)
 
 ---
 
@@ -819,21 +837,29 @@ This feature is currently disabled by default in the browser.  To enable this fe
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Settings.IsSwipeNavigationEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isswipenavigationenabled)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsSwipeNavigationEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isswipenavigationenabled)
 
-* [CoreWebView2EnvironmentOptions.AdditionalBrowserArguments Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.additionalbrowserarguments)
+* `CoreWebView2EnvironmentOptions` Class:
+   * [CoreWebView2EnvironmentOptions.AdditionalBrowserArguments Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.additionalbrowserarguments)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Settings.IsSwipeNavigationEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isswipenavigationenabled)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsSwipeNavigationEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isswipenavigationenabled)
 
-* [CoreWebView2EnvironmentOptions.AdditionalBrowserArguments Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#additionalbrowserarguments)
+* `CoreWebView2EnvironmentOptions` Class:
+   * [CoreWebView2EnvironmentOptions.AdditionalBrowserArguments Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#additionalbrowserarguments)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings6::IsSwipeNavigationEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#get_isswipenavigationenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#put_isswipenavigationenabled)
+* `ICoreWebView2Settings6` interface:
+   * [ICoreWebView2Settings6::get_IsSwipeNavigationEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#get_isswipenavigationenabled)
+   * [ICoreWebView2Settings6::put_IsSwipeNavigationEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#put_isswipenavigationenabled)
 
-* [ICoreWebView2EnvironmentOptions::AdditionalBrowserArguments property (get](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_additionalbrowserarguments), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_additionalbrowserarguments)
+* `ICoreWebView2EnvironmentOptions` interface:
+   * [ICoreWebView2EnvironmentOptions::get_AdditionalBrowserArguments property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_additionalbrowserarguments)
+   * [ICoreWebView2EnvironmentOptions::put_AdditionalBrowserArguments property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_additionalbrowserarguments)
 
 ---
 
@@ -844,18 +870,22 @@ In WebView2, you can find out when an HTML element enters or leaves full-screen 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ContainsFullScreenElement Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.containsfullscreenelement)
-* [CoreWebView2.ContainsFullScreenElementChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.containsfullscreenelementchanged)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ContainsFullScreenElement Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.containsfullscreenelement)
+   * [CoreWebView2.ContainsFullScreenElementChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.containsfullscreenelementchanged)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ContainsFullScreenElement Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#containsfullscreenelement)
-* [CoreWebView2.ContainsFullScreenElementChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#containsfullscreenelementchanged)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ContainsFullScreenElement Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#containsfullscreenelement)
+   * [CoreWebView2.ContainsFullScreenElementChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#containsfullscreenelementchanged)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::ContainsFullScreenElement property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_containsfullscreenelement)<!--no put-->
-* [ICoreWebView2::ContainsFullScreenElementChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_containsfullscreenelementchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_containsfullscreenelementchanged)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::get_ContainsFullScreenElement property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_containsfullscreenelement)<!--no put-->
+   * [ICoreWebView2::add_ContainsFullScreenElementChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_containsfullscreenelementchanged)
+   * [ICoreWebView2::remove_ContainsFullScreenElementChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_containsfullscreenelementchanged)
 
 ---
 
@@ -866,15 +896,19 @@ In the browser PDF viewer, there's a PDF-specific toolbar along the top.  In Web
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Settings.HiddenPdfToolbarItems Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.hiddenpdftoolbaritems)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.HiddenPdfToolbarItems Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.hiddenpdftoolbaritems)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Settings.HiddenPdfToolbarItems Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#hiddenpdftoolbaritems)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.HiddenPdfToolbarItems Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#hiddenpdftoolbaritems)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings7::HiddenPdfToolbarItems property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#get_hiddenpdftoolbaritems), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#put_hiddenpdftoolbaritems)
+* [ICoreWebView2Settings7 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings7)
+   * [ICoreWebView2Settings7::get_HiddenPdfToolbarItems property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#get_hiddenpdftoolbaritems)
+   * [ICoreWebView2Settings7::put_HiddenPdfToolbarItems property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings7#put_hiddenpdftoolbaritems)
 
 ---
 
@@ -885,15 +919,19 @@ In WebView2, you can customize the color theme as system, light, or dark.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Profile.PreferredColorScheme Property](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.preferredcolorscheme)
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.PreferredColorScheme Property](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.preferredcolorscheme)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Profile.PreferredColorScheme Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#preferredcolorscheme)
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.PreferredColorScheme Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#preferredcolorscheme)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Profile::PreferredColorScheme property (get](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_preferredcolorscheme), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_preferredcolorscheme)
+* `ICoreWebView2Profile` interface:
+   * [ICoreWebView2Profile::get_PreferredColorScheme property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#get_preferredcolorscheme)
+   * [ICoreWebView2Profile::put_PreferredColorScheme property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile#put_preferredcolorscheme)
 
 ---
 
@@ -906,27 +944,29 @@ The `ScriptLocale` property allows the host app to set the default locale for al
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2EnvironmentOptions.Language Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.language)
+* `CoreWebView2EnvironmentOptions` Class:
+   * [CoreWebView2EnvironmentOptions.Language Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.language)
 
-* `CoreWebView2ControllerOptions` Class
+* `CoreWebView2ControllerOptions` Class:
    * [CoreWebView2ControllerOptions.ScriptLocale Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.scriptlocale)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2EnvironmentOptions.Language Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#language)
+* `CoreWebView2EnvironmentOptions` Class:
+   * [CoreWebView2EnvironmentOptions.Language Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#language)
 
-* `CoreWebView2ControllerOptions` Class
+* `CoreWebView2ControllerOptions` Class:
    * [CoreWebView2ControllerOptions.ScriptLocale Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions#scriptlocale)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2EnvironmentOptions` interface
-   * [ICoreWebView2EnvironmentOptions::get_Language method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_language)
-   * [ICoreWebView2EnvironmentOptions::put_Language method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_language)
+* `ICoreWebView2EnvironmentOptions` interface:
+   * [ICoreWebView2EnvironmentOptions::get_Language property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_language)
+   * [ICoreWebView2EnvironmentOptions::put_Language property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_language)
 
 * [ICoreWebView2ControllerOptions2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2)
-   * [ICoreWebView2ControllerOptions2::get_ScriptLocale method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#get_scriptlocale)
-   * [ICoreWebView2ControllerOptions2::put_ScriptLocale method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#put_scriptlocale)
+   * [ICoreWebView2ControllerOptions2::get_ScriptLocale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#get_scriptlocale)
+   * [ICoreWebView2ControllerOptions2::put_ScriptLocale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#put_scriptlocale)
 
 ---
 
@@ -938,21 +978,31 @@ WebView2 provides functionality to handle the JavaScript function `window.open()
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.NewWindowRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.newwindowrequested)
-   * [CoreWebView2NewWindowRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2newwindowrequestedeventargs)
-   * [CoreWebView2WindowFeatures Class](/dotnet/api/microsoft.web.webview2.core.corewebview2windowfeatures)
+* `CoreWebView2` Class:
+   * [CoreWebView2.NewWindowRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.newwindowrequested)
+
+* [CoreWebView2NewWindowRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2newwindowrequestedeventargs)
+
+* [CoreWebView2WindowFeatures Class](/dotnet/api/microsoft.web.webview2.core.corewebview2windowfeatures)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.NewWindowRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#newwindowrequested)
-   * [CoreWebView2NewWindowRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2newwindowrequestedeventargs)
-   * [CoreWebView2WindowFeatures Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2windowfeatures)
+* `CoreWebView2` Class:
+   * [CoreWebView2.NewWindowRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#newwindowrequested)
+
+* [CoreWebView2NewWindowRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2newwindowrequestedeventargs)
+
+* [CoreWebView2WindowFeatures Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2windowfeatures)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::NewWindowRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_newwindowrequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_newwindowrequested)
-   * [ICoreWebView2NewWindowRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs)
-   * [ICoreWebView2WindowFeatures interface](/microsoft-edge/webview2/reference/win32/icorewebview2windowfeatures)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_NewWindowRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_newwindowrequested)
+   * [ICoreWebView2::remove_NewWindowRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_newwindowrequested)
+
+* [ICoreWebView2NewWindowRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs)
+
+* [ICoreWebView2WindowFeatures interface](/microsoft-edge/webview2/reference/win32/icorewebview2windowfeatures)
 
 ---
 
@@ -963,18 +1013,28 @@ WebView2 provides functionality to handle the JavaScript function `window.close(
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Controller.Close Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.close)
-* [CoreWebView2.WindowCloseRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.windowcloserequested)
+* `CoreWebView2` Class:
+   * [CoreWebView2.WindowCloseRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.windowcloserequested)
+
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.Close Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.close)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Controller.Close Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#close)
-* [CoreWebView2.WindowCloseRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#windowcloserequested)
+* `CoreWebView2` Class:
+   * [CoreWebView2.WindowCloseRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#windowcloserequested)
+
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.Close Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#close)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
-* [ICoreWebView2::WindowCloseRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_windowcloserequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_windowcloserequested)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_WindowCloseRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_windowcloserequested)
+   * [ICoreWebView2::remove_WindowCloseRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_windowcloserequested)
+
+* `ICoreWebView2Controller` interface:
+   * [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
 
 ---
 
@@ -985,40 +1045,48 @@ Your app can detect when the title of the current top-level document has changed
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.DocumentTitle Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitle)
-* [CoreWebView2.DocumentTitleChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitlechanged)
+* `CoreWebView2` Class:
+   * [CoreWebView2.DocumentTitle Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitle)
+   * [CoreWebView2.DocumentTitleChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.documenttitlechanged)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.DocumentTitle Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitle)
-* [CoreWebView2.DocumentTitleChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitlechanged)
+* `CoreWebView2` Class:
+   * [CoreWebView2.DocumentTitle Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitle)
+   * [CoreWebView2.DocumentTitleChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#documenttitlechanged)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::DocumentTitle property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_documenttitle)<!--no put-->
-* [ICoreWebView2::DocumentTitleChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_documenttitlechanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_documenttitlechanged)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::get_DocumentTitle property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_documenttitle)<!--no put-->
+   * [ICoreWebView2::add_DocumentTitleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_documenttitlechanged)
+   * [ICoreWebView2::remove_DocumentTitleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_documenttitlechanged)
 
 ---
 
 <!-- ------------------------------ -->
 #### Favicon 
 
-In WebView2 you can you can set a [Favicon](https://developer.mozilla.org/docs/Glossary/Favicon) for a website or get notified when it changes. 
+In WebView2, you can set a [Favicon](https://developer.mozilla.org/docs/Glossary/Favicon) for a website, or get notified when it changes.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.FaviconChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconchanged)
-* [CoreWebView2.FaviconUri Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconuri)
-
+* `CoreWebView2` Class:
+   * [CoreWebView2.FaviconChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconchanged)
+   * [CoreWebView2.FaviconUri Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.faviconuri)
+ 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.FaviconChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#faviconchanged)
-* [CoreWebView2.FaviconUri Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#faviconuri)
-
+* `CoreWebView2` Class:
+   * [CoreWebView2.FaviconChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#faviconchanged)
+   * [CoreWebView2.FaviconUri Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#faviconuri)
+ 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_15::FaviconChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_15#add_faviconchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_15#remove_faviconchanged)
-* [ICoreWebView2_15::FaviconUri property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_15#get_faviconuri)<!--no put-->
+* `ICoreWebView2_15` interface:
+   * [ICoreWebView2_15::add_FaviconChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#add_faviconchanged)
+   * [ICoreWebView2_15::remove_FaviconChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#remove_faviconchanged)
+   * [ICoreWebView2_15::get_FaviconUri property method](/microsoft-edge/webview2/reference/win32/icorewebview2_15#get_faviconuri)<!--no put-->
 
 ---
 
@@ -1039,10 +1107,10 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2EnvironmentOptions` Class
+* `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.EnableTrackingPrevention Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.enabletrackingprevention)
 
-* `CoreWebView2Profile` Class
+* `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.PreferredTrackingPreventionLevel Property](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.preferredtrackingpreventionlevel)
 
 * [CoreWebView2TrackingPreventionLevel Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2trackingpreventionlevel)
@@ -1053,10 +1121,10 @@ See also:
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2EnvironmentOptions` Class
+* `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.EnableTrackingPrevention Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#enabletrackingprevention)
 
-* `CoreWebView2Profile` Class
+* `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.PreferredTrackingPreventionLevel Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#preferredtrackingpreventionlevel)
 
 * [CoreWebView2TrackingPreventionLevel Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2trackingpreventionlevel)
@@ -1068,10 +1136,12 @@ See also:
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2EnvironmentOptions5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5)
-   * [ICoreWebView2EnvironmentOptions5::EnableTrackingPrevention property (get](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#get_enabletrackingprevention), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#put_enabletrackingprevention)
+   * [ICoreWebView2EnvironmentOptions5::get_EnableTrackingPrevention property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#get_enabletrackingprevention)
+   * [ICoreWebView2EnvironmentOptions5::put_EnableTrackingPrevention property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#put_enabletrackingprevention)
 
 * [ICoreWebView2Profile3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile3)
-   * [ICoreWebView2Profile3::PreferredTrackingPreventionLevel property (get](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#get_preferredtrackingpreventionlevel), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#put_preferredtrackingpreventionlevel)
+   * [ICoreWebView2Profile3::get_PreferredTrackingPreventionLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#get_preferredtrackingpreventionlevel)
+   * [ICoreWebView2Profile3::put_PreferredTrackingPreventionLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#put_preferredtrackingpreventionlevel)
 
 * [COREWEBVIEW2_TRACKING_PREVENTION_LEVEL enum](/microsoft-edge/webview2/reference/win32/webview2-idl#corewebview2_tracking_prevention_level)
   * `COREWEBVIEW2_TRACKING_PREVENTION_LEVEL_NONE`
@@ -1094,19 +1164,19 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2Settings`
+* `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsReputationCheckingRequired Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2Settings`
+* `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsReputationCheckingRequired Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isreputationcheckingrequired)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings8](/microsoft-edge/webview2/reference/win32/icorewebview2settings8)
-   * [ICoreWebView2Settings8::get_IsReputationCheckingRequired method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#get_isreputationcheckingrequired)
-   * [ICoreWebView2Settings8::put_IsReputationCheckingRequired method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#put_isreputationcheckingrequired)
+* [ICoreWebView2Settings8 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings8)
+   * [ICoreWebView2Settings8::get_IsReputationCheckingRequired property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#get_isreputationcheckingrequired)
+   * [ICoreWebView2Settings8::put_IsReputationCheckingRequired property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#put_isreputationcheckingrequired)
 ---
 
 
@@ -1117,52 +1187,62 @@ Get information about running WebView2 processes, exiting processes, and failed 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-Info:
-* [CoreWebView2.BrowserProcessId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.browserprocessid)
-* [CoreWebView2Environment.GetProcessInfos Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.getprocessinfos)
-* [CoreWebView2Environment.ProcessInfosChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.processinfoschanged)
+* `CoreWebView2` Class:
+   * [CoreWebView2.BrowserProcessId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.browserprocessid)
+   * [CoreWebView2.ProcessFailed Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.processfailed)
+
+* [CoreWebView2BrowserProcessExitedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2browserprocessexitedeventargs)
+
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.BrowserProcessExited Event](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.browserprocessexited)
+   * [CoreWebView2Environment.GetProcessInfos Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.getprocessinfos)
+   * [CoreWebView2Environment.ProcessInfosChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.processinfoschanged)
+
+* [CoreWebView2ProcessFailedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs)
+
 * [CoreWebView2ProcessInfo Class](/dotnet/api/microsoft.web.webview2.core.corewebview2processinfo)
 
-Exited:
-* [CoreWebView2Environment.BrowserProcessExited Event](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.browserprocessexited)
-   * [CoreWebView2BrowserProcessExitedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2browserprocessexitedeventargs)
-
-Failed:
-* [CoreWebView2.ProcessFailed Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.processfailed)
-   * [CoreWebView2ProcessFailedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-Info:
-* [CoreWebView2.BrowserProcessId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#browserprocessid)
-* [CoreWebView2Environment.GetProcessInfos Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#getprocessinfos)
-* [CoreWebView2Environment.ProcessInfosChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#processinfoschanged)
+* `CoreWebView2` Class:
+   * [CoreWebView2.BrowserProcessId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#browserprocessid)
+   * [CoreWebView2.ProcessFailed Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#processfailed)
+
+* [CoreWebView2BrowserProcessExitedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2browserprocessexitedeventargs)
+
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.BrowserProcessExited Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#browserprocessexited)
+   * [CoreWebView2Environment.GetProcessInfos Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#getprocessinfos)
+   * [CoreWebView2Environment.ProcessInfosChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#processinfoschanged)
+
+* [CoreWebView2ProcessFailedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs)
+
 * [CoreWebView2ProcessInfo Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processinfo)
-
-Exited:
-* [CoreWebView2Environment.BrowserProcessExited Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#browserprocessexited)
-   * [CoreWebView2BrowserProcessExitedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2browserprocessexitedeventargs)
-
-Failed:
-* [CoreWebView2.ProcessFailed Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#processfailed)
-   * [CoreWebView2ProcessFailedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-Info:
-* [ICoreWebView2::BrowserProcessId property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_browserprocessid)<!--no put-->
-* [ICoreWebView2Environment8::GetProcessInfos method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#getprocessinfos)
-* [ICoreWebView2Environment8::ProcessInfosChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#add_processinfoschanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#remove_processinfoschanged)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::get_BrowserProcessId property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_browserprocessid)<!--no put-->
+   * [ICoreWebView2::add_ProcessFailed event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_processfailed)
+   * [ICoreWebView2::remove_ProcessFailed event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_processfailed)
+
+* [ICoreWebView2BrowserProcessExitedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2browserprocessexitedeventargs)
+
+* [ICoreWebView2Environment8 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment8)
+   * [ICoreWebView2Environment8::GetProcessInfos method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#getprocessinfos)
+   * [ICoreWebView2Environment8::add_ProcessInfosChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#add_processinfoschanged)
+   * [ICoreWebView2Environment8::remove_ProcessInfosChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#remove_processinfoschanged)
+
+* [ICoreWebView2Environment5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment5)
+   * [ICoreWebView2Environment5::add_BrowserProcessExited event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#add_browserprocessexited)
+   * [ICoreWebView2Environment5::remove_BrowserProcessExited event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#remove_browserprocessexited)
+
+* [ICoreWebView2ProcessFailedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs)
+
 * [ICoreWebView2ProcessInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2processinfo)
+
 * [ICoreWebView2ProcessInfoCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2processinfocollection)
-
-Exited:
-* [ICoreWebView2Environment5::BrowserProcessExited event (add](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#add_browserprocessexited), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#remove_browserprocessexited)
-   * [ICoreWebView2BrowserProcessExitedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2browserprocessexitedeventargs)
-
-Failed:
-* [ICoreWebView2::ProcessFailed event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_processfailed), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_processfailed)
-   * [ICoreWebView2ProcessFailedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs)
 
 ---
 
@@ -1187,39 +1267,54 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.Navigate Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigate)
-* [CoreWebView2.NavigateToString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring)
-* [CoreWebView2.NavigateWithWebResourceRequest Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatewithwebresourcerequest)
-* [CoreWebView2.Stop Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.stop)
-* [CoreWebView2.Reload Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.reload)
-* [CoreWebView2.SetVirtualHostNameToFolderMapping Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.setvirtualhostnametofoldermapping)
-* [CoreWebView2.ClearVirtualHostNameToFolderMapping Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.clearvirtualhostnametofoldermapping)
-* [CoreWebView2.WebResourceRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourcerequested)
-* [CoreWebView2Settings.IsBuiltInErrorPageEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isbuiltinerrorpageenabled#microsoft-web-webview2-core-corewebview2settings-isbuiltinerrorpageenabled)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ClearVirtualHostNameToFolderMapping Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.clearvirtualhostnametofoldermapping)
+   * [CoreWebView2.Navigate Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigate)
+   * [CoreWebView2.NavigateToString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring)
+   * [CoreWebView2.NavigateWithWebResourceRequest Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatewithwebresourcerequest)
+   * [CoreWebView2.Reload Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.reload)
+   * [CoreWebView2.SetVirtualHostNameToFolderMapping Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.setvirtualhostnametofoldermapping)
+   * [CoreWebView2.Stop Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.stop)
+   * [CoreWebView2.WebResourceRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourcerequested)
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsBuiltInErrorPageEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isbuiltinerrorpageenabled#microsoft-web-webview2-core-corewebview2settings-isbuiltinerrorpageenabled)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.Navigate Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigate)
-* [CoreWebView2.NavigateToString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigatetostring)
-* [CoreWebView2.NavigateWithWebResourceRequest Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigatewithwebresourcerequest)
-* [CoreWebView2.Stop Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#stop)
-* [CoreWebView2.Reload Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#reload)
-* [CoreWebView2.SetVirtualHostNameToFolderMapping Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#setvirtualhostnametofoldermapping)
-* [CoreWebView2.ClearVirtualHostNameToFolderMapping Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#clearvirtualhostnametofoldermapping)
-* [CoreWebView2.WebResourceRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourcerequested)
-* [CoreWebView2Settings.IsBuiltInErrorPageEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isbuiltinerrorpageenabled)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ClearVirtualHostNameToFolderMapping Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#clearvirtualhostnametofoldermapping)
+   * [CoreWebView2.Navigate Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigate)
+   * [CoreWebView2.NavigateToString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigatetostring)
+   * [CoreWebView2.NavigateWithWebResourceRequest Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigatewithwebresourcerequest)
+   * [CoreWebView2.Reload Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#reload)
+   * [CoreWebView2.SetVirtualHostNameToFolderMapping Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#setvirtualhostnametofoldermapping)
+   * [CoreWebView2.Stop Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#stop)
+   * [CoreWebView2.WebResourceRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourcerequested)
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsBuiltInErrorPageEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isbuiltinerrorpageenabled)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::Navigate method](/microsoft-edge/webview2/reference/win32/icorewebview2#navigate)
-* [ICoreWebView2::NavigateToString method](/microsoft-edge/webview2/reference/win32/icorewebview2#navigatetostring)
-* [ICoreWebView2_2::NavigateWithWebResourceRequest method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#navigatewithwebresourcerequest)
-* [ICoreWebView2::Stop method](/microsoft-edge/webview2/reference/win32/icorewebview2#stop)
-* [ICoreWebView2::Reload method](/microsoft-edge/webview2/reference/win32/icorewebview2#reload)
-* [ICoreWebView2_3::SetVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#setvirtualhostnametofoldermapping)
-* [ICoreWebView2_3::ClearVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#clearvirtualhostnametofoldermapping)
-* [ICoreWebView2::WebResourceRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
-* [ICoreWebView2Settings::IsBuiltInErrorPageEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isbuiltinerrorpageenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isbuiltinerrorpageenabled)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested)
+   * [ICoreWebView2::remove_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
+   * [ICoreWebView2::Navigate method](/microsoft-edge/webview2/reference/win32/icorewebview2#navigate)
+   * [ICoreWebView2::NavigateToString method](/microsoft-edge/webview2/reference/win32/icorewebview2#navigatetostring)
+   * [ICoreWebView2::Reload method](/microsoft-edge/webview2/reference/win32/icorewebview2#reload)
+   * [ICoreWebView2::Stop method](/microsoft-edge/webview2/reference/win32/icorewebview2#stop)
+
+* `ICoreWebView2_2` interface:
+   * [ICoreWebView2_2::NavigateWithWebResourceRequest method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#navigatewithwebresourcerequest)
+
+* `ICoreWebView2_3` interface:
+   * [ICoreWebView2_3::ClearVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#clearvirtualhostnametofoldermapping)
+   * [ICoreWebView2_3::SetVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#setvirtualhostnametofoldermapping)
+
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_IsBuiltInErrorPageEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isbuiltinerrorpageenabled)
+   * [ICoreWebView2Settings::put_IsBuiltInErrorPageEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isbuiltinerrorpageenabled)
 
 ---
 
@@ -1231,36 +1326,44 @@ The history methods allow back and forward navigation in WebView2, and the histo
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.Source Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.source)
-* [CoreWebView2.SourceChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.sourcechanged)
-   * [CoreWebView2SourceChangedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sourcechangedeventargs)
-* [CoreWebView2.HistoryChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.historychanged)
-* [CoreWebView2.CanGoBack Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.cangoback)
+* `CoreWebView2` Class:
+   * [CoreWebView2.CanGoBack Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.cangoback)
+   * [CoreWebView2.CanGoForward Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.cangoforward)
    * [CoreWebView2.GoBack Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.goback)
-* [CoreWebView2.CanGoForward Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.cangoforward)
    * [CoreWebView2.GoForward Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.goforward)
+   * [CoreWebView2.HistoryChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.historychanged)
+   * [CoreWebView2.Source Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.source)
+   * [CoreWebView2.SourceChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.sourcechanged)
+
+* [CoreWebView2SourceChangedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sourcechangedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.Source Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#source)
-* [CoreWebView2.SourceChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#sourcechanged)
-   * [CoreWebView2SourceChangedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sourcechangedeventargs)
-* [CoreWebView2.HistoryChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#historychanged)
-* [CoreWebView2.CanGoBack Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#cangoback)
+* `CoreWebView2` Class:
+   * [CoreWebView2.CanGoBack Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#cangoback)
+   * [CoreWebView2.CanGoForward Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#cangoforward)
    * [CoreWebView2.GoBack Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#goback)
-* [CoreWebView2.CanGoForward Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#cangoforward)
    * [CoreWebView2.GoForward Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#goforward)
+   * [CoreWebView2.HistoryChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#historychanged)
+   * [CoreWebView2.Source Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#source)
+   * [CoreWebView2.SourceChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#sourcechanged)
+
+* [CoreWebView2SourceChangedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sourcechangedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::Source property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_source)<!--no put-->
-* [ICoreWebView2::SourceChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_sourcechanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_sourcechanged)
-   * [ICoreWebView2SourceChangedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs)
-* [ICoreWebView2::HistoryChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_historychanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_historychanged)
-* [ICoreWebView2::CanGoBack property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoback)<!--no put-->
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_HistoryChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_historychanged)
+   * [ICoreWebView2::add_SourceChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_sourcechanged)
+   * [ICoreWebView2::get_CanGoBack property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoback)<!--no put-->
+   * [ICoreWebView2::get_CanGoForward property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoforward)<!--no put-->
+   * [ICoreWebView2::get_Source property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_source)<!--no put-->
    * [ICoreWebView2::GoBack method](/microsoft-edge/webview2/reference/win32/icorewebview2#goback)
-* [ICoreWebView2::CanGoForward property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2#get_cangoforward)<!--no put-->
    * [ICoreWebView2::GoForward method](/microsoft-edge/webview2/reference/win32/icorewebview2#goforward)
+   * [ICoreWebView2::remove_HistoryChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_historychanged)
+   * [ICoreWebView2::remove_SourceChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_sourcechanged)
+
+* [ICoreWebView2SourceChangedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs)
 
 ---
 
@@ -1272,33 +1375,39 @@ The `NavigationStarting` event allows the app to cancel navigating to specified 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.NavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigationstarting)
-   * [CoreWebView2NavigationStartingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2navigationstartingeventargs)
-* [CoreWebView2Frame.NavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.navigationstarting)
-   * [CoreWebView2NavigationStartingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2navigationstartingeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.NavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigationstarting)
+   * [CoreWebView2.FrameNavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framenavigationstarting) - superseded; use `CoreWebView2Frame.NavigationStarting` instead
 
-Superseded:
-* [CoreWebView2.FrameNavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framenavigationstarting)
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.NavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.navigationstarting)
+
+* [CoreWebView2NavigationStartingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2navigationstartingeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.NavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigationstarting)
-   * [CoreWebView2NavigationStartingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2navigationstartingeventargs)
-* [CoreWebView2Frame.NavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#navigationstarting)
-   * [CoreWebView2NavigationStartingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2navigationstartingeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.NavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigationstarting)
+   * [CoreWebView2.FrameNavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framenavigationstarting) - superseded; use `CoreWebView2Frame.NavigationStarting` instead
 
-Superseded:
-* [CoreWebView2.FrameNavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framenavigationstarting)
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.NavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#navigationstarting)
+
+* [CoreWebView2NavigationStartingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2navigationstartingeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::NavigationStarting event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationstarting), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationstarting)
-   * [ICoreWebView2NavigationStartingEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2)<!--v2-->
-* [ICoreWebView2Frame2::NavigationStarting event (add](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationstarting), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationstarting)
-   * [ICoreWebView2NavigationStartingEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2)<!--v2-->
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationstarting)
+   * [ICoreWebView2::remove_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationstarting)
+   * [ICoreWebView2::add_FrameNavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationstarting) - superseded; use `ICoreWebView2Frame.add_NavigationStarting` instead
+   * [ICoreWebView2::remove_FrameNavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationstarting) - superseded; use `ICoreWebView2Frame.remove_NavigationStarting` instead
 
-Superseded:
-* [ICoreWebView2::FrameNavigationStarting event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationstarting), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationstarting)
+* `ICoreWebView2Frame2` interface:
+   * [ICoreWebView2Frame2::add_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationstarting)
+   * [ICoreWebView2Frame2::remove_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationstarting)
+
+* [ICoreWebView2NavigationStartingEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2)<!--v2-->
 
 ---
 
@@ -1313,43 +1422,71 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ContentLoading Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.contentloading)
-   * [CoreWebView2ContentLoadingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contentloadingeventargs)
-* [CoreWebView2.DOMContentLoaded Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.domcontentloaded)
-   * [CoreWebView2DOMContentLoadedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2domcontentloadedeventargs)
-* [CoreWebView2.NavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigationcompleted)
-   * [CoreWebView2NavigationCompletedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2navigationcompletedeventargs)
-* [CoreWebView2.FrameNavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framenavigationcompleted)
-* [CoreWebView2Frame.ContentLoading Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.contentloading)
-* [CoreWebView2Frame.DOMContentLoaded Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.domcontentloaded)
-* [CoreWebView2Frame.NavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.navigationcompleted)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ContentLoading Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.contentloading)
+   * [CoreWebView2.DOMContentLoaded Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.domcontentloaded)
+   * [CoreWebView2.FrameNavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framenavigationcompleted) - superseded; use `CoreWebView2Frame.NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
+   * [CoreWebView2.NavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigationcompleted)
+
+* [CoreWebView2ContentLoadingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contentloadingeventargs)
+
+* [CoreWebView2DOMContentLoadedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2domcontentloadedeventargs)
+
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.ContentLoading Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.contentloading)
+   * [CoreWebView2Frame.DOMContentLoaded Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.domcontentloaded)
+   * [CoreWebView2Frame.NavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.navigationcompleted)
+
+* [CoreWebView2NavigationCompletedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2navigationcompletedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ContentLoading Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#contentloading)
-   * [CoreWebView2ContentLoadingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contentloadingeventargs)
-* [CoreWebView2.DOMContentLoaded Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#domcontentloaded)
-   * [CoreWebView2DOMContentLoadedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2domcontentloadedeventargs)
-* [CoreWebView2.NavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigationcompleted)
-   * [CoreWebView2NavigationCompletedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2navigationcompletedeventargs)
-* [CoreWebView2.FrameNavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framenavigationcompleted)
-* [CoreWebView2Frame.ContentLoading Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#contentloading)
-* [CoreWebView2Frame.DOMContentLoaded Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#domcontentloaded)
-* [CoreWebView2Frame.NavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#navigationcompleted)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ContentLoading Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#contentloading)
+   * [CoreWebView2.DOMContentLoaded Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#domcontentloaded)
+   * [CoreWebView2.FrameNavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framenavigationcompleted) - superseded; use `CoreWebView2Frame.NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
+   * [CoreWebView2.NavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigationcompleted)
+
+* [CoreWebView2ContentLoadingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contentloadingeventargs)
+
+* [CoreWebView2DOMContentLoadedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2domcontentloadedeventargs)
+
+* `CoreWebView2Frame` Class:
+   * [CoreWebView2Frame.ContentLoading Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#contentloading)
+   * [CoreWebView2Frame.DOMContentLoaded Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#domcontentloaded)
+   * [CoreWebView2Frame.NavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#navigationcompleted)
+
+* [CoreWebView2NavigationCompletedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2navigationcompletedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::ContentLoading event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_contentloading), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_contentloading)
-   * [ICoreWebView2ContentLoadingEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs)
-* [ICoreWebView2_2::DOMContentLoaded event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_domcontentloaded), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_domcontentloaded)
-   * [ICoreWebView2DOMContentLoadedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2domcontentloadedeventargs)
-* [ICoreWebView2::NavigationCompleted event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationcompleted), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationcompleted)
-   * [ICoreWebView2NavigationCompletedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs)
-   * [ICoreWebView2NavigationCompletedEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs2)
-* [ICoreWebView2::FrameNavigationCompleted event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationcompleted), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationcompleted)
-* [ICoreWebView2Frame2::ContentLoading event (add](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_contentloading), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_contentloading)
-* [ICoreWebView2Frame2::DOMContentLoaded event (add](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_domcontentloaded), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_domcontentloaded)
-* [ICoreWebView2Frame2::NavigationCompleted event (add](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationcompleted), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationcompleted)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_contentloading)
+   * [ICoreWebView2::add_FrameNavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationcompleted) - superseded; use `ICoreWebView2Frame::add_NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
+   * [ICoreWebView2::add_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_navigationcompleted)
+   * [ICoreWebView2::remove_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_contentloading)
+   * [ICoreWebView2::remove_FrameNavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationcompleted) - superseded; use `ICoreWebView2Frame::remove_NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
+   * [ICoreWebView2::remove_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationcompleted)
+
+* `ICoreWebView2_2` interface:
+   * [ICoreWebView2_2::add_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_domcontentloaded)
+   * [ICoreWebView2_2::remove_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_domcontentloaded)
+
+* `ICoreWebView2Frame2` interface:
+   * [ICoreWebView2Frame2::add_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_contentloading)
+   * [ICoreWebView2Frame2::add_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_domcontentloaded)
+   * [ICoreWebView2Frame2::add_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationcompleted)
+   * [ICoreWebView2Frame2::remove_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_contentloading)
+   * [ICoreWebView2Frame2::remove_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_domcontentloaded)
+   * [ICoreWebView2Frame2::remove_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationcompleted)
+
+* [ICoreWebView2ContentLoadingEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs)
+
+* [ICoreWebView2DOMContentLoadedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2domcontentloadedeventargs)
+
+* [ICoreWebView2NavigationCompletedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs)
+
+* [ICoreWebView2NavigationCompletedEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs2)
 
 ---
 
@@ -1364,25 +1501,37 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.WebResourceRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourcerequested)
-   * [CoreWebView2WebResourceRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webresourcerequestedeventargs)
-* [CoreWebView2.WebResourceResponseReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourceresponsereceived)
-   * [CoreWebView2WebResourceResponseReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webresourceresponsereceivedeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.WebResourceRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourcerequested)
+   * [CoreWebView2.WebResourceResponseReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourceresponsereceived)
+
+* [CoreWebView2WebResourceRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webresourcerequestedeventargs)
+
+* [CoreWebView2WebResourceResponseReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webresourceresponsereceivedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.WebResourceRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourcerequested)
-   * [CoreWebView2WebResourceRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webresourcerequestedeventargs)
-* [CoreWebView2.WebResourceResponseReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourceresponsereceived)
-   * [CoreWebView2WebResourceResponseReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webresourceresponsereceivedeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.WebResourceRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourcerequested)
+   * [CoreWebView2.WebResourceResponseReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourceresponsereceived)
+
+* [CoreWebView2WebResourceRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webresourcerequestedeventargs)
+
+* [CoreWebView2WebResourceResponseReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webresourceresponsereceivedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::WebResourceRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
-   * [ICoreWebView2WebResourceRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs)
-* [ICoreWebView2_2::WebResourceResponseReceived event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_webresourceresponsereceived), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_webresourceresponsereceived)
-   * [ICoreWebView2WebResourceResponseReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponsereceivedeventargs)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::add_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested)
+   * [ICoreWebView2::remove_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
 
+* `ICoreWebView2_2` interface:
+   * [ICoreWebView2_2::add_WebResourceResponseReceived event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_webresourceresponsereceived)
+   * [ICoreWebView2_2::remove_WebResourceResponseReceived event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_webresourceresponsereceived)
+
+* [ICoreWebView2WebResourceRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs)
+
+* [ICoreWebView2WebResourceResponseReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponsereceivedeventargs)
 
 ---
 
@@ -1395,17 +1544,20 @@ The `CustomSchemeRegistration` allows registration of custom schemes in WebView2
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2CustomSchemeRegistration Class](/dotnet/api/microsoft.web.webview2.core.corewebview2customschemeregistration)
-* [CoreWebView2EnvironmentOptions Class](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions)
+
+* `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.CustomSchemeRegistrations Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.customschemeregistrations)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2CustomSchemeRegistration Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2customschemeregistration)
-* [CoreWebView2EnvironmentOptions Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions)
+
+* [CoreWebView2EnvironmentOptions Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions)<!-- todo: remove or comment-out this item?  no CustomSchemeRegistrations property: https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions -->
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2CustomSchemeRegistration interface](/microsoft-edge/webview2/reference/win32/icorewebview2customschemeregistration)
+
 * [ICoreWebView2EnvironmentOptions4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4)
    * [ICoreWebView2EnvironmentOptions4::GetCustomSchemeRegistrations method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4#getcustomschemeregistrations)
    * [ICoreWebView2EnvironmentOptions4::SetCustomSchemeRegistrations method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4#setcustomschemeregistrations)
@@ -1424,22 +1576,33 @@ In WebView2, you can use the Client Certificate API to select the client certifi
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
+* `CoreWebView2` Class:
+   * [CoreWebView2.ClientCertificateRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.clientcertificaterequested)
+
 * [CoreWebView2ClientCertificate Class](/dotnet/api/microsoft.web.webview2.core.corewebview2clientcertificate)
-* [CoreWebView2.ClientCertificateRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.clientcertificaterequested)
-   * [CoreWebView2ClientCertificateRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2clientcertificaterequestedeventargs)
+
+* [CoreWebView2ClientCertificateRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2clientcertificaterequestedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
+* `CoreWebView2` Class:
+   * [CoreWebView2.ClientCertificateRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#clientcertificaterequested)
+
 * [CoreWebView2ClientCertificate Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2clientcertificate)
-* [CoreWebView2.ClientCertificateRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#clientcertificaterequested)
-   * [CoreWebView2ClientCertificateRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2clientcertificaterequestedeventargs)
+
+* [CoreWebView2ClientCertificateRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2clientcertificaterequestedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
+* [ICoreWebView2_5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_5)
+   * [ICoreWebView2_5::add_ClientCertificateRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#add_clientcertificaterequested)
+   * [ICoreWebView2_5::remove_ClientCertificateRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#remove_clientcertificaterequested)
+
 * [ICoreWebView2ClientCertificate interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificate)
-   * [ICoreWebView2ClientCertificateCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificatecollection)<!--n/a for c#-->
-* [ICoreWebView2_5::ClientCertificateRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_5#add_clientcertificaterequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_5#remove_clientcertificaterequested)
-   * [ICoreWebView2ClientCertificateRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificaterequestedeventargs)
+
+* [ICoreWebView2ClientCertificateCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificatecollection)<!--n/a for c#-->
+
+* [ICoreWebView2ClientCertificateRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificaterequestedeventargs)
 
 ---
 
@@ -1450,18 +1613,22 @@ In WebView2, you can use the Server Certificate API to trust the server's TLS ce
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ServerCertificateErrorDetected Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.servercertificateerrordetected)
-* [CoreWebView2.ClearServerCertificateErrorActionsAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.clearservercertificateerroractionsasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ServerCertificateErrorDetected Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.servercertificateerrordetected)
+   * [CoreWebView2.ClearServerCertificateErrorActionsAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.clearservercertificateerroractionsasync)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ServerCertificateErrorDetected Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#servercertificateerrordetected)
-* [CoreWebView2.ClearServerCertificateErrorActionsAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#clearservercertificateerroractionsasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.ServerCertificateErrorDetected Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#servercertificateerrordetected)
+   * [CoreWebView2.ClearServerCertificateErrorActionsAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#clearservercertificateerroractionsasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2_14::ServerCertificateErrorDetected event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_14#add_servercertificateerrordetected), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_14#remove_servercertificateerrordetected)
-* [ICoreWebView2_14::ClearServerCertificateErrorActions method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#clearservercertificateerroractions)
+* [ICoreWebView2_14 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_14)
+   * [ICoreWebView2_14::add_ServerCertificateErrorDetected event method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#add_servercertificateerrordetected)
+   * [ICoreWebView2_14::remove_ServerCertificateErrorDetected event method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#remove_servercertificateerrordetected)
+   * [ICoreWebView2_14::ClearServerCertificateErrorActions method](/microsoft-edge/webview2/reference/win32/icorewebview2_14#clearservercertificateerroractions)
 
 ---
 
@@ -1483,26 +1650,41 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
+* `CoreWebView2` Class:
+   * [CoreWebView2.FrameCreated Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framecreated)
+
 * [CoreWebView2Frame Class](/dotnet/api/microsoft.web.webview2.core.corewebview2frame)
+
+* [CoreWebView2FrameCreatedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2framecreatedeventargs)
+
 * [CoreWebView2FrameInfo Class](/dotnet/api/microsoft.web.webview2.core.corewebview2frameinfo)
-* [CoreWebView2.FrameCreated Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framecreated)
-   * [CoreWebView2FrameCreatedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2framecreatedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
+* `CoreWebView2` Class:
+   * [CoreWebView2.FrameCreated Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framecreated)
+
 * [CoreWebView2Frame Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame)
+
+* [CoreWebView2FrameCreatedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2framecreatedeventargs)
+
 * [CoreWebView2FrameInfo Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frameinfo)
-* [CoreWebView2.FrameCreated Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framecreated)
-   * [CoreWebView2FrameCreatedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2framecreatedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
+* `ICoreWebView2_4` interface:
+   * [ICoreWebView2_4::add_FrameCreated event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_framecreated)
+   * [ICoreWebView2_4::remove_FrameCreated event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_framecreated)
+
 * [ICoreWebView2Frame interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame)
+
+* [ICoreWebView2FrameCreatedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2framecreatedeventargs)
+
 * [ICoreWebView2FrameInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfo)
-   * [ICoreWebView2FrameInfoCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfocollection)<!--n/a for c#-->
-   * [ICoreWebView2FrameInfoCollectionIterator interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfocollectioniterator)<!--n/a for c#-->
-* [ICoreWebView2_4::FrameCreated event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_framecreated), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_framecreated)
-   * [ICoreWebView2FrameCreatedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2framecreatedeventargs)
+
+* [ICoreWebView2FrameInfoCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfocollection)<!--C++ only-->
+
+* [ICoreWebView2FrameInfoCollectionIterator interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfocollectioniterator)<!--C++ only-->
 
 ---
 
@@ -1521,30 +1703,51 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2HttpRequestHeaders Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httprequestheaders)
-* [CoreWebView2.BasicAuthenticationRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.basicauthenticationrequested)
-   * [CoreWebView2BasicAuthenticationRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2basicauthenticationrequestedeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.BasicAuthenticationRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.basicauthenticationrequested)
+
+* [CoreWebView2BasicAuthenticationRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2basicauthenticationrequestedeventargs)
+
 * [CoreWebView2BasicAuthenticationResponse Class](/dotnet/api/microsoft.web.webview2.core.corewebview2basicauthenticationresponse)
-   * [CoreWebView2HttpResponseHeaders Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httpresponseheaders)
+
 * [CoreWebView2HttpHeadersCollectionIterator Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httpheaderscollectioniterator)
+
+* [CoreWebView2HttpRequestHeaders Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httprequestheaders)
+
+* [CoreWebView2HttpResponseHeaders Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httpresponseheaders)
+
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2HttpRequestHeaders Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httprequestheaders)
-* [CoreWebView2.BasicAuthenticationRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#basicauthenticationrequested)
-   * [CoreWebView2BasicAuthenticationRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2basicauthenticationrequestedeventargs)
+* `CoreWebView2` Class:
+   * [CoreWebView2.BasicAuthenticationRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#basicauthenticationrequested)
+
+* [CoreWebView2BasicAuthenticationRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2basicauthenticationrequestedeventargs)
+
 * [CoreWebView2BasicAuthenticationResponse Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2basicauthenticationresponse)
-   * [CoreWebView2HttpResponseHeaders Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httpresponseheaders)
+
 * [CoreWebView2HttpHeadersCollectionIterator Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httpheaderscollectioniterator)
+
+* [CoreWebView2HttpRequestHeaders Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httprequestheaders)
+
+* [CoreWebView2HttpResponseHeaders Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httpresponseheaders)
+
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2HttpRequestHeaders interface](/microsoft-edge/webview2/reference/win32/icorewebview2httprequestheaders)
-* [ICoreWebView2_10::BasicAuthenticationRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2_10#add_basicauthenticationrequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2_10#remove_basicauthenticationrequested)
-   * [ICoreWebView2BasicAuthenticationRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2basicauthenticationrequestedeventargs)
+* [ICoreWebView2_10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_10)
+   * [ICoreWebView2_10::add_BasicAuthenticationRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#add_basicauthenticationrequested)
+   * [ICoreWebView2_10::remove_BasicAuthenticationRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#remove_basicauthenticationrequested)
+
+* [ICoreWebView2BasicAuthenticationRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2basicauthenticationrequestedeventargs)
+
 * [ICoreWebView2BasicAuthenticationResponse interface](/microsoft-edge/webview2/reference/win32/icorewebview2basicauthenticationresponse)
-   * [ICoreWebView2HttpResponseHeaders interface](/microsoft-edge/webview2/reference/win32/icorewebview2httpresponseheaders)
+
 * [ICoreWebView2HttpHeadersCollectionIterator interface](/microsoft-edge/webview2/reference/win32/icorewebview2httpheaderscollectioniterator)
+
+* [ICoreWebView2HttpRequestHeaders interface](/microsoft-edge/webview2/reference/win32/icorewebview2httprequestheaders)
+
+* [ICoreWebView2HttpResponseHeaders interface](/microsoft-edge/webview2/reference/win32/icorewebview2httpresponseheaders)
 
 ---
 
@@ -1562,21 +1765,30 @@ Use these APIs to set up the WebView2 rendering system if your host app doesn't 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Controller.CoreWebView2 Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.corewebview2)
-* [CoreWebView2Controller.Close Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.close)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)<!--2 overloads-->
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.CoreWebView2 Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.corewebview2)
+   * [CoreWebView2Controller.Close Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.close)
+
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)<!--2 overloads-->
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Controller.CoreWebView2 Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#corewebview2)
-* [CoreWebView2Controller.Close Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#close)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.CoreWebView2 Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#corewebview2)
+   * [CoreWebView2Controller.Close Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#close)
+
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller::CoreWebView2 property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_corewebview2)<!--no put-->
-* [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
-* [ICoreWebView2Environment::CreateCoreWebView2Controller method](/microsoft-edge/webview2/reference/win32/icorewebview2environment#createcorewebview2controller)
+* `ICoreWebView2Controller` interface:
+   * [ICoreWebView2Controller::get_CoreWebView2 property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_corewebview2)<!--no put-->
+   * [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
+
+* `CoreWebView2Environment` Class:
+   * [ICoreWebView2Environment::CreateCoreWebView2Controller method](/microsoft-edge/webview2/reference/win32/icorewebview2environment#createcorewebview2controller)
 
 ---
 
@@ -1591,18 +1803,24 @@ WebView2 gives your app access to window-specific attributes, such as positionin
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Controller.Bounds Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.bounds)
-* [CoreWebView2Controller.IsVisible Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.isvisible)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.Bounds Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.bounds)
+   * [CoreWebView2Controller.IsVisible Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.isvisible)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Controller.Bounds Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#bounds)
-* [CoreWebView2Controller.IsVisible Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#isvisible)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.Bounds Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#bounds)
+   * [CoreWebView2Controller.IsVisible Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#isvisible)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller::Bounds property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_bounds), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_bounds)
-* [ICoreWebView2Controller::IsVisible property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_isvisible), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_isvisible)
+* `ICoreWebView2Controller` interface:
+   * [ICoreWebView2Controller::get_Bounds property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_bounds)
+   * [ICoreWebView2Controller::put_Bounds property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_bounds)
+
+   * [ICoreWebView2Controller::get_IsVisible property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_isvisible)
+   * [ICoreWebView2Controller::put_IsVisible property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_isvisible)
 
 ---
 
@@ -1614,33 +1832,42 @@ WebView2 `ZoomFactor` is used to scale just the web content of the window.  UI s
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Controller.ZoomFactor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.zoomfactor)
-* [CoreWebView2Controller.ZoomFactorChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.zoomfactorchanged)
-* [CoreWebView2Controller.SetBoundsAndZoomFactor Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.setboundsandzoomfactor)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.ZoomFactor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.zoomfactor)
+   * [CoreWebView2Controller.ZoomFactorChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.zoomfactorchanged)
+   * [CoreWebView2Controller.SetBoundsAndZoomFactor Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.setboundsandzoomfactor)
 
-Browser/gesture/zoom features:<!-- moved from Rendering section - fits best in "gestures", or "zoom" list? -->
-* [CoreWebView2Settings.IsPinchZoomEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.ispinchzoomenabled)
-* [CoreWebView2Settings.IsZoomControlEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.iszoomcontrolenabled)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsPinchZoomEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.ispinchzoomenabled)
+   * [CoreWebView2Settings.IsZoomControlEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.iszoomcontrolenabled)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Controller.ZoomFactor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#zoomfactor)
-* [CoreWebView2Controller.ZoomFactorChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#zoomfactorchanged)
-* [CoreWebView2Controller.SetBoundsAndZoomFactor Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#setboundsandzoomfactor)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.ZoomFactor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#zoomfactor)
+   * [CoreWebView2Controller.ZoomFactorChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#zoomfactorchanged)
+   * [CoreWebView2Controller.SetBoundsAndZoomFactor Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#setboundsandzoomfactor)
 
-Browser/gesture/zoom features:
-* [CoreWebView2Settings.IsPinchZoomEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#ispinchzoomenabled)
-* [CoreWebView2Settings.IsZoomControlEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#iszoomcontrolenabled)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsPinchZoomEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#ispinchzoomenabled)
+   * [CoreWebView2Settings.IsZoomControlEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#iszoomcontrolenabled)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller::ZoomFactor property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_zoomfactor), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_zoomfactor)
-* [ICoreWebView2Controller::ZoomFactorChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_zoomfactorchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_zoomfactorchanged)
-* [ICoreWebView2Controller::SetBoundsAndZoomFactor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#setboundsandzoomfactor)
+* `ICoreWebView2Controller` interface:
+   * [ICoreWebView2Controller::get_ZoomFactor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_zoomfactor)
+   * [ICoreWebView2Controller::put_ZoomFactor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_zoomfactor)
+   * [ICoreWebView2Controller::add_ZoomFactorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_zoomfactorchanged)
+   * [ICoreWebView2Controller::remove_ZoomFactorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_zoomfactorchanged)
+   * [ICoreWebView2Controller::SetBoundsAndZoomFactor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#setboundsandzoomfactor)
 
-Browser/gesture/zoom features:
-* [ICoreWebView2Settings5::IsPinchZoomEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#get_ispinchzoomenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#put_ispinchzoomenabled)
-* [ICoreWebView2Settings::IsZoomControlEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iszoomcontrolenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iszoomcontrolenabled)
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_IsZoomControlEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iszoomcontrolenabled)
+   * [ICoreWebView2Settings::put_IsZoomControlEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iszoomcontrolenabled)
+
+* [ICoreWebView2Settings5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings5)
+   * [ICoreWebView2Settings5::get_IsPinchZoomEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#get_ispinchzoomenabled)
+   * [ICoreWebView2Settings5::put_IsPinchZoomEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#put_ispinchzoomenabled)
 
 ---
 
@@ -1652,24 +1879,31 @@ The RasterizationScale API scales all WebView2 UI including context menus, toolt
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Controller.BoundsMode Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.boundsmode)
-* [CoreWebView2Controller.RasterizationScale Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.rasterizationscale)
-* [CoreWebview2Controller.RasterizationScaleChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.rasterizationscalechanged)
-* [CoreWebview2Controller.ShouldDetectMonitorScaleChanges Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.shoulddetectmonitorscalechanges)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.BoundsMode Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.boundsmode)
+   * [CoreWebView2Controller.RasterizationScale Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.rasterizationscale)
+   * [CoreWebview2Controller.RasterizationScaleChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.rasterizationscalechanged)
+   * [CoreWebview2Controller.ShouldDetectMonitorScaleChanges Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.shoulddetectmonitorscalechanges)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Controller.BoundsMode Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#boundsmode)
-* [CoreWebView2Controller.RasterizationScale Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#rasterizationscale)
-* [CoreWebview2Controller.RasterizationScaleChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#rasterizationscalechanged)
-* [CoreWebview2Controller.ShouldDetectMonitorScaleChanges Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#shoulddetectmonitorscalechanges)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.BoundsMode Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#boundsmode)
+   * [CoreWebView2Controller.RasterizationScale Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#rasterizationscale)
+   * [CoreWebview2Controller.RasterizationScaleChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#rasterizationscalechanged)
+   * [CoreWebview2Controller.ShouldDetectMonitorScaleChanges Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#shoulddetectmonitorscalechanges)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller3::BoundsMode property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_boundsmode), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_boundsmode)
-* [ICoreWebView2Controller3::RasterizationScale property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_rasterizationscale), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_rasterizationscale)
-* [ICoreWebView2Controller3::RasterizationScaleChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#add_rasterizationscalechanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#remove_rasterizationscalechanged)
-* [ICoreWebView2Controller3::ShouldDetectMonitorScaleChanges property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_shoulddetectmonitorscalechanges), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_shoulddetectmonitorscalechanges)
+* [ICoreWebView2Controller3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2controller3)
+   * [ICoreWebView2Controller3::add_RasterizationScaleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#add_rasterizationscalechanged)
+   * [ICoreWebView2Controller3::get_BoundsMode property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_boundsmode)
+   * [ICoreWebView2Controller3::get_RasterizationScale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_rasterizationscale)
+   * [ICoreWebView2Controller3::get_ShouldDetectMonitorScaleChanges property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#get_shoulddetectmonitorscalechanges)
+   * [ICoreWebView2Controller3::put_BoundsMode property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_boundsmode)
+   * [ICoreWebView2Controller3::put_RasterizationScale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_rasterizationscale)
+   * [ICoreWebView2Controller3::put_ShouldDetectMonitorScaleChanges property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#put_shoulddetectmonitorscalechanges)
+   * [ICoreWebView2Controller3::remove_RasterizationScaleChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller3#remove_rasterizationscalechanged)
 
 ---
 
@@ -1681,27 +1915,36 @@ The WebView2 control raises events to let the app know when the control gains fo
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebview2Controller.MoveFocus Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.movefocus)
-* [CoreWebview2Controller.MoveFocusRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.movefocusrequested)
-   * [CoreWebView2MoveFocusRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2movefocusrequestedeventargs)
-* [CoreWebview2Controller.GotFocus Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.gotfocus)
-* [CoreWebview2Controller.LostFocus Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.lostfocus)
+* `CoreWebview2Controller` Class:
+   * [CoreWebview2Controller.GotFocus Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.gotfocus)
+   * [CoreWebview2Controller.LostFocus Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.lostfocus)
+   * [CoreWebview2Controller.MoveFocus Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.movefocus)
+   * [CoreWebview2Controller.MoveFocusRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.movefocusrequested)
+
+* [CoreWebView2MoveFocusRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2movefocusrequestedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebview2Controller.MoveFocus Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#movefocus)
-* [CoreWebview2Controller.MoveFocusRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#movefocusrequested)
-   * [CoreWebView2MoveFocusRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2movefocusrequestedeventargs)
-* [CoreWebview2Controller.GotFocus Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#gotfocus)
-* [CoreWebview2Controller.LostFocus Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#lostfocus)
+* `CoreWebview2Controller` Class:
+   * [CoreWebview2Controller.GotFocus Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#gotfocus)
+   * [CoreWebview2Controller.LostFocus Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#lostfocus)
+   * [CoreWebview2Controller.MoveFocus Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#movefocus)
+   * [CoreWebview2Controller.MoveFocusRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#movefocusrequested)
+
+* [CoreWebView2MoveFocusRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2movefocusrequestedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebview2Controller::MoveFocus method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#movefocus)
-* [ICoreWebview2Controller::MoveFocusRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_movefocusrequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_movefocusrequested)
-   * [ICoreWebView2MoveFocusRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs)
-* [ICoreWebview2Controller::GotFocus event (add](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_gotfocus), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_gotfocus)
-* [ICoreWebview2Controller::LostFocus event (add](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_lostfocus), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_lostfocus)
+* `ICoreWebview2Controller` interface:
+   * [ICoreWebview2Controller::add_GotFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_gotfocus)
+   * [ICoreWebview2Controller::add_LostFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_lostfocus)
+   * [ICoreWebview2Controller::add_MoveFocusRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_movefocusrequested)
+   * [ICoreWebview2Controller::MoveFocus method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#movefocus)
+   * [ICoreWebview2Controller::remove_GotFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_gotfocus)
+   * [ICoreWebview2Controller::remove_LostFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_lostfocus)
+   * [ICoreWebview2Controller::remove_MoveFocusRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_movefocusrequested)
+
+* [ICoreWebView2MoveFocusRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs)
 
 ---
 
@@ -1713,18 +1956,22 @@ WebView2 can be reparented to a different parent window handle (`HWND`).  WebVie
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebview2Controller.NotifyParentWindowPositionChanged Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.notifyparentwindowpositionchanged)
+* `CoreWebview2Controller` Class:
+   * [CoreWebview2Controller.NotifyParentWindowPositionChanged Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.notifyparentwindowpositionchanged)
    * [CoreWebview2Controller.ParentWindow Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.parentwindow)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebview2Controller.NotifyParentWindowPositionChanged Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#notifyparentwindowpositionchanged)
+* `CoreWebview2Controller` Class:
+   * [CoreWebview2Controller.NotifyParentWindowPositionChanged Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#notifyparentwindowpositionchanged)
    * [CoreWebview2Controller.ParentWindow Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#parentwindow)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebview2Controller::NotifyParentWindowPositionChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#notifyparentwindowpositionchanged)
-   * [ICoreWebview2Controller::ParentWindow property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_parentwindow), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_parentwindow)
+* `ICoreWebview2Controller` interface:
+   * [ICoreWebview2Controller::get_ParentWindow property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_parentwindow)
+   * [ICoreWebview2Controller::NotifyParentWindowPositionChanged method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#notifyparentwindowpositionchanged)
+   * [ICoreWebview2Controller::put_ParentWindow property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_parentwindow)
 
 ---
 
@@ -1736,21 +1983,35 @@ When WebView2 has focus, it directly receives input from the user. An app may wa
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Settings.AreBrowserAcceleratorKeysEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.arebrowseracceleratorkeysenabled)
-* [CoreWebView2Controller.AcceleratorKeyPressed Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.acceleratorkeypressed)
-   * [CoreWebView2AcceleratorKeyPressedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2acceleratorkeypressedeventargs)
+* [CoreWebView2AcceleratorKeyPressedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2acceleratorkeypressedeventargs)
+
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.AcceleratorKeyPressed Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.acceleratorkeypressed)
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreBrowserAcceleratorKeysEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.arebrowseracceleratorkeysenabled)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Settings.AreBrowserAcceleratorKeysEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arebrowseracceleratorkeysenabled)
-* [CoreWebView2Controller.AcceleratorKeyPressed Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#acceleratorkeypressed)
-   * [CoreWebView2AcceleratorKeyPressedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2acceleratorkeypressedeventargs)
+* [CoreWebView2AcceleratorKeyPressedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2acceleratorkeypressedeventargs)
+
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.AcceleratorKeyPressed Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#acceleratorkeypressed)
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreBrowserAcceleratorKeysEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arebrowseracceleratorkeysenabled)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Settings3::AreBrowserAcceleratorKeysEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#get_arebrowseracceleratorkeysenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#put_arebrowseracceleratorkeysenabled)
-* [ICoreWebView2Controller::AcceleratorKeyPressed event (add](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_acceleratorkeypressed), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_acceleratorkeypressed)
-   * [ICoreWebView2AcceleratorKeyPressedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs)
+* [ICoreWebView2AcceleratorKeyPressedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs)
+
+* `ICoreWebView2Controller` interface:
+   * [ICoreWebView2Controller::add_AcceleratorKeyPressed event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_acceleratorkeypressed)
+   * [ICoreWebView2Controller::remove_AcceleratorKeyPressed event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_acceleratorkeypressed)
+
+* [ICoreWebView2Settings3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings3)
+   * [ICoreWebView2Settings3::get_AreBrowserAcceleratorKeysEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#get_arebrowseracceleratorkeysenabled)
+   * [ICoreWebView2Settings3::put_AreBrowserAcceleratorKeysEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#put_arebrowseracceleratorkeysenabled)
 
 ---
 
@@ -1762,15 +2023,19 @@ WebView2 can specify a default background color.  The color can be any opaque co
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Controller.DefaultBackgroundColor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.defaultbackgroundcolor)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.DefaultBackgroundColor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.defaultbackgroundcolor)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Controller.DefaultBackgroundColor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#defaultbackgroundcolor)
+* `CoreWebView2Controller` Class:
+   * [CoreWebView2Controller.DefaultBackgroundColor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#defaultbackgroundcolor)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Controller2::DefaultBackgroundColor property (get](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#get_defaultbackgroundcolor), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#put_defaultbackgroundcolor)
+* [ICoreWebView2Controller2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2controller2)
+   * [ICoreWebView2Controller2::get_DefaultBackgroundColor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#get_defaultbackgroundcolor)
+   * [ICoreWebView2Controller2::put_DefaultBackgroundColor property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#put_defaultbackgroundcolor)
 
 ---
 
@@ -1783,17 +2048,23 @@ For composition-based WebView2 rendering, use `CoreWebView2Environment` to creat
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2CompositionController Class](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller)
-* [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2compositioncontrollerasync)<!--2 overloads-->
+
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2compositioncontrollerasync)<!--2 overloads-->
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2CompositionController Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller)
-* [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync)
+
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2CompositionController interface](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller)
-* [ICoreWebView2Environment3::CreateCoreWebview2CompositionController method](/microsoft-edge/webview2/reference/win32/icorewebview2environment3#createcorewebview2compositioncontroller)
+
+* `ICoreWebView2Environment3` interface:
+   * [ICoreWebView2Environment3::CreateCoreWebview2CompositionController method](/microsoft-edge/webview2/reference/win32/icorewebview2environment3#createcorewebview2compositioncontroller)
 
 ---
 
@@ -1805,15 +2076,19 @@ WebView2 can connect its composition tree to an [IDCompositionVisual](/windows/w
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2CompositionController.RootVisualTarget Property](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.rootvisualtarget)
+* `CoreWebView2CompositionController` Class:
+   * [CoreWebView2CompositionController.RootVisualTarget Property](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.rootvisualtarget)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2CompositionController.RootVisualTarget Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#rootvisualtarget)
+* `CoreWebView2CompositionController` Class:
+   * [CoreWebView2CompositionController.RootVisualTarget Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#rootvisualtarget)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2CompositionController::RootVisualTarget property (get](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_rootvisualtarget), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#put_rootvisualtarget)
+* `ICoreWebView2CompositionController` interface:
+   * [ICoreWebView2CompositionController::get_RootVisualTarget property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_rootvisualtarget)
+   * [ICoreWebView2CompositionController::put_RootVisualTarget property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#put_rootvisualtarget)
 
 ---
 
@@ -1826,26 +2101,30 @@ Spatial input (mouse, touch, pen) is received by the application and must be sen
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* `CoreWebView2CompositionController` Class
+* `CoreWebView2CompositionController` Class:
    * [CoreWebView2CompositionController.Cursor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.cursor)
    * [CoreWebView2CompositionController.CursorChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.cursorchanged)
    * [CoreWebView2CompositionController.SystemCursorId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.systemcursorid)
    * [CoreWebView2CompositionController.SendMouseInput Method](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.sendmouseinput)
    * [CoreWebView2CompositionController.SendPointerInput Method](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.sendpointerinput)
    
-* [CoreWebView2Environment.CreateCoreWebView2PointerInfo Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2pointerinfo)
-   * [CoreWebView2PointerInfo Class](/dotnet/api/microsoft.web.webview2.core.corewebview2pointerinfo)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2PointerInfo Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2pointerinfo)
+
+* [CoreWebView2PointerInfo Class](/dotnet/api/microsoft.web.webview2.core.corewebview2pointerinfo)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2CompositionController` Class
+* `CoreWebView2CompositionController` Class:
    * [CoreWebView2CompositionController.Cursor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#cursor)
    * [CoreWebView2CompositionController.CursorChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#cursorchanged)
    * [CoreWebView2CompositionController.SendMouseInput Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#sendmouseinput)
    * [CoreWebView2CompositionController.SendPointerInput Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#sendpointerinput)
 
-* [CoreWebView2Environment.CreateCoreWebView2PointerInfo Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2pointerinfo)
-   * [CoreWebView2PointerInfo Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2pointerinfo)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2PointerInfo Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2pointerinfo)
+
+* [CoreWebView2PointerInfo Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2pointerinfo)
 
 <!--
 .NET has CompositionController.SystemCursorId member:
@@ -1856,15 +2135,18 @@ https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_we
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `CoreWebView2CompositionController` interface
-   * [ICoreWebView2CompositionController::Cursor property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_cursor)<!--no put-->
-   * [ICoreWebView2CompositionController::CursorChanged event (add](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#add_cursorchanged), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#remove_cursorchanged)
-   * [ICoreWebView2CompositionController::SystemCursorId property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_systemcursorid)<!--no put-->
+* `CoreWebView2CompositionController` interface:
+   * [ICoreWebView2CompositionController::get_Cursor property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_cursor)<!--no put-->
+   * [ICoreWebView2CompositionController::add_CursorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#add_cursorchanged)
+   * [ICoreWebView2CompositionController::remove_CursorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#remove_cursorchanged)
+   * [ICoreWebView2CompositionController::get_SystemCursorId property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_systemcursorid)<!--no put-->
    * [ICoreWebView2CompositionController::SendMouseInput method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#sendmouseinput)
    * [ICoreWebView2CompositionController::SendPointerInput method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#sendpointerinput)
     
-* [ICoreWebView2Environment3::CreateCoreWebView2PointerInfo method](/microsoft-edge/webview2/reference/win32/icorewebview2environment3#createcorewebview2pointerinfo)
-   * [ICoreWebView2PointerInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2pointerinfo)
+* `ICoreWebView2Environment3` interface:
+   * [ICoreWebView2Environment3::CreateCoreWebView2PointerInfo method](/microsoft-edge/webview2/reference/win32/icorewebview2environment3#createcorewebview2pointerinfo)
+
+* [ICoreWebView2PointerInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2pointerinfo)
 
 ---
 
@@ -1878,22 +2160,27 @@ Use the following APIs to forward `IDropTarget` events from the system to the We
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2CompositionController.DragLeave Method](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.dragleave)
+* `CoreWebView2CompositionController` Class:
+   * [CoreWebView2CompositionController.DragLeave Method](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.dragleave)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2CompositionController.DragLeave Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#dragleave)
-* [ICoreWebView2CompositionControllerInterop2.DragEnter Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragenter)
-* [ICoreWebView2CompositionControllerInterop2.DragLeave Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragleave)
-* [ICoreWebView2CompositionControllerInterop2.DragOver Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragover)
-* [ICoreWebView2CompositionControllerInterop2.Drop Method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#drop)
+* `CoreWebView2CompositionController` Class:
+   * [CoreWebView2CompositionController.DragLeave Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#dragleave)
+
+* [ICoreWebView2CompositionControllerInterop2 interface](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2)
+   * [ICoreWebView2CompositionControllerInterop2.DragEnter method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragenter)
+   * [ICoreWebView2CompositionControllerInterop2.DragLeave method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragleave)
+   * [ICoreWebView2CompositionControllerInterop2.DragOver method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragover)
+   * [ICoreWebView2CompositionControllerInterop2.Drop method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#drop)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2CompositionController3::DragEnter method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragenter)
-* [ICoreWebView2CompositionController3::DragLeave method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragleave)
-* [ICoreWebView2CompositionController3::DragOver method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragover)
-* [ICoreWebView2CompositionController3::Drop method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#drop)
+* [ICoreWebView2CompositionController3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3)
+   * [ICoreWebView2CompositionController3::DragEnter method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragenter)
+   * [ICoreWebView2CompositionController3::DragLeave method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragleave)
+   * [ICoreWebView2CompositionController3::DragOver method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#dragover)
+   * [ICoreWebView2CompositionController3::Drop method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3#drop)
 
 ---
 
@@ -1912,8 +2199,11 @@ Not applicable.
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2CompositionController2::AutomationProvider property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller2#get_automationprovider)<!--no put-->
-* [ICoreWebView2Environment4::GetAutomationProviderForWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2environment4#getautomationproviderforwindow)<!--not in c#-->
+* `ICoreWebView2CompositionController2` interface:
+   * [ICoreWebView2CompositionController2::get_AutomationProvider property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller2#get_automationprovider)<!--no put-->
+
+* [ICoreWebView2Environment4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment4)
+   * [ICoreWebView2Environment4::GetAutomationProviderForWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2environment4#getautomationproviderforwindow)<!--C++ only-->
 
 ---
 
@@ -1927,33 +2217,51 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2Environment.UserDataFolder Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.userdatafolder)
-* [CoreWebView2EnvironmentOptions.ExclusiveUserDataFolderAccess Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.exclusiveuserdatafolderaccess)
-* [CoreWebView2Profile.ClearBrowsingDataAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.clearbrowsingdataasync)
-* [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2compositioncontrollerasync)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controlleroptions)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerWithOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2compositioncontrollerasync)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controlleroptions)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerWithOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)
+   * [CoreWebView2Environment.UserDataFolder Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.userdatafolder)
+
+* `CoreWebView2EnvironmentOptions` Class:
+   * [CoreWebView2EnvironmentOptions.ExclusiveUserDataFolderAccess Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.exclusiveuserdatafolderaccess)
+
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.ClearBrowsingDataAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.clearbrowsingdataasync)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2Environment.UserDataFolder Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#userdatafolder)
-* [CoreWebView2EnvironmentOptions.ExclusiveUserDataFolderAccess Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#exclusiveuserdatafolderaccess)
-* [CoreWebView2Profile.ClearBrowsingDataAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#clearbrowsingdataasync)
-* [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerAsync(options) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync)<!-- c#: might ~=CreateCoreWebView2CompositionControllerAsync -->
-* [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync-1)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controlleroptions)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync(options) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync-1)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controlleroptions)
+   * [CoreWebView2Environment.UserDataFolder Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#userdatafolder)
+
+* `CoreWebView2EnvironmentOptions` Class:
+   * [CoreWebView2EnvironmentOptions.ExclusiveUserDataFolderAccess Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#exclusiveuserdatafolderaccess)
+
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.ClearBrowsingDataAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#clearbrowsingdataasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Environment7::UserDataFolder property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2environment7#get_userdatafolder)<!--no put-->
-* [ICoreWebView2EnvironmentOptions2::ExclusiveUserDataFolderAccess property (get](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#get_exclusiveuserdatafolderaccess), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#put_exclusiveuserdatafolderaccess)
-* [ICoreWebView2Profile2::ClearBrowsingData method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdata)
-* [ICoreWebView2Profile2::ClearBrowsingDataAll method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdataall)
-* [ICoreWebView2Profile2::ClearBrowsingDataInTimeRange method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdataintimerange)
-* [ICoreWebView2Environment10::CreateCoreWebView2CompositionControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2compositioncontrollerwithoptions)<!-- c#: might ~=CreateCoreWebView2CompositionControllerAsync -->
-* [ICoreWebView2Environment10::CreateCoreWebView2ControllerOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controlleroptions)
-* [ICoreWebView2Environment10::CreateCoreWebView2ControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controllerwithoptions)
+* [ICoreWebView2Environment7 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment7)
+   * [ICoreWebView2Environment7::get_UserDataFolder property method](/microsoft-edge/webview2/reference/win32/icorewebview2environment7#get_userdatafolder)<!--no put-->
+
+* [ICoreWebView2Environment10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment10)
+   * [ICoreWebView2Environment10::CreateCoreWebView2CompositionControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2compositioncontrollerwithoptions)<!-- c#: might ~=CreateCoreWebView2CompositionControllerAsync -->
+   * [ICoreWebView2Environment10::CreateCoreWebView2ControllerOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controlleroptions)
+   * [ICoreWebView2Environment10::CreateCoreWebView2ControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controllerwithoptions)
+
+* [ICoreWebView2EnvironmentOptions2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2)
+   * [ICoreWebView2EnvironmentOptions2::get_ExclusiveUserDataFolderAccess property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#get_exclusiveuserdatafolderaccess)
+   * [ICoreWebView2EnvironmentOptions2::put_ExclusiveUserDataFolderAccess property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#put_exclusiveuserdatafolderaccess)
+
+* [ICoreWebView2Profile2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile2)
+   * [ICoreWebView2Profile2::ClearBrowsingData method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdata)
+   * [ICoreWebView2Profile2::ClearBrowsingDataAll method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdataall)
+   * [ICoreWebView2Profile2::ClearBrowsingDataInTimeRange method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdataintimerange)
 
 ---
 
@@ -1969,55 +2277,64 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
+<!-- resume -->
 Create an options object that defines a profile:
-* [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controlleroptions)
-   * [CoreWebView2ControllerOptions Class](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controlleroptions)
+* [CoreWebView2ControllerOptions Class](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions)
 
 <!-- Ref topic breakout: one webpage per overload; covers all overloads of the method, no need for per-overload links -->
 Create a WebView2 control that uses the profile:
-* [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2compositioncontrollerasync)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2compositioncontrollerasync)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)
 
 Access and manipulate the profile:
-* [CoreWebView2.Profile Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.profile#microsoft-web-webview2-core-corewebview2-profile)
+* `CoreWebView2` Class:
+   * [CoreWebView2.Profile Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.profile#microsoft-web-webview2-core-corewebview2-profile)
 * [CoreWebView2Profile Class](/dotnet/api/microsoft.web.webview2.core.corewebview2profile)
 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 Create an options object that defines a profile:
-* [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controlleroptions)
-   * [CoreWebView2ControllerOptions Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controlleroptions)
+* [CoreWebView2ControllerOptions Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions)
 
 <!-- Ref topic breakout: one webpage per type; very long webpage covers all methods of the type including overloads.  2nd overload's url adds -1 at end -->
 <!-- preserve sequence per Ref webpage.  for clarity + brevity, list param names, lowercased -->
 Create a WebView2 control that uses the profile:
-* [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync(parentWindow) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync)
-* [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync(parentWindow, options) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync-1)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerAsync(parentWindow, options) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync)
-* [CoreWebView2Environment.CreateCoreWebView2ControllerAsync(parentWindow) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync-1)
+* `CoreWebView2Environment` Class:
+   * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync(parentWindow) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync)
+   * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync(parentWindow, options) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync-1)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync(parentWindow, options) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync)
+   * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync(parentWindow) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync-1)
 
 Access and manipulate the profile:
-* [CoreWebView2.Profile Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#profile)
+* `CoreWebView2` Class:
+   * [CoreWebView2.Profile Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#profile)
 * [CoreWebView2Profile Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile)
 
 
 ##### [Win32/C++](#tab/win32cpp)
 
 Create an options object that defines a profile:
-* [ICoreWebView2Environment10::CreateCoreWebView2ControllerOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controlleroptions)
-   * [ICoreWebView2ControllerOptions interface](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions)
+* `ICoreWebView2Environment10` interface:
+   * [ICoreWebView2Environment10::CreateCoreWebView2ControllerOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controlleroptions)
+* [ICoreWebView2ControllerOptions interface](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions)
 
 <!-- Ref topic breakout: small dedicated iface.  link to iface to bring up overview, and link to methods to show method names -->
 Create a WebView2 control that uses the profile:
-* **[ICoreWebView2Environment10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment10)**
+* [ICoreWebView2Environment10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment10)
    * [ICoreWebView2Environment10::CreateCoreWebView2ControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controllerwithoptions)
    * [ICoreWebView2Environment10::CreateCoreWebView2CompositionControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2compositioncontrollerwithoptions)
 
 Access and manipulate the profile:
-* [ICoreWebView2_13::Profile property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_13#get_profile)<!--no put-->
+* [ICoreWebView2_13 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_13)
+   * [ICoreWebView2_13::get_Profile property method](/microsoft-edge/webview2/reference/win32/icorewebview2_13#get_profile)<!--no put-->
 * [ICoreWebView2Profile interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile)
-   * [ICoreWebView2Profile2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile2) - Methods to clear browsing data.<!--keep text-->
+* [ICoreWebView2Profile2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile2) - Methods to clear browsing data.<!--keep text-->
 
 ---
 
@@ -2029,27 +2346,35 @@ Analyze and debug performance, handle performance-related events, and manage mem
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.MemoryUsageTargetLevel Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.memoryusagetargetlevel)
-* [CoreWebView2.TrySuspendAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.trysuspendasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.MemoryUsageTargetLevel Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.memoryusagetargetlevel)
+   * [CoreWebView2.TrySuspendAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.trysuspendasync)
    * [CoreWebView2.IsSuspended Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.issuspended)
    * [CoreWebView2.Resume Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.resume)
-* [CoreWebView2.OpenTaskManagerWindow Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow) 
+   * [CoreWebView2.OpenTaskManagerWindow Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.opentaskmanagerwindow) 
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.MemoryUsageTargetLevel Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#memoryusagetargetlevel)
-* [CoreWebView2.TrySuspendAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#trysuspendasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.MemoryUsageTargetLevel Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#memoryusagetargetlevel)
+   * [CoreWebView2.TrySuspendAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#trysuspendasync)
    * [CoreWebView2.IsSuspended Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#issuspended)
    * [CoreWebView2.Resume Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#resume)
-* [CoreWebView2.OpenTaskManagerWindow Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#opentaskmanagerwindow)
+   * [CoreWebView2.OpenTaskManagerWindow Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#opentaskmanagerwindow)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2Experimental5::MemoryUsageTargetLevel property (get](/microsoft-edge/webview2/reference/win32/icorewebview2experimental5#get_memoryusagetargetlevel), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2experimental5#put_memoryusagetargetlevel)
-* [ICoreWebView2_3::TrySuspend method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#trysuspend)
-   * [ICoreWebView2_3::IsSuspended property (get)](/microsoft-edge/webview2/reference/win32/icorewebview2_3#get_issuspended)<!--no put-->
+* `ICoreWebView2Experimental5` interface:<!--todo: delete "experimental" links?-->
+   * [ICoreWebView2Experimental5::get_MemoryUsageTargetLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2experimental5#get_memoryusagetargetlevel)
+   * [ICoreWebView2Experimental5::put_MemoryUsageTargetLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2experimental5#put_memoryusagetargetlevel)
+
+* `ICoreWebView2_3` interface:
+   * [ICoreWebView2_3::TrySuspend method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#trysuspend)
+   * [ICoreWebView2_3::get_IsSuspended property method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#get_issuspended)<!--no put-->
    * [ICoreWebView2_3::Resume method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#resume)
-* [ICoreWebView2_6::OpenTaskManagerWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2_6#opentaskmanagerwindow)
+
+* `ICoreWebView2_6` interface:
+   * [ICoreWebView2_6::OpenTaskManagerWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2_6#opentaskmanagerwindow)
 
 ---
 
@@ -2067,47 +2392,61 @@ See also:
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 Open:
-* [CoreWebView2Settings.AreDevToolsEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.aredevtoolsenabled)
-* [CoreWebView2.OpenDevToolsWindow Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.opendevtoolswindow)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreDevToolsEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.aredevtoolsenabled)
+* `CoreWebView2` Class:
+   * [CoreWebView2.OpenDevToolsWindow Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.opendevtoolswindow)
 
 Call:
-* [CoreWebView2.CallDevToolsProtocolMethodAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.calldevtoolsprotocolmethodasync)
-* [CoreWebView2.CallDevToolsProtocolMethodForSessionAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.calldevtoolsprotocolmethodforsessionasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.CallDevToolsProtocolMethodAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.calldevtoolsprotocolmethodasync)
+   * [CoreWebView2.CallDevToolsProtocolMethodForSessionAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.calldevtoolsprotocolmethodforsessionasync)
 
 Receiver:
-* [CoreWebView2.GetDevToolsProtocolEventReceiver Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.getdevtoolsprotocoleventreceiver)
-   * [CoreWebView2DevToolsProtocolEventReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceivedeventargs)
-   * [CoreWebView2DevToolsProtocolEventReceiver Class](/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceiver)
+* `CoreWebView2` Class:
+   * [CoreWebView2.GetDevToolsProtocolEventReceiver Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.getdevtoolsprotocoleventreceiver)
+* [CoreWebView2DevToolsProtocolEventReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceivedeventargs)
+* [CoreWebView2DevToolsProtocolEventReceiver Class](/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceiver)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 Open:
-* [CoreWebView2Settings.AreDevToolsEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#aredevtoolsenabled)
-* [CoreWebView2.OpenDevToolsWindow Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#opendevtoolswindow)
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.AreDevToolsEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#aredevtoolsenabled)
+* `CoreWebView2` Class:
+   * [CoreWebView2.OpenDevToolsWindow Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#opendevtoolswindow)
 
 Call:
-* [CoreWebView2.CallDevToolsProtocolMethodAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#calldevtoolsprotocolmethodasync)
-* [CoreWebView2.CallDevToolsProtocolMethodForSessionAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#calldevtoolsprotocolmethodforsessionasync)
+* `CoreWebView2` Class:
+   * [CoreWebView2.CallDevToolsProtocolMethodAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#calldevtoolsprotocolmethodasync)
+   * [CoreWebView2.CallDevToolsProtocolMethodForSessionAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#calldevtoolsprotocolmethodforsessionasync)
 
 Receiver:
-* [CoreWebView2.GetDevToolsProtocolEventReceiver Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#getdevtoolsprotocoleventreceiver)
-   * [CoreWebView2DevToolsProtocolEventReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2devtoolsprotocoleventreceivedeventargs)
-   * [CoreWebView2DevToolsProtocolEventReceiver Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2devtoolsprotocoleventreceiver)
+* `CoreWebView2` Class:
+   * [CoreWebView2.GetDevToolsProtocolEventReceiver Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#getdevtoolsprotocoleventreceiver)
+* [CoreWebView2DevToolsProtocolEventReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2devtoolsprotocoleventreceivedeventargs)
+* [CoreWebView2DevToolsProtocolEventReceiver Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2devtoolsprotocoleventreceiver)
 
 ##### [Win32/C++](#tab/win32cpp)
 
 Open:
-* [ICoreWebView2Settings::AreDevToolsEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredevtoolsenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredevtoolsenabled)
-* [ICoreWebView2::OpenDevToolsWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2#opendevtoolswindow)
+* `ICoreWebView2Settings` interface:
+   * [ICoreWebView2Settings::get_AreDevToolsEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredevtoolsenabled)
+   * [ICoreWebView2Settings::put_AreDevToolsEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredevtoolsenabled)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::OpenDevToolsWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2#opendevtoolswindow)
 
 Call:
-* [ICoreWebView2::CallDevToolsProtocolMethod method](/microsoft-edge/webview2/reference/win32/icorewebview2#calldevtoolsprotocolmethod)
-* [ICoreWebView2_11::CallDevToolsProtocolMethodForSession method](/microsoft-edge/webview2/reference/win32/icorewebview2_11#calldevtoolspotocolmethodforsession)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::CallDevToolsProtocolMethod method](/microsoft-edge/webview2/reference/win32/icorewebview2#calldevtoolsprotocolmethod)
+* `ICoreWebView2_11` interface:
+   * [ICoreWebView2_11::CallDevToolsProtocolMethodForSession method](/microsoft-edge/webview2/reference/win32/icorewebview2_11#calldevtoolspotocolmethodforsession)
 
 Receiver:
-* [ICoreWebView2::GetDevToolsProtocolEventReceiver method](/microsoft-edge/webview2/reference/win32/icorewebview2#getdevtoolsprotocoleventreceiver)
-   * [ICoreWebView2DevToolsProtocolEventReceiver interface](/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceiver)
-   * [ICoreWebView2DevToolsProtocolEventReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventargs)
+* `ICoreWebView2` interface:
+   * [ICoreWebView2::GetDevToolsProtocolEventReceiver method](/microsoft-edge/webview2/reference/win32/icorewebview2#getdevtoolsprotocoleventreceiver)
+* [ICoreWebView2DevToolsProtocolEventReceiver interface](/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceiver)
+* [ICoreWebView2DevToolsProtocolEventReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2devtoolsprotocoleventreceivedeventargs)
 
 ---
 

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -31,7 +31,7 @@ When hosting the WebView2 control, your app has access to the following features
 
 <!-- maintenance notes: add table rows for any new h2 sections -->
 
-This page only lists APIs that are in Release SDKs; it doesn't list Experimental APIs, or Stable APIs which are not yet available in Release SDKs.  For a comprehensive list of APIs including Experimental APIs, see [Release Notes for the WebView2 SDK](../release-notes.md).
+This page only lists APIs that are in Release SDKs; it doesn't list Experimental APIs, or Stable APIs that are not yet available in Release SDKs.  For a comprehensive list of APIs including Experimental APIs, see [Release Notes for the WebView2 SDK](../release-notes.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/19/2023
+ms.date: 04/25/2023
 ---
 # Overview of WebView2 features and APIs
 

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -31,7 +31,7 @@ When hosting the WebView2 control, your app has access to the following features
 
 <!-- maintenance notes: add table rows for any new h2 sections -->
 
-Prerelease APIs are not listed in this page.  For prerelease APIs, see [Release Notes for the WebView2 SDK](../release-notes.md).
+This page only lists Release APIs; it doesn't list Experimental APIs or Prerelease-stable APIs (that is, APIs which reached Stable status in a Prerelease SDK, but haven't yet been included in a Release SDK).  For Experimental APIs and Prerelease-stable APIs, see [Release Notes for the WebView2 SDK](../release-notes.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -31,6 +31,8 @@ When hosting the WebView2 control, your app has access to the following features
 
 <!-- maintenance notes: add table rows for any new h2 sections -->
 
+Prerelease APIs are not listed in this page.  For prerelease APIs, see [Release Notes for the WebView2 SDK](../release-notes.md).
+
 
 <!-- ====================================================================== -->
 ## Main classes: Environment, Controller, and Core
@@ -548,43 +550,32 @@ See also:
 
 * `CoreWebView2` Class:
    * [CoreWebView2.PermissionRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.permissionrequested)
-
 * `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.PermissionRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.permissionrequested)
-
 * [CoreWebView2PermissionKind Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionkind)
-
 * `CoreWebView2PermissionRequestedEventArgs` Class:
    * [CoreWebView2PermissionRequestedEventArgs.SavesInProfile Property](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionrequestedeventargs.savesinprofile)   
-
 * [CoreWebView2PermissionSetting Class](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionsetting)
    * [CoreWebView2PermissionSetting.PermissionKind Property](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionsetting.permissionkind)
    * [CoreWebView2PermissionSetting.PermissionOrigin Property](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionsetting.permissionorigin)
    * [CoreWebView2PermissionSetting.PermissionState Property](/dotnet/api/microsoft.web.webview2.core.corewebview2permissionsetting.permissionstate)
-
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.GetNonDefaultPermissionSettingsAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.getnondefaultpermissionsettingsasync)
    * [CoreWebView2Profile.SetPermissionStateAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.setpermissionstateasync)
-
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * `CoreWebView2` Class:
    * [CoreWebView2.PermissionRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#permissionrequested)
-
 * `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.PermissionRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#permissionrequested)
-
 * [CoreWebView2PermissionKind Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionkind)
-
 * `CoreWebView2PermissionRequestedEventArgs` Class:
    * [CoreWebView2PermissionRequestedEventArgs.SavesInProfile Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionrequestedeventargs#savesinprofile)
-
 * [CoreWebView2PermissionSetting Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionsetting)
    * [CoreWebView2PermissionSetting.PermissionKind Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionsetting#permissionkind)
    * [CoreWebView2PermissionSetting.PermissionOrigin Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionsetting#permissionorigin)
    * [CoreWebView2PermissionSetting.PermissionState Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2permissionsetting#permissionstate)
-
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.GetNonDefaultPermissionSettingsAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#getnondefaultpermissionsettingsasync)
    * [CoreWebView2Profile.SetPermissionStateAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#setpermissionstateasync)
@@ -594,34 +585,25 @@ See also:
 * `ICoreWebView2` interface:
    * [ICoreWebView2::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#add_permissionrequested)
    * [ICoreWebView2::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_permissionrequested)
-
 * [ICoreWebView2GetNonDefaultPermissionSettingsCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2getnondefaultpermissionsettingscompletedhandler)
-
 * [ICoreWebView2Frame3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame3)
    * [ICoreWebView2Frame3::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#add_permissionrequested)
    * [ICoreWebView2Frame3::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#remove_permissionrequested)
-
 * [ICoreWebView2PermissionRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs)
-
 * [ICoreWebView2PermissionRequestedEventArgs3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3)
    * [ICoreWebView2PermissionRequestedEventArgs3::get_SavesInProfile](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3#get_savesinprofile)
    * [ICoreWebView2PermissionRequestedEventArgs3::put_SavesInProfile](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs3#put_savesinprofile)
-
 * [ICoreWebView2PermissionSetting interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsetting)
    * [ICoreWebView2PermissionSetting::get_PermissionKind method](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsetting#get_permissionkind)
    * [ICoreWebView2PermissionSetting::get_PermissionOrigin method](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsetting#get_permissionorigin)
    * [ICoreWebView2PermissionSetting::get_PermissionState method](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsetting#get_permissionstate)
-
 * [ICoreWebView2PermissionSettingCollectionView interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsettingcollectionview)
    * [ICoreWebView2PermissionSettingCollectionView::GetValueAtIndex method](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsettingcollectionview#getvalueatindex)
    * [ICoreWebView2PermissionSettingCollectionView::get_Count method](/microsoft-edge/webview2/reference/win32/icorewebview2permissionsettingcollectionview#get_count)
-
 * [ICoreWebView2Profile4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile4)
    * [ICoreWebView2Profile4::GetNonDefaultPermissionSettings method](/microsoft-edge/webview2/reference/win32/icorewebview2profile4#getnondefaultpermissionsettings)
    * [ICoreWebView2Profile4::SetPermissionState method](/microsoft-edge/webview2/reference/win32/icorewebview2profile4#setpermissionstate)
-
 * [ICoreWebView2SetPermissionStateCompletedHandler interface](/microsoft-edge/webview2/reference/win32/icorewebview2setpermissionstatecompletedhandler)
-
 * [COREWEBVIEW2_PERMISSION_KIND enum](/microsoft-edge/webview2/reference/win32/webview2-idl#corewebview2_permission_kind)
 
 ---
@@ -639,16 +621,11 @@ See also:
 
 * `CoreWebView2` Class:
    * [CoreWebView2.ContextMenuRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.contextmenurequested)
-
 * [CoreWebView2ContextMenuItem Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contextmenuitem)
-
 * [CoreWebView2ContextMenuRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contextmenurequestedeventargs)
-
 * [CoreWebView2ContextMenuTarget Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contextmenutarget)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateContextMenuItem Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcontextmenuitem)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.AreDefaultContextMenusEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.aredefaultcontextmenusenabled)
 
@@ -656,16 +633,11 @@ See also:
 
 * `CoreWebView2` Class:
    * [CoreWebView2.ContextMenuRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#contextmenurequested)
-
 * [CoreWebView2ContextMenuItem Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contextmenuitem)
-
 * [CoreWebView2ContextMenuRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contextmenurequestedeventargs)
-
 * [CoreWebView2ContextMenuTarget Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contextmenutarget)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateContextMenuItem Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcontextmenuitem)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.AreDefaultContextMenusEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#aredefaultcontextmenusenabled)
 
@@ -674,17 +646,12 @@ See also:
 * `ICoreWebView2_11` interface:
    * [ICoreWebView2_11::add_ContextMenuRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_11#add_contextmenurequested)
    * [ICoreWebView2_11::remove_ContextMenuRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_11#remove_contextmenurequested)
-
 * [ICoreWebView2ContextMenuRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenurequestedeventargs)
-
 * [ICoreWebView2ContextMenuItem interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenuitem)
    * [ICoreWebView2ContextMenuItemCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenuitemcollection)
-
 * [ICoreWebView2ContextMenuTarget interface](/microsoft-edge/webview2/reference/win32/icorewebview2contextmenutarget)
-
 * `ICoreWebView2Environment9` interface:
    * [ICoreWebView2Environment9::CreateContextMenuItem method](/microsoft-edge/webview2/reference/win32/icorewebview2environment9#createcontextmenuitem)
-
 * `ICoreWebView2Settings` interface:
    * [ICoreWebView2Settings::get_AreDefaultContextMenusEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_aredefaultcontextmenusenabled)
    * [ICoreWebView2Settings::put_AreDefaultContextMenusEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_aredefaultcontextmenusenabled)
@@ -706,7 +673,6 @@ See also:
 * `CoreWebView2` Class:
    * [CoreWebView2.StatusBarText Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.statusbartext)
    * [CoreWebView2.StatusBarTextChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.statusbartextchanged)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsStatusBarEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isstatusbarenabled)
 
@@ -715,7 +681,6 @@ See also:
 * `CoreWebView2` Class:
    * [CoreWebView2.StatusBarText Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#statusbartext)
    * [CoreWebView2.StatusBarTextChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#statusbartextchanged)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsStatusBarEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isstatusbarenabled)
 
@@ -725,7 +690,6 @@ See also:
    * [ICoreWebView2_12::add_StatusBarTextChanged](/microsoft-edge/webview2/reference/win32/icorewebview2_12#add_statusbartextchanged)
    * [ICoreWebView2_12::get_StatusBarText](/microsoft-edge/webview2/reference/win32/icorewebview2_12#get_statusbartext)
    * [ICoreWebView2_12::remove_StatusBarTextChanged](/microsoft-edge/webview2/reference/win32/icorewebview2_12#remove_statusbartextchanged)
-
 * `ICoreWebView2Settings` interface:
    * [ICoreWebView2Settings::get_IsStatusBarEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isstatusbarenabled)
    * [ICoreWebView2Settings::put_IsStatusBarEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isstatusbarenabled)
@@ -839,7 +803,6 @@ This feature is currently disabled by default in the browser.  To enable this fe
 
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsSwipeNavigationEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isswipenavigationenabled)
-
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.AdditionalBrowserArguments Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.additionalbrowserarguments)
 
@@ -847,7 +810,6 @@ This feature is currently disabled by default in the browser.  To enable this fe
 
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsSwipeNavigationEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isswipenavigationenabled)
-
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.AdditionalBrowserArguments Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#additionalbrowserarguments)
 
@@ -856,7 +818,6 @@ This feature is currently disabled by default in the browser.  To enable this fe
 * `ICoreWebView2Settings6` interface:
    * [ICoreWebView2Settings6::get_IsSwipeNavigationEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#get_isswipenavigationenabled)
    * [ICoreWebView2Settings6::put_IsSwipeNavigationEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings6#put_isswipenavigationenabled)
-
 * `ICoreWebView2EnvironmentOptions` interface:
    * [ICoreWebView2EnvironmentOptions::get_AdditionalBrowserArguments property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_additionalbrowserarguments)
    * [ICoreWebView2EnvironmentOptions::put_AdditionalBrowserArguments property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_additionalbrowserarguments)
@@ -946,7 +907,6 @@ The `ScriptLocale` property allows the host app to set the default locale for al
 
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.Language Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.language)
-
 * `CoreWebView2ControllerOptions` Class:
    * [CoreWebView2ControllerOptions.ScriptLocale Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.scriptlocale)
 
@@ -954,7 +914,6 @@ The `ScriptLocale` property allows the host app to set the default locale for al
 
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.Language Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#language)
-
 * `CoreWebView2ControllerOptions` Class:
    * [CoreWebView2ControllerOptions.ScriptLocale Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions#scriptlocale)
 
@@ -963,7 +922,6 @@ The `ScriptLocale` property allows the host app to set the default locale for al
 * `ICoreWebView2EnvironmentOptions` interface:
    * [ICoreWebView2EnvironmentOptions::get_Language property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#get_language)
    * [ICoreWebView2EnvironmentOptions::put_Language property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions#put_language)
-
 * [ICoreWebView2ControllerOptions2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2)
    * [ICoreWebView2ControllerOptions2::get_ScriptLocale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#get_scriptlocale)
    * [ICoreWebView2ControllerOptions2::put_ScriptLocale property method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2#put_scriptlocale)
@@ -980,18 +938,14 @@ WebView2 provides functionality to handle the JavaScript function `window.open()
 
 * `CoreWebView2` Class:
    * [CoreWebView2.NewWindowRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.newwindowrequested)
-
 * [CoreWebView2NewWindowRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2newwindowrequestedeventargs)
-
 * [CoreWebView2WindowFeatures Class](/dotnet/api/microsoft.web.webview2.core.corewebview2windowfeatures)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * `CoreWebView2` Class:
    * [CoreWebView2.NewWindowRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#newwindowrequested)
-
 * [CoreWebView2NewWindowRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2newwindowrequestedeventargs)
-
 * [CoreWebView2WindowFeatures Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2windowfeatures)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -999,9 +953,7 @@ WebView2 provides functionality to handle the JavaScript function `window.open()
 * `ICoreWebView2` interface:
    * [ICoreWebView2::add_NewWindowRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_newwindowrequested)
    * [ICoreWebView2::remove_NewWindowRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_newwindowrequested)
-
 * [ICoreWebView2NewWindowRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2newwindowrequestedeventargs)
-
 * [ICoreWebView2WindowFeatures interface](/microsoft-edge/webview2/reference/win32/icorewebview2windowfeatures)
 
 ---
@@ -1015,7 +967,6 @@ WebView2 provides functionality to handle the JavaScript function `window.close(
 
 * `CoreWebView2` Class:
    * [CoreWebView2.WindowCloseRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.windowcloserequested)
-
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.Close Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.close)
 
@@ -1023,7 +974,6 @@ WebView2 provides functionality to handle the JavaScript function `window.close(
 
 * `CoreWebView2` Class:
    * [CoreWebView2.WindowCloseRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#windowcloserequested)
-
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.Close Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#close)
 
@@ -1032,7 +982,6 @@ WebView2 provides functionality to handle the JavaScript function `window.close(
 * `ICoreWebView2` interface:
    * [ICoreWebView2::add_WindowCloseRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_windowcloserequested)
    * [ICoreWebView2::remove_WindowCloseRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_windowcloserequested)
-
 * `ICoreWebView2Controller` interface:
    * [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
 
@@ -1109,10 +1058,8 @@ See also:
 
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.EnableTrackingPrevention Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.enabletrackingprevention)
-
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.PreferredTrackingPreventionLevel Property](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.preferredtrackingpreventionlevel)
-
 * [CoreWebView2TrackingPreventionLevel Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2trackingpreventionlevel)
     * `None`
     * `Basic`
@@ -1123,10 +1070,8 @@ See also:
 
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.EnableTrackingPrevention Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#enabletrackingprevention)
-
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.PreferredTrackingPreventionLevel Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#preferredtrackingpreventionlevel)
-
 * [CoreWebView2TrackingPreventionLevel Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2trackingpreventionlevel)
     * `None`
     * `Basic`
@@ -1138,11 +1083,9 @@ See also:
 * [ICoreWebView2EnvironmentOptions5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5)
    * [ICoreWebView2EnvironmentOptions5::get_EnableTrackingPrevention property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#get_enabletrackingprevention)
    * [ICoreWebView2EnvironmentOptions5::put_EnableTrackingPrevention property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions5#put_enabletrackingprevention)
-
 * [ICoreWebView2Profile3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile3)
    * [ICoreWebView2Profile3::get_PreferredTrackingPreventionLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#get_preferredtrackingpreventionlevel)
    * [ICoreWebView2Profile3::put_PreferredTrackingPreventionLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2profile3#put_preferredtrackingpreventionlevel)
-
 * [COREWEBVIEW2_TRACKING_PREVENTION_LEVEL enum](/microsoft-edge/webview2/reference/win32/webview2-idl#corewebview2_tracking_prevention_level)
   * `COREWEBVIEW2_TRACKING_PREVENTION_LEVEL_NONE`
   * `COREWEBVIEW2_TRACKING_PREVENTION_LEVEL_BASIC`
@@ -1190,16 +1133,12 @@ Get information about running WebView2 processes, exiting processes, and failed 
 * `CoreWebView2` Class:
    * [CoreWebView2.BrowserProcessId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.browserprocessid)
    * [CoreWebView2.ProcessFailed Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.processfailed)
-
 * [CoreWebView2BrowserProcessExitedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2browserprocessexitedeventargs)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.BrowserProcessExited Event](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.browserprocessexited)
    * [CoreWebView2Environment.GetProcessInfos Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.getprocessinfos)
    * [CoreWebView2Environment.ProcessInfosChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.processinfoschanged)
-
 * [CoreWebView2ProcessFailedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs)
-
 * [CoreWebView2ProcessInfo Class](/dotnet/api/microsoft.web.webview2.core.corewebview2processinfo)
 
 
@@ -1208,16 +1147,12 @@ Get information about running WebView2 processes, exiting processes, and failed 
 * `CoreWebView2` Class:
    * [CoreWebView2.BrowserProcessId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#browserprocessid)
    * [CoreWebView2.ProcessFailed Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#processfailed)
-
 * [CoreWebView2BrowserProcessExitedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2browserprocessexitedeventargs)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.BrowserProcessExited Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#browserprocessexited)
    * [CoreWebView2Environment.GetProcessInfos Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#getprocessinfos)
    * [CoreWebView2Environment.ProcessInfosChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#processinfoschanged)
-
 * [CoreWebView2ProcessFailedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs)
-
 * [CoreWebView2ProcessInfo Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processinfo)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1226,22 +1161,16 @@ Get information about running WebView2 processes, exiting processes, and failed 
    * [ICoreWebView2::get_BrowserProcessId property method](/microsoft-edge/webview2/reference/win32/icorewebview2#get_browserprocessid)<!--no put-->
    * [ICoreWebView2::add_ProcessFailed event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_processfailed)
    * [ICoreWebView2::remove_ProcessFailed event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_processfailed)
-
 * [ICoreWebView2BrowserProcessExitedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2browserprocessexitedeventargs)
-
 * [ICoreWebView2Environment8 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment8)
    * [ICoreWebView2Environment8::GetProcessInfos method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#getprocessinfos)
    * [ICoreWebView2Environment8::add_ProcessInfosChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#add_processinfoschanged)
    * [ICoreWebView2Environment8::remove_ProcessInfosChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment8#remove_processinfoschanged)
-
 * [ICoreWebView2Environment5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment5)
    * [ICoreWebView2Environment5::add_BrowserProcessExited event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#add_browserprocessexited)
    * [ICoreWebView2Environment5::remove_BrowserProcessExited event method](/microsoft-edge/webview2/reference/win32/icorewebview2environment5#remove_browserprocessexited)
-
 * [ICoreWebView2ProcessFailedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2processfailedeventargs)
-
 * [ICoreWebView2ProcessInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2processinfo)
-
 * [ICoreWebView2ProcessInfoCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2processinfocollection)
 
 ---
@@ -1276,7 +1205,6 @@ See also:
    * [CoreWebView2.SetVirtualHostNameToFolderMapping Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.setvirtualhostnametofoldermapping)
    * [CoreWebView2.Stop Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.stop)
    * [CoreWebView2.WebResourceRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourcerequested)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsBuiltInErrorPageEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isbuiltinerrorpageenabled#microsoft-web-webview2-core-corewebview2settings-isbuiltinerrorpageenabled)
 
@@ -1291,7 +1219,6 @@ See also:
    * [CoreWebView2.SetVirtualHostNameToFolderMapping Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#setvirtualhostnametofoldermapping)
    * [CoreWebView2.Stop Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#stop)
    * [CoreWebView2.WebResourceRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourcerequested)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsBuiltInErrorPageEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isbuiltinerrorpageenabled)
 
@@ -1304,14 +1231,11 @@ See also:
    * [ICoreWebView2::NavigateToString method](/microsoft-edge/webview2/reference/win32/icorewebview2#navigatetostring)
    * [ICoreWebView2::Reload method](/microsoft-edge/webview2/reference/win32/icorewebview2#reload)
    * [ICoreWebView2::Stop method](/microsoft-edge/webview2/reference/win32/icorewebview2#stop)
-
 * `ICoreWebView2_2` interface:
    * [ICoreWebView2_2::NavigateWithWebResourceRequest method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#navigatewithwebresourcerequest)
-
 * `ICoreWebView2_3` interface:
    * [ICoreWebView2_3::ClearVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#clearvirtualhostnametofoldermapping)
    * [ICoreWebView2_3::SetVirtualHostNameToFolderMapping method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#setvirtualhostnametofoldermapping)
-
 * `ICoreWebView2Settings` interface:
    * [ICoreWebView2Settings::get_IsBuiltInErrorPageEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isbuiltinerrorpageenabled)
    * [ICoreWebView2Settings::put_IsBuiltInErrorPageEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isbuiltinerrorpageenabled)
@@ -1334,7 +1258,6 @@ The history methods allow back and forward navigation in WebView2, and the histo
    * [CoreWebView2.HistoryChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.historychanged)
    * [CoreWebView2.Source Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.source)
    * [CoreWebView2.SourceChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.sourcechanged)
-
 * [CoreWebView2SourceChangedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2sourcechangedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
@@ -1347,7 +1270,6 @@ The history methods allow back and forward navigation in WebView2, and the histo
    * [CoreWebView2.HistoryChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#historychanged)
    * [CoreWebView2.Source Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#source)
    * [CoreWebView2.SourceChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#sourcechanged)
-
 * [CoreWebView2SourceChangedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2sourcechangedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1362,7 +1284,6 @@ The history methods allow back and forward navigation in WebView2, and the histo
    * [ICoreWebView2::GoForward method](/microsoft-edge/webview2/reference/win32/icorewebview2#goforward)
    * [ICoreWebView2::remove_HistoryChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_historychanged)
    * [ICoreWebView2::remove_SourceChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_sourcechanged)
-
 * [ICoreWebView2SourceChangedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2sourcechangedeventargs)
 
 ---
@@ -1378,10 +1299,8 @@ The `NavigationStarting` event allows the app to cancel navigating to specified 
 * `CoreWebView2` Class:
    * [CoreWebView2.NavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigationstarting)
    * [CoreWebView2.FrameNavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framenavigationstarting) - superseded; use `CoreWebView2Frame.NavigationStarting` instead
-
 * `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.NavigationStarting Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.navigationstarting)
-
 * [CoreWebView2NavigationStartingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2navigationstartingeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
@@ -1389,10 +1308,8 @@ The `NavigationStarting` event allows the app to cancel navigating to specified 
 * `CoreWebView2` Class:
    * [CoreWebView2.NavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigationstarting)
    * [CoreWebView2.FrameNavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framenavigationstarting) - superseded; use `CoreWebView2Frame.NavigationStarting` instead
-
 * `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.NavigationStarting Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#navigationstarting)
-
 * [CoreWebView2NavigationStartingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2navigationstartingeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1402,11 +1319,9 @@ The `NavigationStarting` event allows the app to cancel navigating to specified 
    * [ICoreWebView2::remove_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationstarting)
    * [ICoreWebView2::add_FrameNavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_framenavigationstarting) - superseded; use `ICoreWebView2Frame.add_NavigationStarting` instead
    * [ICoreWebView2::remove_FrameNavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationstarting) - superseded; use `ICoreWebView2Frame.remove_NavigationStarting` instead
-
 * `ICoreWebView2Frame2` interface:
    * [ICoreWebView2Frame2::add_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_navigationstarting)
    * [ICoreWebView2Frame2::remove_NavigationStarting event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationstarting)
-
 * [ICoreWebView2NavigationStartingEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2)<!--v2-->
 
 ---
@@ -1427,16 +1342,12 @@ See also:
    * [CoreWebView2.DOMContentLoaded Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.domcontentloaded)
    * [CoreWebView2.FrameNavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framenavigationcompleted) - superseded; use `CoreWebView2Frame.NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
    * [CoreWebView2.NavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.navigationcompleted)
-
 * [CoreWebView2ContentLoadingEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2contentloadingeventargs)
-
 * [CoreWebView2DOMContentLoadedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2domcontentloadedeventargs)
-
 * `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.ContentLoading Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.contentloading)
    * [CoreWebView2Frame.DOMContentLoaded Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.domcontentloaded)
    * [CoreWebView2Frame.NavigationCompleted Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.navigationcompleted)
-
 * [CoreWebView2NavigationCompletedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2navigationcompletedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
@@ -1446,16 +1357,12 @@ See also:
    * [CoreWebView2.DOMContentLoaded Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#domcontentloaded)
    * [CoreWebView2.FrameNavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framenavigationcompleted) - superseded; use `CoreWebView2Frame.NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
    * [CoreWebView2.NavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#navigationcompleted)
-
 * [CoreWebView2ContentLoadingEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2contentloadingeventargs)
-
 * [CoreWebView2DOMContentLoadedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2domcontentloadedeventargs)
-
 * `CoreWebView2Frame` Class:
    * [CoreWebView2Frame.ContentLoading Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#contentloading)
    * [CoreWebView2Frame.DOMContentLoaded Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#domcontentloaded)
    * [CoreWebView2Frame.NavigationCompleted Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#navigationcompleted)
-
 * [CoreWebView2NavigationCompletedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2navigationcompletedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1467,11 +1374,9 @@ See also:
    * [ICoreWebView2::remove_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_contentloading)
    * [ICoreWebView2::remove_FrameNavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_framenavigationcompleted) - superseded; use `ICoreWebView2Frame::remove_NavigationCompleted` instead<!--todo: tech review this added note; confirm this API is superseded-->
    * [ICoreWebView2::remove_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_navigationcompleted)
-
 * `ICoreWebView2_2` interface:
    * [ICoreWebView2_2::add_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_domcontentloaded)
    * [ICoreWebView2_2::remove_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_domcontentloaded)
-
 * `ICoreWebView2Frame2` interface:
    * [ICoreWebView2Frame2::add_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_contentloading)
    * [ICoreWebView2Frame2::add_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_domcontentloaded)
@@ -1479,13 +1384,9 @@ See also:
    * [ICoreWebView2Frame2::remove_ContentLoading event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_contentloading)
    * [ICoreWebView2Frame2::remove_DOMContentLoaded event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_domcontentloaded)
    * [ICoreWebView2Frame2::remove_NavigationCompleted event method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_navigationcompleted)
-
 * [ICoreWebView2ContentLoadingEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2contentloadingeventargs)
-
 * [ICoreWebView2DOMContentLoadedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2domcontentloadedeventargs)
-
 * [ICoreWebView2NavigationCompletedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs)
-
 * [ICoreWebView2NavigationCompletedEventArgs2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2navigationcompletedeventargs2)
 
 ---
@@ -1504,9 +1405,7 @@ See also:
 * `CoreWebView2` Class:
    * [CoreWebView2.WebResourceRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourcerequested)
    * [CoreWebView2.WebResourceResponseReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webresourceresponsereceived)
-
 * [CoreWebView2WebResourceRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webresourcerequestedeventargs)
-
 * [CoreWebView2WebResourceResponseReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webresourceresponsereceivedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
@@ -1514,9 +1413,7 @@ See also:
 * `CoreWebView2` Class:
    * [CoreWebView2.WebResourceRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourcerequested)
    * [CoreWebView2.WebResourceResponseReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webresourceresponsereceived)
-
 * [CoreWebView2WebResourceRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webresourcerequestedeventargs)
-
 * [CoreWebView2WebResourceResponseReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webresourceresponsereceivedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1524,13 +1421,10 @@ See also:
 * `ICoreWebView2` interface:
    * [ICoreWebView2::add_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webresourcerequested)
    * [ICoreWebView2::remove_WebResourceRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webresourcerequested)
-
 * `ICoreWebView2_2` interface:
    * [ICoreWebView2_2::add_WebResourceResponseReceived event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#add_webresourceresponsereceived)
    * [ICoreWebView2_2::remove_WebResourceResponseReceived event method](/microsoft-edge/webview2/reference/win32/icorewebview2_2#remove_webresourceresponsereceived)
-
 * [ICoreWebView2WebResourceRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourcerequestedeventargs)
-
 * [ICoreWebView2WebResourceResponseReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webresourceresponsereceivedeventargs)
 
 ---
@@ -1544,20 +1438,17 @@ The `CustomSchemeRegistration` allows registration of custom schemes in WebView2
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2CustomSchemeRegistration Class](/dotnet/api/microsoft.web.webview2.core.corewebview2customschemeregistration)
-
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.CustomSchemeRegistrations Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.customschemeregistrations)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2CustomSchemeRegistration Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2customschemeregistration)
-
 * [CoreWebView2EnvironmentOptions Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions)<!-- todo: remove or comment-out this item?  no CustomSchemeRegistrations property: https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions -->
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2CustomSchemeRegistration interface](/microsoft-edge/webview2/reference/win32/icorewebview2customschemeregistration)
-
 * [ICoreWebView2EnvironmentOptions4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4)
    * [ICoreWebView2EnvironmentOptions4::GetCustomSchemeRegistrations method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4#getcustomschemeregistrations)
    * [ICoreWebView2EnvironmentOptions4::SetCustomSchemeRegistrations method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions4#setcustomschemeregistrations)
@@ -1578,18 +1469,14 @@ In WebView2, you can use the Client Certificate API to select the client certifi
 
 * `CoreWebView2` Class:
    * [CoreWebView2.ClientCertificateRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.clientcertificaterequested)
-
 * [CoreWebView2ClientCertificate Class](/dotnet/api/microsoft.web.webview2.core.corewebview2clientcertificate)
-
 * [CoreWebView2ClientCertificateRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2clientcertificaterequestedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * `CoreWebView2` Class:
    * [CoreWebView2.ClientCertificateRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#clientcertificaterequested)
-
 * [CoreWebView2ClientCertificate Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2clientcertificate)
-
 * [CoreWebView2ClientCertificateRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2clientcertificaterequestedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1597,11 +1484,8 @@ In WebView2, you can use the Client Certificate API to select the client certifi
 * [ICoreWebView2_5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_5)
    * [ICoreWebView2_5::add_ClientCertificateRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#add_clientcertificaterequested)
    * [ICoreWebView2_5::remove_ClientCertificateRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_5#remove_clientcertificaterequested)
-
 * [ICoreWebView2ClientCertificate interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificate)
-
 * [ICoreWebView2ClientCertificateCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificatecollection)<!--n/a for c#-->
-
 * [ICoreWebView2ClientCertificateRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2clientcertificaterequestedeventargs)
 
 ---
@@ -1652,22 +1536,16 @@ See also:
 
 * `CoreWebView2` Class:
    * [CoreWebView2.FrameCreated Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.framecreated)
-
 * [CoreWebView2Frame Class](/dotnet/api/microsoft.web.webview2.core.corewebview2frame)
-
 * [CoreWebView2FrameCreatedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2framecreatedeventargs)
-
 * [CoreWebView2FrameInfo Class](/dotnet/api/microsoft.web.webview2.core.corewebview2frameinfo)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * `CoreWebView2` Class:
    * [CoreWebView2.FrameCreated Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#framecreated)
-
 * [CoreWebView2Frame Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame)
-
 * [CoreWebView2FrameCreatedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2framecreatedeventargs)
-
 * [CoreWebView2FrameInfo Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frameinfo)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1675,15 +1553,10 @@ See also:
 * `ICoreWebView2_4` interface:
    * [ICoreWebView2_4::add_FrameCreated event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#add_framecreated)
    * [ICoreWebView2_4::remove_FrameCreated event method](/microsoft-edge/webview2/reference/win32/icorewebview2_4#remove_framecreated)
-
 * [ICoreWebView2Frame interface](/microsoft-edge/webview2/reference/win32/icorewebview2frame)
-
 * [ICoreWebView2FrameCreatedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2framecreatedeventargs)
-
 * [ICoreWebView2FrameInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfo)
-
 * [ICoreWebView2FrameInfoCollection interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfocollection)<!--C++ only-->
-
 * [ICoreWebView2FrameInfoCollectionIterator interface](/microsoft-edge/webview2/reference/win32/icorewebview2frameinfocollectioniterator)<!--C++ only-->
 
 ---
@@ -1705,48 +1578,31 @@ See also:
 
 * `CoreWebView2` Class:
    * [CoreWebView2.BasicAuthenticationRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.basicauthenticationrequested)
-
 * [CoreWebView2BasicAuthenticationRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2basicauthenticationrequestedeventargs)
-
 * [CoreWebView2BasicAuthenticationResponse Class](/dotnet/api/microsoft.web.webview2.core.corewebview2basicauthenticationresponse)
-
 * [CoreWebView2HttpHeadersCollectionIterator Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httpheaderscollectioniterator)
-
 * [CoreWebView2HttpRequestHeaders Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httprequestheaders)
-
 * [CoreWebView2HttpResponseHeaders Class](/dotnet/api/microsoft.web.webview2.core.corewebview2httpresponseheaders)
-
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * `CoreWebView2` Class:
    * [CoreWebView2.BasicAuthenticationRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#basicauthenticationrequested)
-
 * [CoreWebView2BasicAuthenticationRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2basicauthenticationrequestedeventargs)
-
 * [CoreWebView2BasicAuthenticationResponse Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2basicauthenticationresponse)
-
 * [CoreWebView2HttpHeadersCollectionIterator Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httpheaderscollectioniterator)
-
 * [CoreWebView2HttpRequestHeaders Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httprequestheaders)
-
 * [CoreWebView2HttpResponseHeaders Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2httpresponseheaders)
-
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2_10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2_10)
    * [ICoreWebView2_10::add_BasicAuthenticationRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#add_basicauthenticationrequested)
    * [ICoreWebView2_10::remove_BasicAuthenticationRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2_10#remove_basicauthenticationrequested)
-
 * [ICoreWebView2BasicAuthenticationRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2basicauthenticationrequestedeventargs)
-
 * [ICoreWebView2BasicAuthenticationResponse interface](/microsoft-edge/webview2/reference/win32/icorewebview2basicauthenticationresponse)
-
 * [ICoreWebView2HttpHeadersCollectionIterator interface](/microsoft-edge/webview2/reference/win32/icorewebview2httpheaderscollectioniterator)
-
 * [ICoreWebView2HttpRequestHeaders interface](/microsoft-edge/webview2/reference/win32/icorewebview2httprequestheaders)
-
 * [ICoreWebView2HttpResponseHeaders interface](/microsoft-edge/webview2/reference/win32/icorewebview2httpresponseheaders)
 
 ---
@@ -1768,7 +1624,6 @@ Use these APIs to set up the WebView2 rendering system if your host app doesn't 
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.CoreWebView2 Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.corewebview2)
    * [CoreWebView2Controller.Close Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.close)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)<!--2 overloads-->
 
@@ -1777,7 +1632,6 @@ Use these APIs to set up the WebView2 rendering system if your host app doesn't 
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.CoreWebView2 Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#corewebview2)
    * [CoreWebView2Controller.Close Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#close)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync)
 
@@ -1786,7 +1640,6 @@ Use these APIs to set up the WebView2 rendering system if your host app doesn't 
 * `ICoreWebView2Controller` interface:
    * [ICoreWebView2Controller::get_CoreWebView2 property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_corewebview2)<!--no put-->
    * [ICoreWebView2Controller::Close method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#close)
-
 * `CoreWebView2Environment` Class:
    * [ICoreWebView2Environment::CreateCoreWebView2Controller method](/microsoft-edge/webview2/reference/win32/icorewebview2environment#createcorewebview2controller)
 
@@ -1818,7 +1671,6 @@ WebView2 gives your app access to window-specific attributes, such as positionin
 * `ICoreWebView2Controller` interface:
    * [ICoreWebView2Controller::get_Bounds property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_bounds)
    * [ICoreWebView2Controller::put_Bounds property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_bounds)
-
    * [ICoreWebView2Controller::get_IsVisible property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#get_isvisible)
    * [ICoreWebView2Controller::put_IsVisible property method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#put_isvisible)
 
@@ -1836,7 +1688,6 @@ WebView2 `ZoomFactor` is used to scale just the web content of the window.  UI s
    * [CoreWebView2Controller.ZoomFactor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.zoomfactor)
    * [CoreWebView2Controller.ZoomFactorChanged Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.zoomfactorchanged)
    * [CoreWebView2Controller.SetBoundsAndZoomFactor Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.setboundsandzoomfactor)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsPinchZoomEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.ispinchzoomenabled)
    * [CoreWebView2Settings.IsZoomControlEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.iszoomcontrolenabled)
@@ -1847,7 +1698,6 @@ WebView2 `ZoomFactor` is used to scale just the web content of the window.  UI s
    * [CoreWebView2Controller.ZoomFactor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#zoomfactor)
    * [CoreWebView2Controller.ZoomFactorChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#zoomfactorchanged)
    * [CoreWebView2Controller.SetBoundsAndZoomFactor Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#setboundsandzoomfactor)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.IsPinchZoomEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#ispinchzoomenabled)
    * [CoreWebView2Settings.IsZoomControlEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#iszoomcontrolenabled)
@@ -1860,11 +1710,9 @@ WebView2 `ZoomFactor` is used to scale just the web content of the window.  UI s
    * [ICoreWebView2Controller::add_ZoomFactorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_zoomfactorchanged)
    * [ICoreWebView2Controller::remove_ZoomFactorChanged event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_zoomfactorchanged)
    * [ICoreWebView2Controller::SetBoundsAndZoomFactor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#setboundsandzoomfactor)
-
 * `ICoreWebView2Settings` interface:
    * [ICoreWebView2Settings::get_IsZoomControlEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iszoomcontrolenabled)
    * [ICoreWebView2Settings::put_IsZoomControlEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iszoomcontrolenabled)
-
 * [ICoreWebView2Settings5 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings5)
    * [ICoreWebView2Settings5::get_IsPinchZoomEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#get_ispinchzoomenabled)
    * [ICoreWebView2Settings5::put_IsPinchZoomEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings5#put_ispinchzoomenabled)
@@ -1920,7 +1768,6 @@ The WebView2 control raises events to let the app know when the control gains fo
    * [CoreWebview2Controller.LostFocus Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.lostfocus)
    * [CoreWebview2Controller.MoveFocus Method](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.movefocus)
    * [CoreWebview2Controller.MoveFocusRequested Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.movefocusrequested)
-
 * [CoreWebView2MoveFocusRequestedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2movefocusrequestedeventargs)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
@@ -1930,7 +1777,6 @@ The WebView2 control raises events to let the app know when the control gains fo
    * [CoreWebview2Controller.LostFocus Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#lostfocus)
    * [CoreWebview2Controller.MoveFocus Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#movefocus)
    * [CoreWebview2Controller.MoveFocusRequested Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#movefocusrequested)
-
 * [CoreWebView2MoveFocusRequestedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2movefocusrequestedeventargs)
 
 ##### [Win32/C++](#tab/win32cpp)
@@ -1943,7 +1789,6 @@ The WebView2 control raises events to let the app know when the control gains fo
    * [ICoreWebview2Controller::remove_GotFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_gotfocus)
    * [ICoreWebview2Controller::remove_LostFocus event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_lostfocus)
    * [ICoreWebview2Controller::remove_MoveFocusRequested event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_movefocusrequested)
-
 * [ICoreWebView2MoveFocusRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2movefocusrequestedeventargs)
 
 ---
@@ -1984,31 +1829,25 @@ When WebView2 has focus, it directly receives input from the user. An app may wa
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2AcceleratorKeyPressedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2acceleratorkeypressedeventargs)
-
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.AcceleratorKeyPressed Event](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.acceleratorkeypressed)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.AreBrowserAcceleratorKeysEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.arebrowseracceleratorkeysenabled)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2AcceleratorKeyPressedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2acceleratorkeypressedeventargs)
-
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.AcceleratorKeyPressed Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#acceleratorkeypressed)
-
 * `CoreWebView2Settings` Class:
    * [CoreWebView2Settings.AreBrowserAcceleratorKeysEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arebrowseracceleratorkeysenabled)
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2AcceleratorKeyPressedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2acceleratorkeypressedeventargs)
-
 * `ICoreWebView2Controller` interface:
    * [ICoreWebView2Controller::add_AcceleratorKeyPressed event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#add_acceleratorkeypressed)
    * [ICoreWebView2Controller::remove_AcceleratorKeyPressed event method](/microsoft-edge/webview2/reference/win32/icorewebview2controller#remove_acceleratorkeypressed)
-
 * [ICoreWebView2Settings3 interface](/microsoft-edge/webview2/reference/win32/icorewebview2settings3)
    * [ICoreWebView2Settings3::get_AreBrowserAcceleratorKeysEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#get_arebrowseracceleratorkeysenabled)
    * [ICoreWebView2Settings3::put_AreBrowserAcceleratorKeysEnabled property method](/microsoft-edge/webview2/reference/win32/icorewebview2settings3#put_arebrowseracceleratorkeysenabled)
@@ -2048,21 +1887,18 @@ For composition-based WebView2 rendering, use `CoreWebView2Environment` to creat
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2CompositionController Class](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2compositioncontrollerasync)<!--2 overloads-->
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2CompositionController Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateCoreWebView2CompositionControllerAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2compositioncontrollerasync)
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2CompositionController interface](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller)
-
 * `ICoreWebView2Environment3` interface:
    * [ICoreWebView2Environment3::CreateCoreWebview2CompositionController method](/microsoft-edge/webview2/reference/win32/icorewebview2environment3#createcorewebview2compositioncontroller)
 
@@ -2107,10 +1943,8 @@ Spatial input (mouse, touch, pen) is received by the application and must be sen
    * [CoreWebView2CompositionController.SystemCursorId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.systemcursorid)
    * [CoreWebView2CompositionController.SendMouseInput Method](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.sendmouseinput)
    * [CoreWebView2CompositionController.SendPointerInput Method](/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller.sendpointerinput)
-   
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateCoreWebView2PointerInfo Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2pointerinfo)
-
 * [CoreWebView2PointerInfo Class](/dotnet/api/microsoft.web.webview2.core.corewebview2pointerinfo)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
@@ -2120,10 +1954,8 @@ Spatial input (mouse, touch, pen) is received by the application and must be sen
    * [CoreWebView2CompositionController.CursorChanged Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#cursorchanged)
    * [CoreWebView2CompositionController.SendMouseInput Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#sendmouseinput)
    * [CoreWebView2CompositionController.SendPointerInput Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#sendpointerinput)
-
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateCoreWebView2PointerInfo Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2pointerinfo)
-
 * [CoreWebView2PointerInfo Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2pointerinfo)
 
 <!--
@@ -2142,10 +1974,8 @@ https://learn.microsoft.com/microsoft-edge/webview2/reference/winrt/microsoft_we
    * [ICoreWebView2CompositionController::get_SystemCursorId property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#get_systemcursorid)<!--no put-->
    * [ICoreWebView2CompositionController::SendMouseInput method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#sendmouseinput)
    * [ICoreWebView2CompositionController::SendPointerInput method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller#sendpointerinput)
-    
 * `ICoreWebView2Environment3` interface:
    * [ICoreWebView2Environment3::CreateCoreWebView2PointerInfo method](/microsoft-edge/webview2/reference/win32/icorewebview2environment3#createcorewebview2pointerinfo)
-
 * [ICoreWebView2PointerInfo interface](/microsoft-edge/webview2/reference/win32/icorewebview2pointerinfo)
 
 ---
@@ -2167,7 +1997,6 @@ Use the following APIs to forward `IDropTarget` events from the system to the We
 
 * `CoreWebView2CompositionController` Class:
    * [CoreWebView2CompositionController.DragLeave Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2compositioncontroller#dragleave)
-
 * [ICoreWebView2CompositionControllerInterop2 interface](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2)
    * [ICoreWebView2CompositionControllerInterop2.DragEnter method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragenter)
    * [ICoreWebView2CompositionControllerInterop2.DragLeave method](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop2#dragleave)
@@ -2201,7 +2030,6 @@ Not applicable.
 
 * `ICoreWebView2CompositionController2` interface:
    * [ICoreWebView2CompositionController2::get_AutomationProvider property method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller2#get_automationprovider)<!--no put-->
-
 * [ICoreWebView2Environment4 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment4)
    * [ICoreWebView2Environment4::GetAutomationProviderForWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2environment4#getautomationproviderforwindow)<!--C++ only-->
 
@@ -2222,10 +2050,8 @@ See also:
    * [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controlleroptions)
    * [CoreWebView2Environment.CreateCoreWebView2ControllerWithOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controllerasync)
    * [CoreWebView2Environment.UserDataFolder Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.userdatafolder)
-
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.ExclusiveUserDataFolderAccess Property](/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions.exclusiveuserdatafolderaccess)
-
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.ClearBrowsingDataAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.clearbrowsingdataasync)
 
@@ -2237,10 +2063,8 @@ See also:
    * [CoreWebView2Environment.CreateCoreWebView2ControllerAsync(options) Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controllerasync-1)
    * [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createcorewebview2controlleroptions)
    * [CoreWebView2Environment.UserDataFolder Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#userdatafolder)
-
 * `CoreWebView2EnvironmentOptions` Class:
    * [CoreWebView2EnvironmentOptions.ExclusiveUserDataFolderAccess Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions#exclusiveuserdatafolderaccess)
-
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.ClearBrowsingDataAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#clearbrowsingdataasync)
 
@@ -2248,16 +2072,13 @@ See also:
 
 * [ICoreWebView2Environment7 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment7)
    * [ICoreWebView2Environment7::get_UserDataFolder property method](/microsoft-edge/webview2/reference/win32/icorewebview2environment7#get_userdatafolder)<!--no put-->
-
 * [ICoreWebView2Environment10 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environment10)
    * [ICoreWebView2Environment10::CreateCoreWebView2CompositionControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2compositioncontrollerwithoptions)<!-- c#: might ~=CreateCoreWebView2CompositionControllerAsync -->
    * [ICoreWebView2Environment10::CreateCoreWebView2ControllerOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controlleroptions)
    * [ICoreWebView2Environment10::CreateCoreWebView2ControllerWithOptions method](/microsoft-edge/webview2/reference/win32/icorewebview2environment10#createcorewebview2controllerwithoptions)
-
 * [ICoreWebView2EnvironmentOptions2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2)
    * [ICoreWebView2EnvironmentOptions2::get_ExclusiveUserDataFolderAccess property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#get_exclusiveuserdatafolderaccess)
    * [ICoreWebView2EnvironmentOptions2::put_ExclusiveUserDataFolderAccess property method](/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions2#put_exclusiveuserdatafolderaccess)
-
 * [ICoreWebView2Profile2 interface](/microsoft-edge/webview2/reference/win32/icorewebview2profile2)
    * [ICoreWebView2Profile2::ClearBrowsingData method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdata)
    * [ICoreWebView2Profile2::ClearBrowsingDataAll method](/microsoft-edge/webview2/reference/win32/icorewebview2profile2#clearbrowsingdataall)
@@ -2277,7 +2098,6 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-<!-- resume -->
 Create an options object that defines a profile:
 * `CoreWebView2Environment` Class:
    * [CoreWebView2Environment.CreateCoreWebView2ControllerOptions Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createcorewebview2controlleroptions)
@@ -2347,7 +2167,6 @@ Analyze and debug performance, handle performance-related events, and manage mem
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * `CoreWebView2` Class:
-   * [CoreWebView2.MemoryUsageTargetLevel Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.memoryusagetargetlevel)
    * [CoreWebView2.TrySuspendAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.trysuspendasync)
    * [CoreWebView2.IsSuspended Property](/dotnet/api/microsoft.web.webview2.core.corewebview2.issuspended)
    * [CoreWebView2.Resume Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.resume)
@@ -2356,7 +2175,6 @@ Analyze and debug performance, handle performance-related events, and manage mem
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * `CoreWebView2` Class:
-   * [CoreWebView2.MemoryUsageTargetLevel Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#memoryusagetargetlevel)
    * [CoreWebView2.TrySuspendAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#trysuspendasync)
    * [CoreWebView2.IsSuspended Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#issuspended)
    * [CoreWebView2.Resume Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#resume)
@@ -2364,15 +2182,10 @@ Analyze and debug performance, handle performance-related events, and manage mem
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2Experimental5` interface:<!--todo: delete "experimental" links?-->
-   * [ICoreWebView2Experimental5::get_MemoryUsageTargetLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2experimental5#get_memoryusagetargetlevel)
-   * [ICoreWebView2Experimental5::put_MemoryUsageTargetLevel property method](/microsoft-edge/webview2/reference/win32/icorewebview2experimental5#put_memoryusagetargetlevel)
-
 * `ICoreWebView2_3` interface:
    * [ICoreWebView2_3::TrySuspend method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#trysuspend)
    * [ICoreWebView2_3::get_IsSuspended property method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#get_issuspended)<!--no put-->
    * [ICoreWebView2_3::Resume method](/microsoft-edge/webview2/reference/win32/icorewebview2_3#resume)
-
 * `ICoreWebView2_6` interface:
    * [ICoreWebView2_6::OpenTaskManagerWindow method](/microsoft-edge/webview2/reference/win32/icorewebview2_6#opentaskmanagerwindow)
 

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -54,25 +54,19 @@ See also:
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2 Class](/dotnet/api/microsoft.web.webview2.core.corewebview2)
-
 * [CoreWebView2Controller Class](/dotnet/api/microsoft.web.webview2.core.corewebview2controller)
-
 * [CoreWebView2Environment Class](/dotnet/api/microsoft.web.webview2.core.corewebview2environment)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2 Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2)
-
 * [CoreWebView2Controller Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller)
-
 * [CoreWebView2Environment Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment)
 
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2](/microsoft-edge/webview2/reference/win32/icorewebview2)
-
 * [ICoreWebView2Controller](/microsoft-edge/webview2/reference/win32/icorewebview2controller)
-
 * [ICoreWebView2Environment](/microsoft-edge/webview2/reference/win32/icorewebview2environment)
 
 ---
@@ -107,15 +101,17 @@ Host objects can be projected into JavaScript, so that you can call native objec
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.AddHostObjectToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.addhostobjecttoscript)
-* [CoreWebView2.RemoveHostObjectFromScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.removehostobjectfromscript)
+* `CoreWebView2` Class
+   * [CoreWebView2.AddHostObjectToScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.addhostobjecttoscript)
+   * [CoreWebView2.RemoveHostObjectFromScript Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.removehostobjectfromscript)
 
 * [CoreWebView2Settings.AreHostObjectsAllowed Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.arehostobjectsallowed)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.AddHostObjectToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#addhostobjecttoscript)
-* [CoreWebView2.RemoveHostObjectFromScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#removehostobjectfromscript)
+* `CoreWebView2` Class
+   * [CoreWebView2.AddHostObjectToScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#addhostobjecttoscript)
+   * [CoreWebView2.RemoveHostObjectFromScript Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#removehostobjectfromscript)
 
 * [CoreWebView2Settings.AreHostObjectsAllowed Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#arehostobjectsallowed)
 
@@ -123,8 +119,9 @@ Host objects can be projected into JavaScript, so that you can call native objec
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::AddHostObjectToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#addhostobjecttoscript)
-* [ICoreWebView2::RemoveHostObjectFromScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#removehostobjectfromscript)
+* `ICoreWebView2` interface
+   * [ICoreWebView2::AddHostObjectToScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#addhostobjecttoscript)
+   * [ICoreWebView2::RemoveHostObjectFromScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#removehostobjectfromscript)
 
 * [ICoreWebView2Settings::AreHostObjectsAllowed property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_arehostobjectsallowed), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_arehostobjectsallowed)
 
@@ -140,9 +137,10 @@ Allows host app to add JavaScript in the web content within the WebView2 control
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.addscripttoexecuteondocumentcreatedasync)
-* [CoreWebView2.ExecuteScriptAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.executescriptasync)
-* [CoreWebView2.RemoveScriptToExecuteOnDocumentCreated Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.removescripttoexecuteondocumentcreated)
+* `CoreWebView2` Class
+   * [CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.addscripttoexecuteondocumentcreatedasync)
+   * [CoreWebView2.ExecuteScriptAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.executescriptasync)
+   * [CoreWebView2.RemoveScriptToExecuteOnDocumentCreated Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.removescripttoexecuteondocumentcreated)
 
 * [CoreWebView2Settings.IsScriptEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isscriptenabled)
 
@@ -150,9 +148,10 @@ Allows host app to add JavaScript in the web content within the WebView2 control
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#addscripttoexecuteondocumentcreatedasync)
-* [CoreWebView2.ExecuteScriptAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#executescriptasync)
-* [CoreWebView2.RemoveScriptToExecuteOnDocumentCreated Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#removescripttoexecuteondocumentcreated)
+* `CoreWebView2` Class
+   * [CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#addscripttoexecuteondocumentcreatedasync)
+   * [CoreWebView2.ExecuteScriptAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#executescriptasync)
+   * [CoreWebView2.RemoveScriptToExecuteOnDocumentCreated Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#removescripttoexecuteondocumentcreated)
 
 * [CoreWebView2Settings.IsScriptEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isscriptenabled)
 
@@ -160,9 +159,10 @@ Allows host app to add JavaScript in the web content within the WebView2 control
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::AddScriptToExecuteOnDocumentCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2#addscripttoexecuteondocumentcreated)
-* [ICoreWebView2::ExecuteScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#executescript)
-* [ICoreWebView2::RemoveScriptToExecuteOnDocumentCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2#removescripttoexecuteondocumentcreated)
+* `ICoreWebView2` interface
+   * [ICoreWebView2::AddScriptToExecuteOnDocumentCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2#addscripttoexecuteondocumentcreated)
+   * [ICoreWebView2::ExecuteScript method](/microsoft-edge/webview2/reference/win32/icorewebview2#executescript)
+   * [ICoreWebView2::RemoveScriptToExecuteOnDocumentCreated method](/microsoft-edge/webview2/reference/win32/icorewebview2#removescripttoexecuteondocumentcreated)
 
 * [ICoreWebView2Settings::IsScriptEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_isscriptenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_isscriptenabled)
 
@@ -178,42 +178,51 @@ Your app can send messages to the web content that's within the WebView2 control
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.PostWebMessageAsJson Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postwebmessageasjson)
-* [CoreWebView2.PostWebMessageAsString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postwebmessageasstring)
-* [CoreWebView2.WebMessageReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webmessagereceived)
-   * [CoreWebView2WebMessageReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs)
+* `CoreWebView2` Class
+   * [CoreWebView2.PostWebMessageAsJson Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postwebmessageasjson)
+   * [CoreWebView2.PostWebMessageAsString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.postwebmessageasstring)
+   * [CoreWebView2.WebMessageReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2.webmessagereceived)
+      * [CoreWebView2WebMessageReceivedEventArgs Class](/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs)
 
 * [CoreWebView2Settings.IsWebMessageEnabled Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.iswebmessageenabled)
 
-* [CoreWebView2Frame.PostWebMessageAsJson Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postwebmessageasjson)
-* [CoreWebView2Frame.PostWebMessageAsString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postwebmessageasstring)
-* [CoreWebView2Frame.WebMessageReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.webmessagereceived)
+* `CoreWebView2Frame` Class
+   * [CoreWebView2Frame.PostWebMessageAsJson Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postwebmessageasjson)
+   * [CoreWebView2Frame.PostWebMessageAsString Method](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.postwebmessageasstring)
+   * [CoreWebView2Frame.WebMessageReceived Event](/dotnet/api/microsoft.web.webview2.core.corewebview2frame.webmessagereceived)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.PostWebMessageAsJson Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#postwebmessageasjson)
-* [CoreWebView2.PostWebMessageAsString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#postwebmessageasstring)
-* [CoreWebView2.WebMessageReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webmessagereceived)
-   * [CoreWebView2WebMessageReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webmessagereceivedeventargs)
-
+* `CoreWebView2` Class
+   * [CoreWebView2.PostWebMessageAsJson Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#postwebmessageasjson)
+   * [CoreWebView2.PostWebMessageAsString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#postwebmessageasstring)
+   * [CoreWebView2.WebMessageReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#webmessagereceived)
+      * [CoreWebView2WebMessageReceivedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2webmessagereceivedeventargs)
+   
 * [CoreWebView2Settings.IsWebMessageEnabled Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#iswebmessageenabled)
 
-* [CoreWebView2Frame.PostWebMessageAsJson Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#postwebmessageasjson)
-* [CoreWebView2Frame.PostWebMessageAsString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#postwebmessageasstring)
-* [CoreWebView2Frame.WebMessageReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#webmessagereceived)
+* `CoreWebView2Frame` Class
+   * [CoreWebView2Frame.PostWebMessageAsJson Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#postwebmessageasjson)
+   * [CoreWebView2Frame.PostWebMessageAsString Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#postwebmessageasstring)
+   * [CoreWebView2Frame.WebMessageReceived Event](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2frame#webmessagereceived)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::PostWebMessageAsJson method](/microsoft-edge/webview2/reference/win32/icorewebview2#postwebmessageasjson)
-* [ICoreWebView2::PostWebMessageAsString method](/microsoft-edge/webview2/reference/win32/icorewebview2#postwebmessageasstring)
-* [ICoreWebView2::WebMessageReceived event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webmessagereceived), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webmessagereceived)
-   * [ICoreWebView2WebMessageReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs)
+* `ICoreWebView2` interface
+   * [ICoreWebView2::PostWebMessageAsJson method](/microsoft-edge/webview2/reference/win32/icorewebview2#postwebmessageasjson)
+   * [ICoreWebView2::PostWebMessageAsString method](/microsoft-edge/webview2/reference/win32/icorewebview2#postwebmessageasstring)
+   * [ICoreWebView2::add_WebMessageReceived](/microsoft-edge/webview2/reference/win32/icorewebview2#add_webmessagereceived)
+      * [ICoreWebView2WebMessageReceivedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2webmessagereceivedeventargs)
+   * [ICoreWebView2::remove_WebMessageReceived](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_webmessagereceived)
 
-* [ICoreWebView2Settings::IsWebMessageEnabled property (get](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iswebmessageenabled), [put)](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iswebmessageenabled)
+* [ICoreWebView2Settings::get_IsWebMessageEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#get_iswebmessageenabled)
+* [ICoreWebView2Settings::put_IsWebMessageEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings#put_iswebmessageenabled)
 
-* [ICoreWebView2Frame2::PostWebMessageAsJson method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#postwebmessageasjson)
-* [ICoreWebView2Frame2::PostWebMessageAsString method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#postwebmessageasstring)
-* [ICoreWebView2Frame2::WebMessageReceived event (add](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_webmessagereceived), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_webmessagereceived)
+* `ICoreWebView2Frame2` interface
+   * [ICoreWebView2Frame2::PostWebMessageAsJson method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#postwebmessageasjson)
+   * [ICoreWebView2Frame2::PostWebMessageAsString method](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#postwebmessageasstring)
+   * [ICoreWebView2Frame2::add_WebMessageReceived](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#add_webmessagereceived)
+   * [ICoreWebView2Frame2::remove_WebMessageReceived](/microsoft-edge/webview2/reference/win32/icorewebview2frame2#remove_webmessagereceived)
 
 ---
 
@@ -340,10 +349,11 @@ See also:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2.ShowPrintUI Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.showprintui#microsoft-web-webview2-core-corewebview2-showprintui)
-* [CoreWebView2.PrintAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printasync#microsoft-web-webview2-core-corewebview2-printasync)
-* [CoreWebView2.PrintToPdfAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync)
-* [CoreWebView2.PrintToPdfStreamAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfstreamasync#microsoft-web-webview2-core-corewebview2-printtopdfstreamasync)
+* `CoreWebView2` Class
+   * [CoreWebView2.ShowPrintUI Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.showprintui#microsoft-web-webview2-core-corewebview2-showprintui)
+   * [CoreWebView2.PrintAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printasync#microsoft-web-webview2-core-corewebview2-printasync)
+   * [CoreWebView2.PrintToPdfAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync)
+   * [CoreWebView2.PrintToPdfStreamAsync Method](/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfstreamasync#microsoft-web-webview2-core-corewebview2-printtopdfstreamasync)
 
 * [CoreWebView2Environment.CreatePrintSettings Method](/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createprintsettings)
 
@@ -355,10 +365,11 @@ See also:
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* [CoreWebView2.ShowPrintUI Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#showprintui)
-* [CoreWebView2.PrintAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printasync)
-* [CoreWebView2.PrintToPdfAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printtopdfasync)
-* [CoreWebView2.PrintToPdfStreamAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printtopdfstreamasync)
+* `CoreWebView2` Class
+   * [CoreWebView2.ShowPrintUI Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#showprintui)
+   * [CoreWebView2.PrintAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printasync)
+   * [CoreWebView2.PrintToPdfAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printtopdfasync)
+   * [CoreWebView2.PrintToPdfStreamAsync Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2#printtopdfstreamasync)
 
 * [CoreWebView2Environment.CreatePrintSettings Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment#createprintsettings)
 
@@ -373,7 +384,7 @@ See also:
 
 * [ICoreWebView2_7::PrintToPdf method](/microsoft-edge/webview2/reference/win32/icorewebview2_7#printtopdf)
 
-* `ICoreWebView2_16`
+* `ICoreWebView2_16` interface
    * [ICoreWebView2_16::ShowPrintUI method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#showprintui)
    * [ICoreWebView2_16::Print method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#print)
    * [ICoreWebView2_16::PrintToPdfStream method](/microsoft-edge/webview2/reference/win32/icorewebview2_16#printtopdfstream)
@@ -585,10 +596,12 @@ See also:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2::PermissionRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2#add_permissionrequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_permissionrequested)
+* [ICoreWebView2::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#add_permissionrequested)
    * [ICoreWebView2PermissionRequestedEventArgs interface](/microsoft-edge/webview2/reference/win32/icorewebview2permissionrequestedeventargs)
+* [ICoreWebView2::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2#remove_permissionrequested)
 
-* [ICoreWebView2Frame3::PermissionRequested event (add](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#add_permissionrequested), [remove)](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#remove_permissionrequested)
+* [ICoreWebView2Frame3::add_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#add_permissionrequested)
+* [ICoreWebView2Frame3::remove_PermissionRequested](/microsoft-edge/webview2/reference/win32/icorewebview2frame3#remove_permissionrequested)
 
 <!-- from RelNotes 111: -->
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -127,7 +127,7 @@ To help you evaluate the Experimental APIs and share your feedback, use the [Web
 
 ### Moving from Experimental APIs to Stable APIs
 
-Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs is not recommended for production apps, but it's okay to use Stable APIs (in a Prerelease SDK) in production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs:
+Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs or a Prerelease SDK is not recommended for production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs:
 
 *  In your project in Visual Studio, update your WebView2 SDK package version to a newer Prerelease SDK or Release SDK.  See [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -16,9 +16,9 @@ New APIs are introduced in phases as follows:
 
 | API status | Description |
 |---|---|
-| _Experimental APIs_ | Experimental APIs in a Prerelease SDK. |
-| _Stable APIs_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
-| _Release APIs_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
+| _Experimental_ | Experimental APIs in a Prerelease SDK. |
+| _Stable_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
+| _Release_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
 
 _Prerelease_ SDK packages are for use during development if you want to test the latest WebView2 APIs, including the experimental APIs, before support for those APIs is added to the Runtime.  The Canary channel is recommended, because it has the implementations of the latest APIs.  When you want to test and use experimental WebView2 APIs, use the following combination:
 *  A _Prerelease_ version of the WebView2 SDK.
@@ -101,9 +101,9 @@ As mentioned above, new APIs are introduced in phases as follows:
 
 | API status | Description |
 |---|---|
-| _Experimental APIs_ | Experimental APIs in a Prerelease SDK. |
-| _Stable APIs_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
-| _Release APIs_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
+| _Experimental_ | Experimental APIs in a Prerelease SDK. |
+| _Stable_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
+| _Release_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
 
 
 ### Developing with Experimental APIs and providing feedback

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -43,7 +43,12 @@ When developing an Evergreen WebView2 app, regularly test the app against the la
 
 When you use a WebView2 _Prerelease_ SDK package, use a Microsoft Edge preview channel on your development client.  Preview channels are also called _Insiders_ channels.  The Canary preview channel is recommended rather than Beta or Dev, because Canary is most recent and has implementations of the latest Experimental APIs.
 
-The _Prerelease_ SDK package is a superset of the _Release_ SDK package, with method signatures for additional, [Experimental APIs](#experimental-apis) and Stable APIs, which are no longer Experimental, but haven't been included in a Release SDK yet.  Preview channels of Microsoft Edge provide the implementations of the Experimental WebView2 APIs, and of Stable APIs.  The Experimental APIs are subject to change based on your feedback.  Avoid using a Prerelease SDK package to build production apps.
+The Prerelease SDK package is a superset of the Release SDK package.  A Prerelease SDK contains method signatures for:
+*  [Experimental APIs](#experimental-apis).
+*  Stable APIs that are no longer Experimental, but haven't been included in a Release SDK yet.
+*  Stable APIs that have been added to Release SDKs.
+
+Preview channels of Microsoft Edge provide the implementations of Experimental WebView2 APIs and of Stable APIs.  The Experimental APIs are subject to change based on feedback.  Avoid using a Prerelease SDK package to build production apps.
 
 For information about temporarily pointing your app to a preview channel instead of defaulting to the WebView2 Runtime, see [Test upcoming APIs and features](../how-to/set-preview-channel.md).
 
@@ -51,9 +56,9 @@ For information about temporarily pointing your app to a preview channel instead
 <!-- ====================================================================== -->
 ## Use a release version of the SDK along with the Runtime
 
-When you use a WebView2 SDK _release_ package, use the WebView2 Evergreen _Runtime_ on your development client, rather than a Microsoft Edge preview channel.  By default, a WebView2 app targets the Runtime rather than Microsoft Edge.  By design, the Microsoft Edge Stable channel doesn't support WebView2.
+When you use a WebView2 Release SDK package, use the WebView2 Evergreen _Runtime_ on your development client, rather than a Microsoft Edge preview channel.  By default, a WebView2 app targets the Runtime rather than Microsoft Edge.  By design, the Microsoft Edge Stable channel doesn't support WebView2.
 
-The SDK _release_ package contains all of the Stable Win32 C/C++ and .NET APIs, and doesn't include method signatures for Experimental APIs.  All of the APIs that are in a Release SDK package are fully supported, in an equal or higher build number of the WebView2 Runtime.
+The Release SDK package contains all of the Stable Win32 C/C++ and .NET APIs that are in production release, and doesn't include method signatures for Experimental APIs.  All of the APIs that are in a Release SDK package are fully supported, in an equal or higher build number of the WebView2 Runtime.
 
 The Release SDK package contains the following components:
 *  [Win32 C/C++ APIs](/microsoft-edge/webview2/reference/win32).
@@ -100,7 +105,7 @@ For full support for the latest APIs in a release version of the SDK, the Runtim
 <!-- ====================================================================== -->
 ## Experimental APIs
 
-To try out new forthcoming features that are in development, use _Experimental_ APIs.  Experimental APIs are contained in Prerelease versions of the WebView2 SDK, but not in Release versions of the WebView2 SDK.
+To try out new forthcoming features that are in development, use _Experimental_ APIs.  Experimental APIs are contained in Prerelease SDKs, but not in Release SDKs.
 
 As mentioned above, new APIs are introduced in phases as follows:
 
@@ -155,7 +160,7 @@ Once an API has been moved from Experimental to Stable status, you need to move 
 
 In the Evergreen distribution approach, the client's WebView2 Runtime automatically updates to the latest version available.  However, a user or IT admin might choose to prevent automatic updating of the WebView2 Runtime.  The resulting outdated Runtime on the client might cause compatibility issues with your updated WebView2 app that uses new APIs from a recent SDK.
 
-In case updating the WebView2 Runtime is prevented on the client, make sure that you know the minimum build number of the WebView2 Runtime that is required by your app.  See [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/).  The minimum required Runtime version to support the General Availability release of the SDK (build 616) is older than for the latest Runtime.  The latest Runtime supports all APIs that are in the latest SDK release build.
+In case updating the WebView2 Runtime is prevented on the client, make sure that you know the minimum build number of the WebView2 Runtime that is required by your app.  See [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/).  The minimum required Runtime version to support the General Availability release of the SDK (build 616) is older than for the latest Runtime.  The latest Runtime supports all APIs that are in the latest Release SDK.
 
 To check the compatibility between specific build numbers of the SDK and the Runtime or Microsoft Edge preview channel, see [Release Notes for the WebView2 SDK](../release-notes.md).
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -10,21 +10,26 @@ ms.date: 04/24/2023
 ---
 # Understand the different WebView2 SDK versions
 
-The NuGet package for the WebView2 SDK contains both a release and prerelease package.  Either use a prerelease SDK with a preview channel of Microsoft Edge, or use a release SDK with the WebView2 Runtime.
+The NuGet package for the WebView2 SDK contains both a Prerelease package and a Release package.<!--todo: true?  actually two separate NuGet packages?-->  Either use a Prerelease SDK with a preview channel of Microsoft Edge, or use a Release SDK with the WebView2 Runtime.
 
-New APIs are introduced in three phases, as follows:
+<!-- terminology:
+APIs are Experimental or Stable
+SDKs/packages are Prerelease or Release
+-->
+
+New APIs are introduced in phases as follows:
 
 | API status | Description |
 |---|---|
 | _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
-| _Stable_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
-| _Release_ | 3. Then the API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK.  |
+| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
 
-_Prerelease_ SDK packages are for use during development if you want to test the latest WebView2 APIs, including the experimental APIs, before support for those APIs is added to the Runtime.  The Canary channel is recommended, because it has the implementations of the latest APIs.  When you want to test and use experimental WebView2 APIs, use the following combination:
+_Prerelease_ SDK packages are for use during development if you want to test the latest WebView2 APIs, including the Experimental APIs, before support for those APIs is added to the Runtime.  The Canary channel is recommended, because it has the implementations of the latest APIs.  When you want to test and use Experimental WebView2 APIs, use the following combination:
 *  A _Prerelease_ version of the WebView2 SDK.
 *  A _preview channel_ of Microsoft Edge on your development client.
 
-_Release_ SDK packages only contain stable APIs, not Experimental APIs.  When you're working on a production release of your WebView2 app, use the following combination:
+_Release_ SDK packages only contain Stable APIs, not Experimental APIs.  When you're working on a production release of your WebView2 app, use the following combination:
 *  A _Release_ version of the WebView2 SDK.
 *  The WebView2 _Runtime_ on your development client.
 
@@ -38,7 +43,7 @@ When developing an Evergreen WebView2 app, regularly test the app against the la
 
 When you use a WebView2 _Prerelease_ SDK package, use a Microsoft Edge preview channel on your development client.  Preview channels are also called _Insiders_ channels.  The Canary preview channel is recommended rather than Beta or Dev, because Canary is most recent and has implementations of the latest Experimental APIs.
 
-The _Prerelease_ SDK package is a superset of the _Release_ SDK package, with method signatures for additional, [Experimental APIs](#experimental-apis) and Stable APIs, which are no longer Experimental, but haven't reached Release status yet.  Preview channels of Microsoft Edge provide the implementations of the Experimental WebView2 APIs, and of Stable APIs.  The Experimental APIs are subject to change based on your feedback.  Avoid using a Prerelease SDK package to build production apps.
+The _Prerelease_ SDK package is a superset of the _Release_ SDK package, with method signatures for additional, [Experimental APIs](#experimental-apis) and Stable APIs, which are no longer Experimental, but haven't been included in a Release SDK yet.  Preview channels of Microsoft Edge provide the implementations of the Experimental WebView2 APIs, and of Stable APIs.  The Experimental APIs are subject to change based on your feedback.  Avoid using a Prerelease SDK package to build production apps.
 
 For information about temporarily pointing your app to a preview channel instead of defaulting to the WebView2 Runtime, see [Test upcoming APIs and features](../how-to/set-preview-channel.md).
 
@@ -97,13 +102,13 @@ For full support for the latest APIs in a release version of the SDK, the Runtim
 
 To try out new forthcoming features that are in development, use _Experimental_ APIs.  Experimental APIs are contained in Prerelease versions of the WebView2 SDK, but not in Release versions of the WebView2 SDK.
 
-As mentioned above, new APIs are introduced in three phases, as follows:
+As mentioned above, new APIs are introduced in phases as follows:
 
 | API status | Description |
 |---|---|
 | _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
-| _Stable_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
-| _Release_ | 3. Then the API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK.  |
+| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
 
 
 <!-- ------------------------------ -->
@@ -111,17 +116,17 @@ As mentioned above, new APIs are introduced in three phases, as follows:
 
 The Experimental APIs in a WebView2 Prerelease SDK package aren't guaranteed to be forward-compatible, and might be removed in future Runtime updates.
 
-For full support of Experimental APIs, use a Microsoft Edge preview channel, not the WebView2 Evergreen Runtime.  When a _prerelease_ version of the WebView2 SDK is initially made available, that SDK only works with Microsoft Edge Canary.  Soon after that, the Prerelease SDK also works with the Beta and Dev channels.
+For full support of Experimental APIs, use a Microsoft Edge preview channel, not the WebView2 Evergreen Runtime.  When a Prerelease version of the WebView2 SDK is initially made available, that SDK only works with Microsoft Edge Canary.  Soon after that, the Prerelease SDK also works with the Beta and Dev channels.
 
 Use a Prerelease SDK to try out new, Experimental APIs early and provide feedback before the Experimental APIs are promoted to become Stable, forward-compatible APIs.
 
 *  The Experimental APIs (in a Prerelease SDK) aren't guaranteed to be forward-compatible.
-*  The Stable APIs (in a Prerelease SDK) are forward-compatible.
-*  The Release APIs (in a Release SDK) are also forward-compatible.
+*  The Stable APIs that are in a Prerelease SDK are forward-compatible, even if they aren't included in a Release SDK yet.
+*  The Stable APIs that are in a Release SDK are forward-compatible.
 
 For more information, see [Forward compatibility of APIs](#forward-compatibility-of-apis), above.
 
-The WebView2 team is seeking feedback on Experimental WebView2 APIs that might be promoted to Stable in future Prerelease SDKs (and then promoted to Release in Release SDKs).  The Experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
+The WebView2 team is seeking feedback on Experimental WebView2 APIs that might be promoted to Stable in future releases.  The Experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation, such as: "Note: This an experimental API that is shipped with our prerelease SDK."
 <!-- todo: "experimental" is missing from .NET API Ref:
 https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs.additionalobjects?view=webview2-dotnet-1.0.1724-prerelease&preserve-view=true
 Win32:

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -6,24 +6,11 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/24/2023
+ms.date: 04/25/2023
 ---
 # Understand the different WebView2 SDK versions
 
-The NuGet package for the WebView2 SDK contains both a Prerelease package and a Release package.<!--todo: true?  actually two separate NuGet packages?-->  Either use a Prerelease SDK with a preview channel of Microsoft Edge, or use a Release SDK with the WebView2 Runtime.
-
-<!-- terminology:
-APIs are Experimental or Stable
-SDKs/packages are Prerelease or Release
--->
-
-New APIs are introduced in phases as follows:
-
-| API status | Description |
-|---|---|
-| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
-| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
-| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
+The WebView2 SDK is provided as a Prerelease or Release version of the **Microsoft.Web.WebView2** NuGet package.  Either use a Prerelease SDK with a preview channel of Microsoft Edge, or use a Release SDK with the WebView2 Runtime.
 
 _Prerelease_ SDK packages are for use during development if you want to test the latest WebView2 APIs, including the Experimental APIs, before support for those APIs is added to the Runtime.  The Canary channel is recommended, because it has the implementations of the latest APIs.  When you want to test and use Experimental WebView2 APIs, use the following combination:
 *  A _Prerelease_ version of the WebView2 SDK.
@@ -33,7 +20,32 @@ _Release_ SDK packages only contain Stable APIs, not Experimental APIs.  When yo
 *  A _Release_ version of the WebView2 SDK.
 *  The WebView2 _Runtime_ on your development client.
 
-More detail about the Prerelease and Release SDK packages is provided below.
+More details about the Prerelease and Release SDK packages are provided below.
+
+
+<!-- ------------------------------ -->
+#### Phases of introducing APIs
+
+New APIs are introduced in phases as follows:
+
+| API status | Description |
+|---|---|
+| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
+| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
+
+<!-- terminology:
+APIs are Experimental or Stable
+SDKs/packages are Prerelease or Release
+-->
+
+
+<!-- ------------------------------ -->
+#### Selecting which type of SDK to use
+
+To select which version of WebView2 SDK NuGet package a Visual Studio project uses, in Visual Studio, right-click a project, select **Manage NuGet Packages**, select or clear the **Include prerelease** checkbox, select the **Microsoft.Web.WebView2** package, and then in the **Version** dropdown list, select a version of the **Microsoft.Web.WebView2** NuGet package.
+
+For details, see [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  You can also view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -119,14 +119,6 @@ For full support for the latest APIs in a release version of the SDK, the Runtim
 
 To try out new forthcoming features that are in development, use _Experimental_ APIs.  Experimental APIs are contained in Prerelease SDKs, but not in Release SDKs.
 
-As mentioned above, new APIs are introduced in phases as follows:
-
-| API status | Description |
-|---|---|
-| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
-| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
-| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
-
 
 <!-- ------------------------------ -->
 #### Developing with Experimental APIs and providing feedback

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -89,29 +89,35 @@ For full support for the latest APIs in a release version of the SDK, the Runtim
 
 To try out new forthcoming features that are in development, use experimental APIs.  Experimental APIs are contained in prerelease versions of the WebView2 SDK, but not in release versions of the WebView2 SDK.
 
+New APIs are introduced in phases as follows:
+
+1. Experimental in prerelease.
+1. Promoted to stable in prerelease.
+1. Promoted to stable in release; that is, promoted to release.
+
 
 ### Developing with experimental APIs and providing feedback
 
-The experimental APIs in a WebView2 SDK _prerelease_ package aren't guaranteed to be forward-compatible and might be removed in future Runtime updates.  When a _prerelease_ version of the WebView2 SDK is initially made available, that SDK only works with Microsoft Edge Canary.  Soon after that, the prerelease SDK also works with the Beta and Dev channels.  Use a prerelease SDK to try out new APIs early and provide feedback before the new APIs are promoted to become stable, forward-compatible APIs.
+The experimental APIs in a WebView2 SDK _prerelease_ package aren't guaranteed to be forward-compatible and might be removed in future Runtime updates.  When a _prerelease_ version of the WebView2 SDK is initially made available, that SDK only works with Microsoft Edge Canary.  Soon after that, the prerelease SDK also works with the Beta and Dev channels.  Use a prerelease SDK to try out new APIs early and provide feedback before the new APIs are promoted to become stable,<!-- todo: change "stable" to "prerelease stable" or to "release"? --> forward-compatible APIs.
 
 For full support of experimental APIs, use a Microsoft Edge preview channel, not the WebView2 Evergreen Runtime.  Any experimental APIs that are in a prerelease SDK aren't guaranteed to be forward-compatible.  The APIs that are in an SDK _release_ version are forward-compatible.  For more information, see [Forward compatibility of APIs](#forward-compatibility-of-apis), above.
 
-The WebView2 team is seeking feedback on experimental WebView2 APIs that might be promoted to Stable in future releases.  The experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
+The WebView2 team is seeking feedback on experimental WebView2 APIs that might be promoted to stable<!-- todo: change "stable" to "prerelease stable" or to "release"? --> in future releases.  The experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
 
 To help you evaluate the experimental APIs and share your feedback, use the [WebView2Feedback](https://github.com/MicrosoftEdge/WebViewFeedback) repo.
 
 
 ### Moving from experimental APIs to stable APIs
 
-Once an API has been moved from experimental to stable APIs, you need to move your app's code to the stable API.  Using experimental APIs is not recommended for production apps.  Follow these practices when moving your app from using experimental APIs to using stable APIs:
+Once an API has been moved from experimental to stable APIs, you need to move your app's code to the stable API.  Using experimental APIs is not recommended for production apps.  Follow these practices when moving your app from using experimental APIs to using stable<!-- todo: change "stable" to "prerelease stable" or to "release"? --> APIs:
 
 *  In your project in Visual Studio, update your WebView2 SDK package version.  See [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 
-*  Update your app's code to use stable APIs instead of experimental APIs (for COM).  The stable API will be supported with bug fixes, but the experimental API will be deprecated, and not available in the newer SDK.  After the release of an API as stable, the experimental version of that API is supported for two releases, in a deprecated state.  In subsequent versions of the SDK, experimental APIs might be modified, removed, or added.
+*  Update your app's code to use stable APIs instead of experimental APIs (for COM).  The stable API will be supported with bug fixes, but the experimental API will be deprecated, and not available in the newer SDK.  After the release<!-- todo: change "stable" to "prerelease stable" or to "release"? --> of an API as stable,<!-- todo: change "stable" to "prerelease stable" or to "release"? --> the experimental version of that API is supported for two releases, in a deprecated state.  In subsequent versions of the SDK, experimental APIs might be modified, removed, or added.
 
 *  Always use feature detection, to ensure that the stable API is implemented in the user's version of the WebView2 Runtime.  See [Feature-detecting to test whether the installed Runtime supports recently added APIs](#feature-detecting-to-test-whether-the-installed-runtime-supports-recently-added-apis), below.
 
-*  Note for .NET only: In a prerelease WebView2 SDK, the .NET stable APIs will fallback to the corresponding experimental APIs, if the user's WebView2 Runtime has only the experimental API implementation and doesn't have the stable API implementation.
+*  Note for .NET only: In a prerelease WebView2 SDK, the .NET stable<!-- todo: change "stable" to "prerelease stable" or to "release"? --> APIs will fallback to the corresponding experimental APIs, if the user's WebView2 Runtime has only the experimental API implementation and doesn't have the stable API implementation.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -144,11 +144,6 @@ Use a Prerelease SDK to try out new, Experimental APIs early and provide feedbac
 For more information, see [Forward compatibility of APIs](#forward-compatibility-of-apis), above.
 
 The WebView2 team is seeking feedback on Experimental WebView2 APIs that might be promoted to Stable in future releases.  The Experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation, such as: "Note: This an experimental API that is shipped with our prerelease SDK."
-<!-- todo: "experimental" is missing from .NET API Ref:
-https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs.additionalobjects?view=webview2-dotnet-1.0.1724-prerelease&preserve-view=true
-Win32:
-https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebmessagereceivedeventargs?view=webview2-1.0.1724-prerelease&preserve-view=true#get_additionalobjects
--->
 
 To help you evaluate the Experimental APIs and share your feedback, use the [WebView2Feedback](https://github.com/MicrosoftEdge/WebViewFeedback) repo.
 
@@ -172,7 +167,7 @@ Once an API has been moved from Experimental to Stable status, you need to move 
 
 In the Evergreen distribution approach, the client's WebView2 Runtime automatically updates to the latest version available.  However, a user or IT admin might choose to prevent automatic updating of the WebView2 Runtime.  The resulting outdated Runtime on the client might cause compatibility issues with your updated WebView2 app that uses new APIs from a recent SDK.
 
-In case updating the WebView2 Runtime is prevented on the client, make sure that you know the minimum build number of the WebView2 Runtime that is required by your app.  See [Microsoft Edge WebView2](https://developer.microsoft.com/microsoft-edge/webview2/).  The minimum required Runtime version to support the General Availability release of the SDK (build 616) is older than for the latest Runtime.  The latest Runtime supports all APIs that are in the latest Release SDK.
+In case updating the WebView2 Runtime is prevented on the client, make sure that you know the minimum build number of the WebView2 Runtime that is required by your app.  To view or get the latest WebView2 Runtime versions, see [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/#download-section) in the _Microsoft Edge WebView2_ page at developer.microsoft.com.  The minimum required Runtime version to support the General Availability release of the SDK (build 616) is older than for the latest Runtime.  The latest Runtime supports all APIs that are in the latest Release SDK.
 
 To check the compatibility between specific build numbers of the SDK and the Runtime or Microsoft Edge preview channel, see [Release Notes for the WebView2 SDK](../release-notes.md).
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -6,31 +6,39 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 08/03/2021
+ms.date: 04/21/2023
 ---
 # Understand the different WebView2 SDK versions
 
 The NuGet package for the WebView2 SDK contains both a release and prerelease package.  Either use a prerelease SDK with a preview channel of Microsoft Edge, or use a release SDK with the WebView2 Runtime.
 
+New APIs are introduced in phases as follows:
+
+| API status | Description |
+|---|---|
+| _Experimental APIs_ | Experimental APIs in a Prerelease SDK. |
+| _Stable APIs_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
+| _Release APIs_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
+
 _Prerelease_ SDK packages are for use during development if you want to test the latest WebView2 APIs, including the experimental APIs, before support for those APIs is added to the Runtime.  The Canary channel is recommended, because it has the implementations of the latest APIs.  When you want to test and use experimental WebView2 APIs, use the following combination:
-*  A _prerelease_ version of the WebView2 SDK.
+*  A _Prerelease_ version of the WebView2 SDK.
 *  A _preview channel_ of Microsoft Edge on your development client.
 
-_Release_ SDK packages only contain stable APIs, not experimental APIs.  When you're working on a production release of your WebView2 app, use the following combination:
-*  A _release_ version of the WebView2 SDK.
+_Release_ SDK packages only contain stable APIs, not Experimental APIs.  When you're working on a production release of your WebView2 app, use the following combination:
+*  A _Release_ version of the WebView2 SDK.
 *  The WebView2 _Runtime_ on your development client.
 
-More detail about the prerelease and release SDK packages is provided below.
+More detail about the Prerelease and Release SDK packages is provided below.
 
 
 <!-- ====================================================================== -->
-## Use a prerelease version of the SDK along with a preview channel of Microsoft Edge
+## Use a Prerelease version of the SDK along with a preview channel of Microsoft Edge
 
 When developing an Evergreen WebView2 app, regularly test the app against the latest Microsoft Edge preview channel, in addition to testing against the WebView2 Runtime.  Because the web platform is constantly evolving, regular testing is the best way to ensure your app will continue to work as intended.
 
-When you use a WebView2 SDK _prerelease_ package, use a Microsoft Edge preview channel on your development client.  Preview channels are also called _Insiders_ channels.  The Canary preview channel is recommended rather than Beta or Dev, because Canary is most recent and has implementations of the latest experimental APIs.
+When you use a WebView2 _Prerelease_ SDK package, use a Microsoft Edge preview channel on your development client.  Preview channels are also called _Insiders_ channels.  The Canary preview channel is recommended rather than Beta or Dev, because Canary is most recent and has implementations of the latest Experimental APIs.
 
-The SDK _prerelease_ package is a superset of the SDK release package, with method signatures for more, [Experimental APIs](#experimental-apis).  Preview channels provide the implementations of the experimental WebView2 APIs.  The experimental APIs are subject to change based on your feedback.  Avoid using the SDK prerelease package to build production apps.
+The _Prerelease_ SDK package is a superset of the _Release_ SDK package, with method signatures for additional, [Experimental APIs](#experimental-apis) and Stable APIs, which are no longer Experimental, but haven't reached Release status yet.  Preview channels of Microsoft Edge provide the implementations of the Experimental WebView2 APIs, and of Stable APIs.  The Experimental APIs are subject to change based on your feedback.  Avoid using a Prerelease SDK package to build production apps.
 
 For information about temporarily pointing your app to a preview channel instead of defaulting to the WebView2 Runtime, see [Test upcoming APIs and features](../how-to/set-preview-channel.md).
 
@@ -40,9 +48,9 @@ For information about temporarily pointing your app to a preview channel instead
 
 When you use a WebView2 SDK _release_ package, use the WebView2 Evergreen _Runtime_ on your development client, rather than a Microsoft Edge preview channel.  By default, a WebView2 app targets the Runtime rather than Microsoft Edge.  By design, the Microsoft Edge Stable channel doesn't support WebView2.
 
-The SDK _release_ package contains all of the stable Win32 C/C++ and .NET APIs, and doesn't include method signatures for experimental APIs.  All of the APIs that are in an SDK release package are fully supported, in an equal or higher build number of the WebView2 Runtime.
+The SDK _release_ package contains all of the Stable Win32 C/C++ and .NET APIs, and doesn't include method signatures for Experimental APIs.  All of the APIs that are in a Release SDK package are fully supported, in an equal or higher build number of the WebView2 Runtime.
 
-The SDK release package contains the following components:
+The Release SDK package contains the following components:
 *  [Win32 C/C++ APIs](/microsoft-edge/webview2/reference/win32).
 *  .NET APIs:  [WPF](/dotnet/api/microsoft.web.webview2.wpf), [WinForms](/dotnet/api/microsoft.web.webview2.winforms), and [Core](/dotnet/api/microsoft.web.webview2.core).
 
@@ -67,9 +75,9 @@ On a development machine, the client must have either the Microsoft Edge preview
 ## Forward compatibility of APIs
 
 The WebView2 _release_ SDK has been forward-compatible ever since version 1 (that is, SDK version [1.0.622.22](../release-notes.md#1062222)).
-You can update your WebView2 app to use the latest APIs from the most recent release version of the SDK.  Your app will continue to work on clients because clients automatically have the latest WebView2 Evergreen Runtime.
+You can update your WebView2 app to use the latest APIs from the most recent Release version of the SDK.  Your app will continue to work on clients because clients automatically have the latest WebView2 Evergreen Runtime.
 
-The WebView2 APIs in an SDK _release_ package are stable and forward-compatible.  A WebView2 API works when using a WebView2 Runtime that has an equal or higher build number as the SDK build number in which the API was introduced.  The build number is the third part of the four-part version number for the Webview2 SDK, and of the four-part version number for Microsoft Edge and the WebView2 Runtime.
+The WebView2 APIs in a Release SDK package are stable and forward-compatible.  A WebView2 API works when using a WebView2 Runtime that has an equal or higher build number as the SDK build number in which the API was introduced.  The build number is the third part of the four-part version number for the Webview2 SDK, and of the four-part version number for Microsoft Edge and the WebView2 Runtime.
 
 *  When you use a WebView2 SDK that has a build number _equal to or less than_ the WebView2 Runtime, every API that you have access to in that SDK works with that version of the Runtime.
 
@@ -87,37 +95,47 @@ For full support for the latest APIs in a release version of the SDK, the Runtim
 <!-- ====================================================================== -->
 ## Experimental APIs
 
-To try out new forthcoming features that are in development, use experimental APIs.  Experimental APIs are contained in prerelease versions of the WebView2 SDK, but not in release versions of the WebView2 SDK.
+To try out new forthcoming features that are in development, use _Experimental_ APIs.  Experimental APIs are contained in Prerelease versions of the WebView2 SDK, but not in Release versions of the WebView2 SDK.
 
-New APIs are introduced in phases as follows:
+As mentioned above, new APIs are introduced in phases as follows:
 
-1. Experimental in prerelease.
-1. Promoted to stable in prerelease.
-1. Promoted to stable in release; that is, promoted to release.
-
-
-### Developing with experimental APIs and providing feedback
-
-The experimental APIs in a WebView2 SDK _prerelease_ package aren't guaranteed to be forward-compatible and might be removed in future Runtime updates.  When a _prerelease_ version of the WebView2 SDK is initially made available, that SDK only works with Microsoft Edge Canary.  Soon after that, the prerelease SDK also works with the Beta and Dev channels.  Use a prerelease SDK to try out new APIs early and provide feedback before the new APIs are promoted to become stable,<!-- todo: change "stable" to "prerelease stable" or to "release"? --> forward-compatible APIs.
-
-For full support of experimental APIs, use a Microsoft Edge preview channel, not the WebView2 Evergreen Runtime.  Any experimental APIs that are in a prerelease SDK aren't guaranteed to be forward-compatible.  The APIs that are in an SDK _release_ version are forward-compatible.  For more information, see [Forward compatibility of APIs](#forward-compatibility-of-apis), above.
-
-The WebView2 team is seeking feedback on experimental WebView2 APIs that might be promoted to stable<!-- todo: change "stable" to "prerelease stable" or to "release"? --> in future releases.  The experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
-
-To help you evaluate the experimental APIs and share your feedback, use the [WebView2Feedback](https://github.com/MicrosoftEdge/WebViewFeedback) repo.
+| API status | Description |
+|---|---|
+| _Experimental APIs_ | Experimental APIs in a Prerelease SDK. |
+| _Stable APIs_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
+| _Release APIs_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
 
 
-### Moving from experimental APIs to stable APIs
+### Developing with Experimental APIs and providing feedback
 
-Once an API has been moved from experimental to stable APIs, you need to move your app's code to the stable API.  Using experimental APIs is not recommended for production apps.  Follow these practices when moving your app from using experimental APIs to using stable<!-- todo: change "stable" to "prerelease stable" or to "release"? --> APIs:
+The Experimental APIs in a WebView2 Prerelease SDK package aren't guaranteed to be forward-compatible, and might be removed in future Runtime updates.
+
+For full support of Experimental APIs, use a Microsoft Edge preview channel, not the WebView2 Evergreen Runtime.  When a _prerelease_ version of the WebView2 SDK is initially made available, that SDK only works with Microsoft Edge Canary.  Soon after that, the Prerelease SDK also works with the Beta and Dev channels.
+
+Use a Prerelease SDK to try out new APIs early and provide feedback before the Experimental APIs are promoted to become Stable, forward-compatible APIs (first in the Prerelease SDK and then in the Release SDK).
+
+*  The Experimental APIs that are in a Prerelease SDK aren't guaranteed to be forward-compatible.
+*  The Stable APIs that are in a Prerelease SDK are forward-compatible.
+*  The Release APIs, in a Release SDK, are forward-compatible.
+
+For more information, see [Forward compatibility of APIs](#forward-compatibility-of-apis), above.
+
+The WebView2 team is seeking feedback on Experimental WebView2 APIs that might be promoted to Stable in future Prerelease SDKs and then Release SDKs.  The Experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
+
+To help you evaluate the Experimental APIs and share your feedback, use the [WebView2Feedback](https://github.com/MicrosoftEdge/WebViewFeedback) repo.
+
+
+### Moving from Experimental APIs to Stable APIs
+
+Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs is not recommended for production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs (possibly in a Release SDK, and then in Release SDKs):
 
 *  In your project in Visual Studio, update your WebView2 SDK package version.  See [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 
-*  Update your app's code to use stable APIs instead of experimental APIs (for COM).  The stable API will be supported with bug fixes, but the experimental API will be deprecated, and not available in the newer SDK.  After the release<!-- todo: change "stable" to "prerelease stable" or to "release"? --> of an API as stable,<!-- todo: change "stable" to "prerelease stable" or to "release"? --> the experimental version of that API is supported for two releases, in a deprecated state.  In subsequent versions of the SDK, experimental APIs might be modified, removed, or added.
+*  Update your app's code to use Stable APIs instead of Experimental APIs (for COM).  The Stable API will be supported with bug fixes, but the Experimental API will be deprecated, and not available in the newer (Prerelease or Release) SDK.  After the promotion of an API to Stable, the Experimental version of that API is supported for two releases, in a deprecated state.  In subsequent versions of the Prerelease SDK, Experimental APIs might be modified, removed, or added.
 
-*  Always use feature detection, to ensure that the stable API is implemented in the user's version of the WebView2 Runtime.  See [Feature-detecting to test whether the installed Runtime supports recently added APIs](#feature-detecting-to-test-whether-the-installed-runtime-supports-recently-added-apis), below.
+*  Always use feature detection, to ensure that the Stable API is implemented in the user's version of the WebView2 Runtime.  See [Feature-detecting to test whether the installed Runtime supports recently added APIs](#feature-detecting-to-test-whether-the-installed-runtime-supports-recently-added-apis), below.
 
-*  Note for .NET only: In a prerelease WebView2 SDK, the .NET stable<!-- todo: change "stable" to "prerelease stable" or to "release"? --> APIs will fallback to the corresponding experimental APIs, if the user's WebView2 Runtime has only the experimental API implementation and doesn't have the stable API implementation.
+*  Note for .NET only: In a Prerelease WebView2 SDK, the .NET Stable APIs will fallback to the corresponding experimental APIs, if the user's WebView2 Runtime has only the Experimental API implementation and doesn't have the Stable API implementation.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -6,19 +6,19 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/21/2023
+ms.date: 04/24/2023
 ---
 # Understand the different WebView2 SDK versions
 
 The NuGet package for the WebView2 SDK contains both a release and prerelease package.  Either use a prerelease SDK with a preview channel of Microsoft Edge, or use a release SDK with the WebView2 Runtime.
 
-New APIs are introduced in phases as follows:
+New APIs are introduced in three phases, as follows:
 
 | API status | Description |
 |---|---|
-| _Experimental_ | Experimental APIs in a Prerelease SDK. |
-| _Stable_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
-| _Release_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
+| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
+| _Stable_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Release_ | 3. Then the API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK.  |
 
 _Prerelease_ SDK packages are for use during development if you want to test the latest WebView2 APIs, including the experimental APIs, before support for those APIs is added to the Runtime.  The Canary channel is recommended, because it has the implementations of the latest APIs.  When you want to test and use experimental WebView2 APIs, use the following combination:
 *  A _Prerelease_ version of the WebView2 SDK.
@@ -97,16 +97,17 @@ For full support for the latest APIs in a release version of the SDK, the Runtim
 
 To try out new forthcoming features that are in development, use _Experimental_ APIs.  Experimental APIs are contained in Prerelease versions of the WebView2 SDK, but not in Release versions of the WebView2 SDK.
 
-As mentioned above, new APIs are introduced in phases as follows:
+As mentioned above, new APIs are introduced in three phases, as follows:
 
 | API status | Description |
 |---|---|
-| _Experimental_ | Experimental APIs in a Prerelease SDK. |
-| _Stable_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
-| _Release_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
+| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
+| _Stable_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Release_ | 3. Then the API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK.  |
 
 
-### Developing with Experimental APIs and providing feedback
+<!-- ------------------------------ -->
+#### Developing with Experimental APIs and providing feedback
 
 The Experimental APIs in a WebView2 Prerelease SDK package aren't guaranteed to be forward-compatible, and might be removed in future Runtime updates.
 
@@ -121,11 +122,17 @@ Use a Prerelease SDK to try out new, Experimental APIs early and provide feedbac
 For more information, see [Forward compatibility of APIs](#forward-compatibility-of-apis), above.
 
 The WebView2 team is seeking feedback on Experimental WebView2 APIs that might be promoted to Stable in future Prerelease SDKs (and then promoted to Release in Release SDKs).  The Experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
+<!-- todo: "experimental" is missing from .NET API Ref:
+https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs.additionalobjects?view=webview2-dotnet-1.0.1724-prerelease&preserve-view=true
+Win32:
+https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2experimentalwebmessagereceivedeventargs?view=webview2-1.0.1724-prerelease&preserve-view=true#get_additionalobjects
+-->
 
 To help you evaluate the Experimental APIs and share your feedback, use the [WebView2Feedback](https://github.com/MicrosoftEdge/WebViewFeedback) repo.
 
 
-### Moving from Experimental APIs to Stable APIs
+<!-- ------------------------------ -->
+#### Moving from Experimental APIs to Stable APIs
 
 Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs or a Prerelease SDK is not recommended for production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs:
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -112,30 +112,30 @@ The Experimental APIs in a WebView2 Prerelease SDK package aren't guaranteed to 
 
 For full support of Experimental APIs, use a Microsoft Edge preview channel, not the WebView2 Evergreen Runtime.  When a _prerelease_ version of the WebView2 SDK is initially made available, that SDK only works with Microsoft Edge Canary.  Soon after that, the Prerelease SDK also works with the Beta and Dev channels.
 
-Use a Prerelease SDK to try out new APIs early and provide feedback before the Experimental APIs are promoted to become Stable, forward-compatible APIs (first in the Prerelease SDK and then in the Release SDK).
+Use a Prerelease SDK to try out new, Experimental APIs early and provide feedback before the Experimental APIs are promoted to become Stable, forward-compatible APIs.
 
-*  The Experimental APIs that are in a Prerelease SDK aren't guaranteed to be forward-compatible.
-*  The Stable APIs that are in a Prerelease SDK are forward-compatible.
-*  The Release APIs, in a Release SDK, are forward-compatible.
+*  The Experimental APIs (in a Prerelease SDK) aren't guaranteed to be forward-compatible.
+*  The Stable APIs (in a Prerelease SDK) are forward-compatible.
+*  The Release APIs (in a Release SDK) are also forward-compatible.
 
 For more information, see [Forward compatibility of APIs](#forward-compatibility-of-apis), above.
 
-The WebView2 team is seeking feedback on Experimental WebView2 APIs that might be promoted to Stable in future Prerelease SDKs and then Release SDKs.  The Experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
+The WebView2 team is seeking feedback on Experimental WebView2 APIs that might be promoted to Stable in future Prerelease SDKs (and then promoted to Release in Release SDKs).  The Experimental APIs are indicated as "experimental" in the WebView2 SDK Reference documentation.
 
 To help you evaluate the Experimental APIs and share your feedback, use the [WebView2Feedback](https://github.com/MicrosoftEdge/WebViewFeedback) repo.
 
 
 ### Moving from Experimental APIs to Stable APIs
 
-Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs is not recommended for production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs (possibly in a Release SDK, and then in Release SDKs):
+Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs is not recommended for production apps, but it's okay to use Stable APIs (in a Prerelease SDK) in production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs:
 
-*  In your project in Visual Studio, update your WebView2 SDK package version.  See [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
+*  In your project in Visual Studio, update your WebView2 SDK package version to a newer Prerelease SDK or Release SDK.  See [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 
-*  Update your app's code to use Stable APIs instead of Experimental APIs (for COM).  The Stable API will be supported with bug fixes, but the Experimental API will be deprecated, and not available in the newer (Prerelease or Release) SDK.  After the promotion of an API to Stable, the Experimental version of that API is supported for two releases, in a deprecated state.  In subsequent versions of the Prerelease SDK, Experimental APIs might be modified, removed, or added.
+*  Update your app's code to use Stable APIs instead of Experimental APIs (for COM).  The Stable API will be supported with bug fixes, but the Experimental API will be deprecated, and not available in the newer (Prerelease or Release) SDK.  After an API is promoted to Stable, the Experimental version of that API is supported for two releases of the Prerelease SDK, in a deprecated state.  In subsequent versions of the Prerelease SDK, Experimental APIs might be modified, removed, or added.
 
 *  Always use feature detection, to ensure that the Stable API is implemented in the user's version of the WebView2 Runtime.  See [Feature-detecting to test whether the installed Runtime supports recently added APIs](#feature-detecting-to-test-whether-the-installed-runtime-supports-recently-added-apis), below.
 
-*  Note for .NET only: In a Prerelease WebView2 SDK, the .NET Stable APIs will fallback to the corresponding experimental APIs, if the user's WebView2 Runtime has only the Experimental API implementation and doesn't have the Stable API implementation.
+*  Note for .NET only: In a Prerelease WebView2 SDK, the .NET Stable APIs will fallback to the corresponding Experimental APIs, if the user's WebView2 Runtime has only the Experimental API implementation and doesn't have the Stable API implementation.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -45,7 +45,7 @@ SDKs/packages are Prerelease or Release
 
 To select which version of WebView2 SDK NuGet package a Visual Studio project uses, in Visual Studio, right-click a project, select **Manage NuGet Packages**, select or clear the **Include prerelease** checkbox, select the **Microsoft.Web.WebView2** package, and then in the **Version** dropdown list, select a version of the **Microsoft.Web.WebView2** NuGet package.
 
-For details, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  You can also view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
+For details, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  You can also view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
 
 
 <!-- ====================================================================== -->
@@ -145,7 +145,7 @@ To help you evaluate the Experimental APIs and share your feedback, use the [Web
 
 Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs or a Prerelease SDK is not recommended for production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs:
 
-*  In your project in Visual Studio, update your WebView2 SDK package version to a newer Prerelease SDK or Release SDK.  See [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
+*  In your project in Visual Studio, update your WebView2 SDK package version to a newer Prerelease SDK or Release SDK.  See [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 
 *  Update your app's code to use Stable APIs instead of Experimental APIs (for COM).  The Stable API will be supported with bug fixes, but the Experimental API will be deprecated, and not available in the newer (Prerelease or Release) SDK.  After an API is promoted to Stable, the Experimental version of that API is supported for two releases of the Prerelease SDK, in a deprecated state.  In subsequent versions of the Prerelease SDK, Experimental APIs might be modified, removed, or added.
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -45,7 +45,7 @@ SDKs/packages are Prerelease or Release
 
 To select which version of WebView2 SDK NuGet package a Visual Studio project uses, in Visual Studio, right-click a project, select **Manage NuGet Packages**, select or clear the **Include prerelease** checkbox, select the **Microsoft.Web.WebView2** package, and then in the **Version** dropdown list, select a version of the **Microsoft.Web.WebView2** NuGet package.
 
-For details, see [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  You can also view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
+For details, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  You can also view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
 
 
 <!-- ====================================================================== -->
@@ -145,7 +145,7 @@ To help you evaluate the Experimental APIs and share your feedback, use the [Web
 
 Once an API has been moved from Experimental to Stable status, you need to move your app's code to the Stable API.  Using Experimental APIs or a Prerelease SDK is not recommended for production apps.  Follow these practices when moving your app from using Experimental APIs to using Stable APIs:
 
-*  In your project in Visual Studio, update your WebView2 SDK package version to a newer Prerelease SDK or Release SDK.  See [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
+*  In your project in Visual Studio, update your WebView2 SDK package version to a newer Prerelease SDK or Release SDK.  See [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 
 *  Update your app's code to use Stable APIs instead of Experimental APIs (for COM).  The Stable API will be supported with bug fixes, but the Experimental API will be deprecated, and not available in the newer (Prerelease or Release) SDK.  After an API is promoted to Stable, the Experimental version of that API is supported for two releases of the Prerelease SDK, in a deprecated state.  In subsequent versions of the Prerelease SDK, Experimental APIs might be modified, removed, or added.
 

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -226,7 +226,7 @@ Continue with the steps below.
 
 
 <!-- maintenance link; keep: main copy:
-[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
 ## Step 9 - Update or install the WebView2 SDK

--- a/microsoft-edge/webview2/get-started/win32.md
+++ b/microsoft-edge/webview2/get-started/win32.md
@@ -226,7 +226,7 @@ Continue with the steps below.
 
 
 <!-- maintenance link; keep: main copy:
-[Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
 ## Step 9 - Update or install the WebView2 SDK

--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -103,7 +103,7 @@ You now have an empty WinForms project that runs.  Next, set up the project to a
 
 
 <!-- maintenance link; keep: main copy:
-[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
 ## Step 4 - Install the WebView2 SDK

--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -103,7 +103,7 @@ You now have an empty WinForms project that runs.  Next, set up the project to a
 
 
 <!-- maintenance link; keep: main copy:
-[Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
 ## Step 4 - Install the WebView2 SDK

--- a/microsoft-edge/webview2/get-started/wpf.md
+++ b/microsoft-edge/webview2/get-started/wpf.md
@@ -194,7 +194,7 @@ If you are creating a WPF App (.NET Framework) project, do the following steps. 
 
 
 <!-- maintenance link; keep: main copy:
-[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
 ## Step 5 - Install the WebView2 SDK

--- a/microsoft-edge/webview2/get-started/wpf.md
+++ b/microsoft-edge/webview2/get-started/wpf.md
@@ -194,7 +194,7 @@ If you are creating a WPF App (.NET Framework) project, do the following steps. 
 
 
 <!-- maintenance link; keep: main copy:
-[Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 -->
 <!-- ====================================================================== -->
 ## Step 5 - Install the WebView2 SDK

--- a/microsoft-edge/webview2/how-to/machine-setup.md
+++ b/microsoft-edge/webview2/how-to/machine-setup.md
@@ -229,16 +229,22 @@ Install Visual Studio workloads if prompted.  When you open a `.sln` file from t
 <!--
 maintenance links; keep:
 Main, central copy:
-[Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 Secondary copies:
-[Install the WebView2 SDK](../get-started/win32.md#step-6---install-the-webview2-sdk) in _Get started with WebView2 in Win32 apps_
-[Install the WebView2 SDK](../get-started/winforms.md#step-3---install-the-webview2-sdk) in _Get started with WebView2 in WinForms apps_
-[Install the WebView2 SDK](../get-started/wpf.md#step-3---install-the-webview2-sdk) in _Get started with WebView2 in WPF apps_
-[Install the WebView2 SDK](../get-started/winui2.md#step-6---install-the-webview2-sdk) in _Get started with WebView2 in WinUI 2 (UWP) apps_
-[Install the WebView2 SDK](../get-started/winui.md#step-4---install-the-webview2-sdk) in _Get started with WebView2 in WinUI 3 (Windows App SDK) apps_
+[Install or update the WebView2 SDK](../get-started/win32.md#step-6---install-the-webview2-sdk) in _Get started with WebView2 in Win32 apps_
+[Install or update the WebView2 SDK](../get-started/winforms.md#step-3---install-the-webview2-sdk) in _Get started with WebView2 in WinForms apps_
+[Install or update the WebView2 SDK](../get-started/wpf.md#step-3---install-the-webview2-sdk) in _Get started with WebView2 in WPF apps_
+[Install or update the WebView2 SDK](../get-started/winui2.md#step-6---install-the-webview2-sdk) in _Get started with WebView2 in WinUI 2 (UWP) apps_
+[Install or update the WebView2 SDK](../get-started/winui.md#step-4---install-the-webview2-sdk) in _Get started with WebView2 in WinUI 3 (Windows App SDK) apps_
 -->
 <!-- ====================================================================== -->
-## Install the WebView2 SDK
+## Install or update the WebView2 SDK
+
+<!--
+condensed summary to possibly use elsewhere:
+To select which version of WebView2 SDK NuGet package a Visual Studio project uses, in Visual Studio, right-click a project, select **Manage NuGet Packages**, select or clear the **Include prerelease** checkbox, select the **Microsoft.Web.WebView2** package, and then in the **Version** dropdown list, select a version of the **Microsoft.Web.WebView2** NuGet package.
+-->
+
 
 The WebView2 SDK includes the WebView2 control, which is powered by Microsoft Edge, and enables you to embed web technologies (HTML, CSS, and JavaScript) in your native applications.
 
@@ -249,7 +255,7 @@ Instead of downloading the `Microsoft.Web.WebView2` SDK NuGet package from nuget
 The `Microsoft.Web.WebView2` SDK is available in Release and Prerelease versions.  To get started, a Release version is recommended.
 
 
-Install the WebView2 SDK, as follows:
+Install or update the Release or Prerelease WebView2 SDK, as follows:
 
 1. Open a `.sln` file in Visual Studio.  For example, open your local copy of [WebView2Samples.sln](https://github.com/MicrosoftEdge/WebView2Samples/blob/main/SampleApps/WebView2Samples.sln).  This repo's solution files require Visual Studio, not Visual Studio Code.
 
@@ -263,7 +269,7 @@ Install the WebView2 SDK, as follows:
 
 1. In the **NuGet** window, click the **Browse** tab.
 
-1. On the right of the search bar, clear the **Include prerelease** checkbox (unless you know that you want a prerelease version of the SDK).
+1. On the right of the search bar, clear the **Include prerelease** checkbox, or set it if you want a prerelease version of the SDK, which includes experimental APIs.
 
 1. In the search bar in the upper left, type **Microsoft.Web.WebView2**.
 

--- a/microsoft-edge/webview2/how-to/machine-setup.md
+++ b/microsoft-edge/webview2/how-to/machine-setup.md
@@ -284,6 +284,12 @@ See also:
 
 
 <!-- ====================================================================== -->
+## Updating the WebView2 Runtime
+
+To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](./concepts/distribution.md).
+
+
+<!-- ====================================================================== -->
 ## See also
 
 * [Cloning a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) - GitHub docs.

--- a/microsoft-edge/webview2/how-to/machine-setup.md
+++ b/microsoft-edge/webview2/how-to/machine-setup.md
@@ -229,7 +229,7 @@ Install Visual Studio workloads if prompted.  When you open a `.sln` file from t
 <!--
 maintenance links; keep:
 Main, central copy:
-[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_
+[Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_
 Secondary copies:
 [Install or update the WebView2 SDK](../get-started/win32.md#step-6---install-the-webview2-sdk) in _Get started with WebView2 in Win32 apps_
 [Install or update the WebView2 SDK](../get-started/winforms.md#step-3---install-the-webview2-sdk) in _Get started with WebView2 in WinForms apps_
@@ -292,7 +292,7 @@ See also:
 <!-- ====================================================================== -->
 ## Updating the WebView2 Runtime
 
-To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](./concepts/distribution.md).
+To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](../concepts/distribution.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -34,7 +34,7 @@ WebView2 shares code and binaries with the Microsoft Edge browser, and is releas
 
 *  To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](./concepts/distribution.md).  To view or get the latest WebView2 Runtime versions, see [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/#download-section) in the _Microsoft Edge WebView2_ page at developer.microsoft.com.
 
-*  To install or update the WebView2 SDK, see [Install or update the WebView2 SDK](./how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
+*  To install or update the WebView2 SDK, see [Install or update the WebView2 SDK](./how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -32,9 +32,9 @@ New APIs are introduced in phases as follows:
 
 | API status | Description |
 |---|---|
-| _Experimental APIs_ | Experimental APIs in a Prerelease SDK. |
-| _Stable APIs_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
-| _Release APIs_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
+| _Experimental_ | Experimental APIs in a Prerelease SDK. |
+| _Stable_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
+| _Release_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/21/2023
+ms.date: 04/24/2023
 ---
 # Release Notes for the WebView2 SDK
 
@@ -28,13 +28,13 @@ WebView2 shares code and binaries with the Microsoft Edge browser, and is releas
 <!-- ------------------------------ -->
 #### Phases of introducing APIs
 
-New APIs are introduced in phases as follows:
+New APIs are introduced in three phases, as follows:
 
 | API status | Description |
 |---|---|
-| _Experimental_ | Experimental APIs in a Prerelease SDK. |
-| _Stable_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
-| _Release_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
+| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
+| _Stable_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Release_ | 3. Then the API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK.  |
 
 
 <!-- ------------------------------ -->
@@ -104,7 +104,7 @@ WebView2 SDK 1.0.1722.32 is deprecated, and that package has been removed from t
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 <!-- ------------------------------ -->
@@ -167,13 +167,13 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ------------------------------ -->
 ###### Experimental features
 
-No experimental features are added in this prerelease.
+No experimental features are added in this Prerelease SDK.
 
 
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 <!-- ------------------------------ -->
@@ -260,7 +260,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 <!-- ------------------------------ -->
@@ -787,7 +787,7 @@ Add support for managing profile deletion:
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 <!-- ------------------------------ -->
@@ -838,7 +838,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 <!-- ------------------------------ -->
@@ -925,7 +925,7 @@ The above interface is currently being used for:
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 <!-- ------------------------------ -->
@@ -1028,7 +1028,7 @@ The following APIs have been promoted from Experimental to Stable.
    * [CoreWebView2ControllerOptions.ScriptLocale Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.scriptlocale?view=webview2-dotnet-1.0.1671-prerelease&preserve-view=true)
 
 Previous name in 1619-prerelease:
-* [CoreWebView2ControllerOptions.LocaleRegion Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.localeregion?view=webview2-dotnet-1.0.1619-prerelease&preserve-view=true)
+* [CoreWebView2ControllerOptions.LocaleRegion Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.localeregion?view=webview2-dotnet-1.0.1619-prerelease&preserve-view=true)<!--keep 1619-->
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
@@ -1036,7 +1036,7 @@ Previous name in 1619-prerelease:
    * [CoreWebView2ControllerOptions.ScriptLocale Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.1671-prerelease&preserve-view=true#scriptlocale)
 
 Previous name in 1619-prerelease:
-* [CoreWebView2ControllerOptions.LocaleRegion Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.1619-prerelease&preserve-view=true#localeregion)
+* [CoreWebView2ControllerOptions.LocaleRegion Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.1619-prerelease&preserve-view=true#localeregion)<!--keep 1619-->
 
 ##### [Win32/C++](#tab/win32cpp)
 
@@ -1045,8 +1045,8 @@ Previous name in 1619-prerelease:
    * [ICoreWebView2ControllerOptions2::put_ScriptLocale method](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions2?view=webview2-1.0.1671-prerelease&preserve-view=true#put_scriptlocale)
 
 Previous name in 1619-prerelease:
-* [ICoreWebView2ExperimentalControllerOptions::get_LocaleRegion method](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontrolleroptions?view=webview2-1.0.1619-prerelease&preserve-view=true#get_localeregion)
-* [ICoreWebView2ExperimentalControllerOptions::put_LocaleRegion method](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontrolleroptions?view=webview2-1.0.1619-prerelease&preserve-view=true#put_localeregion)
+* [ICoreWebView2ExperimentalControllerOptions::get_LocaleRegion method](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontrolleroptions?view=webview2-1.0.1619-prerelease&preserve-view=true#get_localeregion)<!--keep 1619-->
+* [ICoreWebView2ExperimentalControllerOptions::put_LocaleRegion method](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontrolleroptions?view=webview2-1.0.1619-prerelease&preserve-view=true#put_localeregion)<!--keep 1619-->
 
 ---
 
@@ -1083,7 +1083,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 <!-- ------------------------------ -->
@@ -1263,7 +1263,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 <!-- ------------------------------ -->
@@ -1408,7 +1408,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 <!-- ------------------------------ -->
@@ -1641,7 +1641,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 <!-- ------------------------------ -->
@@ -1817,7 +1817,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 *  The drag and drop API:
@@ -1836,10 +1836,10 @@ The following APIs have been promoted from Experimental to Stable.
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* [ICoreWebView2CompositionController3.DragEnter method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#dragenter)
-* [ICoreWebView2CompositionController3.DragLeave method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#dragleave)
-* [ICoreWebView2CompositionController3.DragOver method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#dragover)
-* [ICoreWebView2CompositionController3.Drop method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#drop)
+* [ICoreWebView2CompositionController3::DragEnter method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#dragenter)
+* [ICoreWebView2CompositionController3::DragLeave method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#dragleave)
+* [ICoreWebView2CompositionController3::DragOver method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#dragover)
+* [ICoreWebView2CompositionController3::Drop method](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller3?view=webview2-1.0.1369-prerelease&preserve-view=true#drop)
 
 ---
 
@@ -1871,7 +1871,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 * The Favicon API:
@@ -1986,7 +1986,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 *  Added `ContextMenuRequested`API to enable host app to create or modify their own context menu.
@@ -2019,7 +2019,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 * The Favicon API:
@@ -2077,7 +2077,7 @@ There is no corresponding prerelease package.
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 
 * The [Server Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_14?view=webview2-1.0.1245.22&preserve-view=true) which provides an option to trust the server's TLS certificate at the application level. It renders the page without prompting the user about TLS or providing the ability to cancel the web request.
@@ -2112,7 +2112,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 * Support for [multiple user profiles](/microsoft-edge/webview2/reference/win32/icorewebview2environment10?view=webview2-1.0.1210.39&preserve-view=true) in WebView2.
 
@@ -2135,7 +2135,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 * The [Server Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_14?view=webview2-1.0.1248-prerelease&preserve-view=true) which provides an option to trust the server's TLS certificate at the application level and render the page without prompting the user about TLS or providing the ability to cancel the web request.
 
@@ -2173,7 +2173,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 * The [CallDevToolsProtocolMethodForSession API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1185.39&preserve-view=true#calldevtoolsprotocolmethodforsession) that supports `sessionId` for CDP method calls.
 
@@ -2212,7 +2212,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 * Support for [multiple user profiles](/microsoft-edge/webview2/reference/win32/icorewebview2environment10?view=webview2-1.0.1222-prerelease&preserve-view=true) in WebView2.
 
@@ -2250,7 +2250,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *   The [BasicAuthentication API](/microsoft-edge/webview2/reference/win32/icorewebview2_10?view=webview2-1.0.1150.38&preserve-view=true) that enables developers to handle Basic HTTP Authentication request and response.
 
@@ -2272,7 +2272,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *    The [CallDevToolsProtocolMethodForSession API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1189-prerelease&preserve-view=true#calldevtoolsprotocolmethodforsession) that supports sessionId for CDP method calls.
 *   The [StatusBarText API](/microsoft-edge/webview2/reference/win32/icorewebview2_12?view=webview2-1.0.1189-prerelease&preserve-view=true):
@@ -2304,7 +2304,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *  The [AdditionalAllowedFrameAncestors API](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2?view=webview2-1.0.1108.44&preserve-view=true) that enable developers to provide additional allowed frame ancestors.
 
@@ -2344,7 +2344,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  Rename ICoreWebView2ClientCertificate to [ICoreWebView2Certificate](/microsoft-edge/webview2/reference/win32/icorewebview2certificate?view=webview2-1.0.1158-prerelease&preserve-view=true).
 *  New [APIs for iframes](/microsoft-edge/webview2/reference/win32/icorewebview2frame3?view=webview2-1.0.1158-prerelease&preserve-view=true):
@@ -2372,7 +2372,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *  The [Media API](/microsoft-edge/webview2/reference/win32/icorewebview2_8?view=webview2-1.0.1072.54&preserve-view=true#summary) that enables developers to mute/unmute media within WebView2.
 
@@ -2402,7 +2402,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  New [APIs for iframes](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalframe2?view=webview2-1.0.1133-prerelease&preserve-view=true):
    *  `PostWebMessageAsJson`
@@ -2447,7 +2447,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 #### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  The [Media API](/microsoft-edge/webview2/reference/win32/icorewebview2experimental9?view=webview2-1.0.1083-prerelease&preserve-view=true#summary) that enables developers to mute/unmute media within WebView2.
 *  The [Download Positioning and Anchoring API](/microsoft-edge/webview2/reference/win32/icorewebview2experimental11?view=webview2-1.0.1083-prerelease&preserve-view=true).  This API enables:
@@ -2533,7 +2533,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *  [PrintToPdf API](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1020.30&preserve-view=true#printtopdf).
 
@@ -2555,7 +2555,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *  [OpenTaskManagerWindow API](/microsoft-edge/webview2/reference/win32/icorewebview2_6?view=webview2-1.0.992.28&preserve-view=true#summary).
 *  [isSwipeNavigationEnabled property](/microsoft-edge/webview2/reference/win32/icorewebview2settings6?view=webview2-1.0.992.28&preserve-view=true#summary).
@@ -2630,7 +2630,7 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  `IsSwipeNavigationEnabled`
 *  `BrowserProcessExited`
@@ -2658,7 +2658,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *  [Client Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.961.33&preserve-view=true#add_clientcertificaterequested).
 
@@ -2700,7 +2700,7 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  [add_ClientCertificateRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.955-prerelease&preserve-view=true#add_clientcertificaterequested)
 
@@ -2732,7 +2732,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *  [add_FrameCreated](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902.49&preserve-view=true#add_framecreated).
 *  [get_IsGeneralAutofillEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings4?view=webview2-1.0.902.49&preserve-view=true#get_isgeneralautofillenabled).
@@ -2778,7 +2778,7 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  [Download API](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902-prerelease&preserve-view=true#add_downloadstarting).
 *  [PinchZoom API](/microsoft-edge/webview2/reference/win32/icorewebview2settings5?view=webview2-1.0.902-prerelease&preserve-view=true#get_ispinchzoomenabled).
@@ -2817,7 +2817,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
 *  [UserAgent API](/microsoft-edge/webview2/reference/win32/icorewebview2settings2?view=webview2-1.0.864.35&preserve-view=true#get_useragent)
 *  [AreBrowserkeysenabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings3?view=webview2-1.0.864.35&preserve-view=true#get_arebrowseracceleratorkeysenabled)
@@ -2912,7 +2912,7 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  [UserAgent](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived).
 
@@ -2949,15 +2949,13 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-<!-- todo: change version number in links to match heading? -->
+The following APIs have been promoted to Release.
 
-The following APIs have been promoted from Stable to Release.
-
-   *  [DPI support](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived) related APIs
+   *  [DPI support](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.774.44&preserve-view=true#add_webresourceresponsereceived) related APIs
    *  Visual hosting APIs
-   *  [SetVirtualHostNameToFolderMapping](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.790-prerelease&preserve-view=true#setvirtualhostnametofoldermapping)
-   *  [TrySuspend and Resume](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.790-prerelease&preserve-view=true#trysuspend)
-   *  [DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controller2?view=webview2-1.0.790-prerelease&preserve-view=true#get_defaultbackgroundcolor)
+   *  [SetVirtualHostNameToFolderMapping](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.774.44&preserve-view=true#setvirtualhostnametofoldermapping)
+   *  [TrySuspend and Resume](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.774.44&preserve-view=true#trysuspend)
+   *  [DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controller2?view=webview2-1.0.774.44&preserve-view=true#get_defaultbackgroundcolor)
 
 ###### Bug fixes
 
@@ -3007,7 +3005,7 @@ This prerelease version of the WebView2 SDK requires Microsoft Edge version 86.0
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  Visual Hosting APIs
 *  [SetVirtualHostNameToFolderMapping](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.790-prerelease&preserve-view=true#setvirtualhostnametofoldermapping)
@@ -3033,7 +3031,7 @@ This version of the WebView2 SDK requires WebView2 Runtime version 86.0.616.0 or
 
 ###### Promotions
 
-The following APIs have been promoted from Stable to Release.
+The following APIs have been promoted to Release.
 
    *  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
    *  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
@@ -3075,7 +3073,7 @@ This prerelease version of the WebView2 SDK requires Microsoft Edge version 86.0
 
 ###### Promotions
 
-The following APIs have been promoted from Experimental to Stable.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 *  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
 *  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
@@ -3306,8 +3304,8 @@ This version of the WebView2 SDK requires Microsoft Edge version 84.0.488.0 or h
 
 *  > [!IMPORTANT]
    > **Announcement**:  Moving forward, the WebView2 team releases two packages:
-   > * A Prerelease SDK package containing Experimental APIs (for you to try out), Stable (Prerelease) APIs, and Release (stable) APIs.
-   > * A Release SDK package that consists entirely of Release (stable) APIs (for your confidence).
+   > * A Prerelease SDK package containing Experimental APIs (for you to try out) and also APIs that have been promoted to Stable status.
+   > * A Release SDK package that consists entirely of APIs that have reached Stable status (for your confidence).
    >
    > To learn about the differences, see [Understanding browser versions and WebView2](concepts/versioning.md).
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/13/2023
+ms.date: 04/21/2023
 ---
 # Release Notes for the WebView2 SDK
 
@@ -14,7 +14,7 @@ The WebView2 team updates the [WebView2 SDK](https://www.nuget.org/packages/Micr
 
 Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).
 
-WebView2 changes may require an update to the Runtime, SDK, or both.  Most new APIs require both Runtime and SDK updates. Starting with the February 2023 release, the update requirement for each bug fix is indicated as follows:
+WebView2 changes may require an update to the Runtime, SDK, or both.  Most new APIs require both Runtime and SDK updates.  Starting with the February 2023 release, the update requirement for each bug fix is indicated as follows:
 
 | Indicator | Meaning |
 |---|---|
@@ -30,9 +30,11 @@ WebView2 shares code and binaries with the Microsoft Edge browser, and is releas
 
 New APIs are introduced in phases as follows:
 
-1. Experimental in prerelease.
-1. Promoted to stable in prerelease.
-1. Promoted to stable in release; that is, promoted to release.
+| API status | Description |
+|---|---|
+| _Experimental APIs_ | Experimental APIs in a Prerelease SDK. |
+| _Stable APIs_ | _Promoted to Stable_ means promoted from Experimental APIs to to Stable APIs in a Prerelease SDK.  Capital 'S' means Stable status in a Prerelease SDK. |
+| _Release APIs_ | _Promoted to Release_ means promoted from Stable APIs in a Prerelease SDK to stable APIs in a Release SDK. |
 
 
 <!-- ------------------------------ -->
@@ -40,7 +42,7 @@ New APIs are introduced in phases as follows:
 
 Make sure to re-compile your WebView2 app after updating the WebView2 SDK NuGet package.  The WebView2 team recommends the following:
 
-* Use the Canary preview channel of Microsoft Edge when you develop using a prerelease version of the WebView2 SDK package.  Canary is the recommended preview channel, because it ships at the fastest cadence and has the newest APIs.
+* Use the Canary preview channel of Microsoft Edge when you develop using a Prerelease version of the WebView2 SDK package.  Canary is the recommended preview channel, because it ships at the fastest cadence and has the newest APIs.
 
 * Use the Evergreen WebView2 Runtime when you use a release version of the WebView2 SDK package.
 
@@ -52,7 +54,7 @@ For more information, see [Matching the Runtime version with the SDK version](co
 
 To load WebView2, the minimum version of Microsoft Edge or the WebView2 Runtime is 86.0.616.0.  The minimum version to load WebView2 only changes when a breaking change occurs in the web platform.
 
-To use a prerelease SDK along with a Microsoft Edge preview channel, see [Test upcoming APIs and features](how-to/set-preview-channel.md).
+To use a Prerelease SDK along with a Microsoft Edge preview channel, see [Test upcoming APIs and features](how-to/set-preview-channel.md).
 
 <!-- maintenance notes: version # patterns to check:
 ## 1.0.####.##
@@ -102,7 +104,7 @@ WebView2 SDK 1.0.1722.32 is deprecated, and that package has been removed from t
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 <!-- ------------------------------ -->
@@ -171,7 +173,7 @@ No experimental features are added in this prerelease.
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 
 <!-- ------------------------------ -->
@@ -258,7 +260,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 <!-- ------------------------------ -->
@@ -785,7 +787,7 @@ Add support for managing profile deletion:
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 
 <!-- ------------------------------ -->
@@ -836,7 +838,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 <!-- ------------------------------ -->
@@ -923,7 +925,7 @@ The above interface is currently being used for:
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 
 <!-- ------------------------------ -->
@@ -1081,7 +1083,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 <!-- ------------------------------ -->
@@ -1261,7 +1263,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 
 <!-- ------------------------------ -->
@@ -1406,7 +1408,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 
 <!-- ------------------------------ -->
@@ -1639,7 +1641,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 <!-- ------------------------------ -->
@@ -1815,7 +1817,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 
 *  The drag and drop API:
@@ -1869,7 +1871,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 * The Favicon API:
@@ -1984,7 +1986,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 *  Added `ContextMenuRequested`API to enable host app to create or modify their own context menu.
@@ -2017,7 +2019,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 
 * The Favicon API:
@@ -2075,7 +2077,7 @@ There is no corresponding prerelease package.
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 
 * The [Server Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_14?view=webview2-1.0.1245.22&preserve-view=true) which provides an option to trust the server's TLS certificate at the application level. It renders the page without prompting the user about TLS or providing the ability to cancel the web request.
@@ -2110,7 +2112,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 * Support for [multiple user profiles](/microsoft-edge/webview2/reference/win32/icorewebview2environment10?view=webview2-1.0.1210.39&preserve-view=true) in WebView2.
 
@@ -2133,7 +2135,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 * The [Server Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_14?view=webview2-1.0.1248-prerelease&preserve-view=true) which provides an option to trust the server's TLS certificate at the application level and render the page without prompting the user about TLS or providing the ability to cancel the web request.
 
@@ -2171,7 +2173,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 * The [CallDevToolsProtocolMethodForSession API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1185.39&preserve-view=true#calldevtoolsprotocolmethodforsession) that supports `sessionId` for CDP method calls.
 
@@ -2210,7 +2212,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 * Support for [multiple user profiles](/microsoft-edge/webview2/reference/win32/icorewebview2environment10?view=webview2-1.0.1222-prerelease&preserve-view=true) in WebView2.
 
@@ -2248,7 +2250,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 *   The [BasicAuthentication API](/microsoft-edge/webview2/reference/win32/icorewebview2_10?view=webview2-1.0.1150.38&preserve-view=true) that enables developers to handle Basic HTTP Authentication request and response.
 
@@ -2270,7 +2272,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *    The [CallDevToolsProtocolMethodForSession API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1189-prerelease&preserve-view=true#calldevtoolsprotocolmethodforsession) that supports sessionId for CDP method calls.
 *   The [StatusBarText API](/microsoft-edge/webview2/reference/win32/icorewebview2_12?view=webview2-1.0.1189-prerelease&preserve-view=true):
@@ -2302,7 +2304,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 *  The [AdditionalAllowedFrameAncestors API](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2?view=webview2-1.0.1108.44&preserve-view=true) that enable developers to provide additional allowed frame ancestors.
 
@@ -2342,7 +2344,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  Rename ICoreWebView2ClientCertificate to [ICoreWebView2Certificate](/microsoft-edge/webview2/reference/win32/icorewebview2certificate?view=webview2-1.0.1158-prerelease&preserve-view=true).
 *  New [APIs for iframes](/microsoft-edge/webview2/reference/win32/icorewebview2frame3?view=webview2-1.0.1158-prerelease&preserve-view=true):
@@ -2370,7 +2372,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 *  The [Media API](/microsoft-edge/webview2/reference/win32/icorewebview2_8?view=webview2-1.0.1072.54&preserve-view=true#summary) that enables developers to mute/unmute media within WebView2.
 
@@ -2400,7 +2402,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  New [APIs for iframes](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalframe2?view=webview2-1.0.1133-prerelease&preserve-view=true):
    *  `PostWebMessageAsJson`
@@ -2445,7 +2447,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 #### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  The [Media API](/microsoft-edge/webview2/reference/win32/icorewebview2experimental9?view=webview2-1.0.1083-prerelease&preserve-view=true#summary) that enables developers to mute/unmute media within WebView2.
 *  The [Download Positioning and Anchoring API](/microsoft-edge/webview2/reference/win32/icorewebview2experimental11?view=webview2-1.0.1083-prerelease&preserve-view=true).  This API enables:
@@ -2531,7 +2533,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 *  [PrintToPdf API](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1020.30&preserve-view=true#printtopdf).
 
@@ -2553,7 +2555,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 *  [OpenTaskManagerWindow API](/microsoft-edge/webview2/reference/win32/icorewebview2_6?view=webview2-1.0.992.28&preserve-view=true#summary).
 *  [isSwipeNavigationEnabled property](/microsoft-edge/webview2/reference/win32/icorewebview2settings6?view=webview2-1.0.992.28&preserve-view=true#summary).
@@ -2628,7 +2630,7 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  `IsSwipeNavigationEnabled`
 *  `BrowserProcessExited`
@@ -2656,7 +2658,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 *  [Client Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.961.33&preserve-view=true#add_clientcertificaterequested).
 
@@ -2698,7 +2700,7 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  [add_ClientCertificateRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.955-prerelease&preserve-view=true#add_clientcertificaterequested)
 
@@ -2730,7 +2732,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
 *  [add_FrameCreated](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902.49&preserve-view=true#add_framecreated).
 *  [get_IsGeneralAutofillEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings4?view=webview2-1.0.902.49&preserve-view=true#get_isgeneralautofillenabled).
@@ -2776,12 +2778,12 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  [Download API](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902-prerelease&preserve-view=true#add_downloadstarting).
 *  [PinchZoom API](/microsoft-edge/webview2/reference/win32/icorewebview2settings5?view=webview2-1.0.902-prerelease&preserve-view=true#get_ispinchzoomenabled).
 *  [AddFrameCreated](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902-prerelease&preserve-view=true#add_framecreated).
-*  [AddHostObjectToScriptWithOrigins](/microsoft-edge/webview2/reference/win32/icorewebview2frame?view=webview2-1.0.902-prerelease&preserve-view=true#addhostobjecttoscriptwithorigins) API promoted to stable with iframe element support.
+*  [AddHostObjectToScriptWithOrigins](/microsoft-edge/webview2/reference/win32/icorewebview2frame?view=webview2-1.0.902-prerelease&preserve-view=true#addhostobjecttoscriptwithorigins) API promoted to Stable with iframe element support.
 *  [Autofill API](/microsoft-edge/webview2/reference/win32/icorewebview2settings4?view=webview2-1.0.902-prerelease&preserve-view=true#get_isgeneralautofillenabled).
    > [!NOTE]
    > There is no current API to delete the locally stored general autofill and password autosave information.  Please provide a control to delete the data, which will involve deleting the entire user data folder.
@@ -2815,10 +2817,10 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
-*  [UserAgent API](/microsoft-edge/webview2/reference/win32/icorewebview2settings2?view=webview2-1.0.864.35&preserve-view=true#get_useragent) is now stable.
-*  [AreBrowserkeysenabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings3?view=webview2-1.0.864.35&preserve-view=true#get_arebrowseracceleratorkeysenabled) is now stable.
+*  [UserAgent API](/microsoft-edge/webview2/reference/win32/icorewebview2settings2?view=webview2-1.0.864.35&preserve-view=true#get_useragent)
+*  [AreBrowserkeysenabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings3?view=webview2-1.0.864.35&preserve-view=true#get_arebrowseracceleratorkeysenabled)
 
 #### .NET
 
@@ -2910,7 +2912,7 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  [UserAgent](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived).
 
@@ -2949,7 +2951,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 <!-- todo: change version number in links to match heading? -->
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
    *  [DPI support](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived) related APIs
    *  Visual hosting APIs
@@ -3005,7 +3007,7 @@ This prerelease version of the WebView2 SDK requires Microsoft Edge version 86.0
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  Visual Hosting APIs
 *  [SetVirtualHostNameToFolderMapping](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.790-prerelease&preserve-view=true#setvirtualhostnametofoldermapping)
@@ -3031,7 +3033,7 @@ This version of the WebView2 SDK requires WebView2 Runtime version 86.0.616.0 or
 
 ###### Promotions
 
-The following APIs have been promoted from prerelease stable to release.
+The following APIs have been promoted from Stable to Release.
 
    *  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
    *  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
@@ -3073,7 +3075,7 @@ This prerelease version of the WebView2 SDK requires Microsoft Edge version 86.0
 
 ###### Promotions
 
-The following APIs have been promoted from experimental to prerelease stable.
+The following APIs have been promoted from Experimental to Stable.
 
 *  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
 *  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
@@ -3300,8 +3302,14 @@ This version of the WebView2 SDK requires Microsoft Edge version 84.0.488.0 or h
 *  > [!IMPORTANT]
    > **Announcement**:  Starting with the upcoming Microsoft Edge version 83, Evergreen WebView2 no longer targets the Stable browser channel.  Instead, it targets another set of binaries, branded Evergreen WebView2 Runtime, that you can chain-install through an installer that the WebView2 team is currently developing.  See [Distribute your app and the WebView2 Runtime](concepts/distribution.md).
 
+<!-- todo: review: -->
+
 *  > [!IMPORTANT]
-   > **Announcement**:  Moving forward, the WebView2 team releases two packages:  a prerelease package with experimental APIs (for you to try out) and a stable release package with stable APIs (for your confidence).  To learn about the differences, see [Understanding browser versions and WebView2](concepts/versioning.md).
+   > **Announcement**:  Moving forward, the WebView2 team releases two packages:
+   > * A Prerelease SDK package containing Experimental APIs (for you to try out), Stable (Prerelease) APIs, and Release (stable) APIs.
+   > * A Release SDK package that consists entirely of Release (stable) APIs (for your confidence).
+   >
+   > To learn about the differences, see [Understanding browser versions and WebView2](concepts/versioning.md).
 
 *  > [!IMPORTANT]
    > **Breaking Change**:  In order to ensure the WebView2 API aligns with the Windows API naming conventions, the WebView2 team updated the names of the following interfaces.

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -14,6 +14,11 @@ The WebView2 team updates the [WebView2 SDK](https://www.nuget.org/packages/Micr
 
 Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).
 
+<!-- terminology:
+APIs are Experimental or Stable
+SDKs/packages are Prerelease or Release
+-->
+
 WebView2 changes may require an update to the Runtime, SDK, or both.  Most new APIs require both Runtime and SDK updates.  Starting with the February 2023 release, the update requirement for each bug fix is indicated as follows:
 
 | Indicator | Meaning |
@@ -28,13 +33,13 @@ WebView2 shares code and binaries with the Microsoft Edge browser, and is releas
 <!-- ------------------------------ -->
 #### Phases of introducing APIs
 
-New APIs are introduced in three phases, as follows:
+New APIs are introduced in phases as follows:
 
 | API status | Description |
 |---|---|
 | _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
-| _Stable_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
-| _Release_ | 3. Then the API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK.  |
+| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
 
 
 <!-- ------------------------------ -->
@@ -104,7 +109,7 @@ WebView2 SDK 1.0.1722.32 is deprecated, and that package has been removed from t
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 <!-- ------------------------------ -->
@@ -260,7 +265,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 <!-- ------------------------------ -->
@@ -838,7 +843,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 <!-- ------------------------------ -->
@@ -1083,7 +1088,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 <!-- ------------------------------ -->
@@ -1641,7 +1646,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 <!-- ------------------------------ -->
@@ -1871,7 +1876,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 * The Favicon API:
@@ -1986,7 +1991,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 *  Added `ContextMenuRequested`API to enable host app to create or modify their own context menu.
@@ -2077,7 +2082,7 @@ There is no corresponding prerelease package.
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 * The [Server Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_14?view=webview2-1.0.1245.22&preserve-view=true) which provides an option to trust the server's TLS certificate at the application level. It renders the page without prompting the user about TLS or providing the ability to cancel the web request.
@@ -2112,7 +2117,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 * Support for [multiple user profiles](/microsoft-edge/webview2/reference/win32/icorewebview2environment10?view=webview2-1.0.1210.39&preserve-view=true) in WebView2.
 
@@ -2173,7 +2178,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 * The [CallDevToolsProtocolMethodForSession API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1185.39&preserve-view=true#calldevtoolsprotocolmethodforsession) that supports `sessionId` for CDP method calls.
 
@@ -2250,7 +2255,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *   The [BasicAuthentication API](/microsoft-edge/webview2/reference/win32/icorewebview2_10?view=webview2-1.0.1150.38&preserve-view=true) that enables developers to handle Basic HTTP Authentication request and response.
 
@@ -2304,7 +2309,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *  The [AdditionalAllowedFrameAncestors API](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2?view=webview2-1.0.1108.44&preserve-view=true) that enable developers to provide additional allowed frame ancestors.
 
@@ -2372,7 +2377,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *  The [Media API](/microsoft-edge/webview2/reference/win32/icorewebview2_8?view=webview2-1.0.1072.54&preserve-view=true#summary) that enables developers to mute/unmute media within WebView2.
 
@@ -2533,7 +2538,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *  [PrintToPdf API](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1020.30&preserve-view=true#printtopdf).
 
@@ -2555,7 +2560,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *  [OpenTaskManagerWindow API](/microsoft-edge/webview2/reference/win32/icorewebview2_6?view=webview2-1.0.992.28&preserve-view=true#summary).
 *  [isSwipeNavigationEnabled property](/microsoft-edge/webview2/reference/win32/icorewebview2settings6?view=webview2-1.0.992.28&preserve-view=true#summary).
@@ -2658,7 +2663,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *  [Client Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.961.33&preserve-view=true#add_clientcertificaterequested).
 
@@ -2732,7 +2737,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *  [add_FrameCreated](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902.49&preserve-view=true#add_framecreated).
 *  [get_IsGeneralAutofillEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings4?view=webview2-1.0.902.49&preserve-view=true#get_isgeneralautofillenabled).
@@ -2817,7 +2822,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 *  [UserAgent API](/microsoft-edge/webview2/reference/win32/icorewebview2settings2?view=webview2-1.0.864.35&preserve-view=true#get_useragent)
 *  [AreBrowserkeysenabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings3?view=webview2-1.0.864.35&preserve-view=true#get_arebrowseracceleratorkeysenabled)
@@ -2949,7 +2954,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
    *  [DPI support](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.774.44&preserve-view=true#add_webresourceresponsereceived) related APIs
    *  Visual hosting APIs
@@ -3031,7 +3036,7 @@ This version of the WebView2 SDK requires WebView2 Runtime version 86.0.616.0 or
 
 ###### Promotions
 
-The following APIs have been promoted to Release.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
    *  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
    *  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
@@ -3300,11 +3305,9 @@ This version of the WebView2 SDK requires Microsoft Edge version 84.0.488.0 or h
 *  > [!IMPORTANT]
    > **Announcement**:  Starting with the upcoming Microsoft Edge version 83, Evergreen WebView2 no longer targets the Stable browser channel.  Instead, it targets another set of binaries, branded Evergreen WebView2 Runtime, that you can chain-install through an installer that the WebView2 team is currently developing.  See [Distribute your app and the WebView2 Runtime](concepts/distribution.md).
 
-<!-- todo: review: -->
-
 *  > [!IMPORTANT]
    > **Announcement**:  Moving forward, the WebView2 team releases two packages:
-   > * A Prerelease SDK package containing Experimental APIs (for you to try out) and also APIs that have been promoted to Stable status.
+   > * A Prerelease SDK package containing Experimental APIs (for you to try out), and also APIs that have been promoted to Stable status.
    > * A Release SDK package that consists entirely of APIs that have reached Stable status (for your confidence).
    >
    > To learn about the differences, see [Understanding browser versions and WebView2](concepts/versioning.md).

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -34,15 +34,7 @@ WebView2 shares code and binaries with the Microsoft Edge browser, and is releas
 
 *  To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](./concepts/distribution.md).  To view or get the latest WebView2 Runtime versions, see [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/#download-section) in the _Microsoft Edge WebView2_ page at developer.microsoft.com.
 
-*  To update the WebView2 SDK, see [Selecting which type of SDK to use](#selecting-which-type-of-sdk-to-use), below.
-
-
-<!-- ------------------------------ -->
-#### Selecting which type of SDK to use
-
-To select which version of WebView2 SDK NuGet package a Visual Studio project uses, in Visual Studio, right-click a project, select **Manage NuGet Packages**, select or clear the **Include prerelease** checkbox, select the **Microsoft.Web.WebView2** package, and then in the **Version** dropdown list, select a version of the **Microsoft.Web.WebView2** NuGet package.
-
-For details, see [Install the WebView2 SDK](./how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  You can also view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
+*  To install or update the WebView2 SDK, see [Install or update the WebView2 SDK](./how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.
 
 
 <!-- ------------------------------ -->
@@ -91,6 +83,11 @@ Async methods:
 
 <!-- ------------------------------ -->
 #### Phases of introducing APIs
+
+<!-- todo: duplicated information across various pages:
+experimental/stable in prerelease/stable in release table
+selecting what SDK to use
+-->
 
 New APIs are introduced in phases as follows:
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -10,11 +10,11 @@ ms.date: 04/13/2023
 ---
 # Release Notes for the WebView2 SDK
 
-The WebView2 team updates the [WebView2 SDK](https://www.nuget.org/packages/Microsoft.Web.WebView2) on a four-week cadence. This article contains the latest information on product announcements, additions, modifications, and breaking changes to the APIs.
+The WebView2 team updates the [WebView2 SDK](https://www.nuget.org/packages/Microsoft.Web.WebView2) on a four-week cadence.  This article contains the latest information on product announcements, additions, modifications, and breaking changes to the APIs.
 
 Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).
 
-WebView2 changes may require an update to the Runtime, SDK, or both. Most new APIs require both Runtime and SDK updates. Starting with the February 2023 release, the update requirement for each bug fix is indicated as follows:
+WebView2 changes may require an update to the Runtime, SDK, or both.  Most new APIs require both Runtime and SDK updates. Starting with the February 2023 release, the update requirement for each bug fix is indicated as follows:
 
 | Indicator | Meaning |
 |---|---|
@@ -22,7 +22,17 @@ WebView2 changes may require an update to the Runtime, SDK, or both. Most new AP
 | **Runtime-only** | Only the Runtime needs to be updated. |
 | **SDK-only** | Only the SDK needs to be updated. |
 
-WebView2 shares code and binaries with the Microsoft Edge browser, and is released around the same time. As a result, WebView2 Runtime releases generally also include Microsoft Edge updates. For Microsoft Edge updates, see [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Beta Channel](/deployedge/microsoft-edge-relnote-beta-channel).
+WebView2 shares code and binaries with the Microsoft Edge browser, and is released around the same time.  As a result, WebView2 Runtime releases generally also include Microsoft Edge updates.  For Microsoft Edge updates, see [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Beta Channel](/deployedge/microsoft-edge-relnote-beta-channel).
+
+
+<!-- ------------------------------ -->
+#### Phases of introducing APIs
+
+New APIs are introduced in phases as follows:
+
+1. Experimental in prerelease.
+1. Promoted to stable in prerelease.
+1. Promoted to stable in release; that is, promoted to release.
 
 
 <!-- ------------------------------ -->
@@ -92,7 +102,7 @@ WebView2 SDK 1.0.1722.32 is deprecated, and that package has been removed from t
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following items are now stable.
+The following APIs have been promoted from prerelease stable to release.
 
 
 <!-- ------------------------------ -->
@@ -161,7 +171,7 @@ No experimental features are added in this prerelease.
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK.
+The following APIs have been promoted from experimental to prerelease stable.
 
 
 <!-- ------------------------------ -->
@@ -248,7 +258,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following items are now stable.
+The following APIs have been promoted from prerelease stable to release.
 
 
 <!-- ------------------------------ -->
@@ -775,7 +785,7 @@ Add support for managing profile deletion:
 <!-- ------------------------------ -->
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK.
+The following APIs have been promoted from experimental to prerelease stable.
 
 
 <!-- ------------------------------ -->
@@ -826,8 +836,10 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following items are now stable.
+The following APIs have been promoted from prerelease stable to release.
 
+
+<!-- ------------------------------ -->
 *  Additional options used to create a WebView2 Environment to manage custom scheme registration:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
@@ -911,7 +923,7 @@ The above interface is currently being used for:
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK.
+The following APIs have been promoted from experimental to prerelease stable.
 
 
 <!-- ------------------------------ -->
@@ -1069,7 +1081,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
 
 
 <!-- ------------------------------ -->
@@ -1249,7 +1261,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
 
 <!-- ------------------------------ -->
@@ -1394,8 +1406,10 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
+
+<!-- ------------------------------ -->
 *  Added support for the Print API:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
@@ -1625,8 +1639,10 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 <!-- ---------- -->
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
 
+
+<!-- ------------------------------ -->
 *  The drag and drop API:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
@@ -1799,7 +1815,8 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 <!-- ---------- -->
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from experimental to prerelease stable.
+
 
 *  The drag and drop API:
 
@@ -1852,7 +1869,8 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
+
 
 * The Favicon API:
 
@@ -1966,7 +1984,8 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
+
 
 *  Added `ContextMenuRequested`API to enable host app to create or modify their own context menu.
 
@@ -1998,7 +2017,8 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
+
 
 * The Favicon API:
 
@@ -2055,7 +2075,8 @@ There is no corresponding prerelease package.
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
+
 
 * The [Server Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_14?view=webview2-1.0.1245.22&preserve-view=true) which provides an option to trust the server's TLS certificate at the application level. It renders the page without prompting the user about TLS or providing the ability to cancel the web request.
 
@@ -2089,7 +2110,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
 
 * Support for [multiple user profiles](/microsoft-edge/webview2/reference/win32/icorewebview2environment10?view=webview2-1.0.1210.39&preserve-view=true) in WebView2.
 
@@ -2112,7 +2133,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
 * The [Server Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_14?view=webview2-1.0.1248-prerelease&preserve-view=true) which provides an option to trust the server's TLS certificate at the application level and render the page without prompting the user about TLS or providing the ability to cancel the web request.
 
@@ -2150,7 +2171,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
 
 * The [CallDevToolsProtocolMethodForSession API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1185.39&preserve-view=true#calldevtoolsprotocolmethodforsession) that supports `sessionId` for CDP method calls.
 
@@ -2189,7 +2210,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
 * Support for [multiple user profiles](/microsoft-edge/webview2/reference/win32/icorewebview2environment10?view=webview2-1.0.1222-prerelease&preserve-view=true) in WebView2.
 
@@ -2227,7 +2248,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
 
 *   The [BasicAuthentication API](/microsoft-edge/webview2/reference/win32/icorewebview2_10?view=webview2-1.0.1150.38&preserve-view=true) that enables developers to handle Basic HTTP Authentication request and response.
 
@@ -2249,7 +2270,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
 *    The [CallDevToolsProtocolMethodForSession API](/microsoft-edge/webview2/reference/win32/icorewebview2_11?view=webview2-1.0.1189-prerelease&preserve-view=true#calldevtoolsprotocolmethodforsession) that supports sessionId for CDP method calls.
 *   The [StatusBarText API](/microsoft-edge/webview2/reference/win32/icorewebview2_12?view=webview2-1.0.1189-prerelease&preserve-view=true):
@@ -2281,10 +2302,12 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
 
 *  The [AdditionalAllowedFrameAncestors API](/microsoft-edge/webview2/reference/win32/icorewebview2navigationstartingeventargs2?view=webview2-1.0.1108.44&preserve-view=true) that enable developers to provide additional allowed frame ancestors.
+
 *  The [ProcessInfo APIs](/microsoft-edge/webview2/reference/win32/icorewebview2processinfo?view=webview2-1.0.1108.44&preserve-view=true) provide more information about WebView2 processes and process collections.
+
 *  New [APIs for iframes](/microsoft-edge/webview2/reference/win32/icorewebview2frame2?view=webview2-1.0.1108.44&preserve-view=true&preserve-view=true):
    *  `add_NavigationStarting`
    *  `remove_NavigationStarting`
@@ -2319,7 +2342,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
 *  Rename ICoreWebView2ClientCertificate to [ICoreWebView2Certificate](/microsoft-edge/webview2/reference/win32/icorewebview2certificate?view=webview2-1.0.1158-prerelease&preserve-view=true).
 *  New [APIs for iframes](/microsoft-edge/webview2/reference/win32/icorewebview2frame3?view=webview2-1.0.1158-prerelease&preserve-view=true):
@@ -2347,9 +2370,10 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
 
 *  The [Media API](/microsoft-edge/webview2/reference/win32/icorewebview2_8?view=webview2-1.0.1072.54&preserve-view=true#summary) that enables developers to mute/unmute media within WebView2.
+
 *  The [Download Positioning and Anchoring API](/microsoft-edge/webview2/reference/win32/icorewebview2_9?view=webview2-1.0.1072.54&preserve-view=true) enables:
    *  Changing the position of the download dialog, relative to the WebView2 bounds.  You can anchor the download dialog to the **Download** button, instead of the default position, which is the top-right corner.
    *  Programmatically open and close the default download dialog.
@@ -2376,7 +2400,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
 *  New [APIs for iframes](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalframe2?view=webview2-1.0.1133-prerelease&preserve-view=true):
    *  `PostWebMessageAsJson`
@@ -2421,7 +2445,7 @@ For full API compatibility, this version of the WebView2 SDK requires Microsoft 
 
 #### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
 
 *  The [Media API](/microsoft-edge/webview2/reference/win32/icorewebview2experimental9?view=webview2-1.0.1083-prerelease&preserve-view=true#summary) that enables developers to mute/unmute media within WebView2.
 *  The [Download Positioning and Anchoring API](/microsoft-edge/webview2/reference/win32/icorewebview2experimental11?view=webview2-1.0.1083-prerelease&preserve-view=true).  This API enables:
@@ -2507,7 +2531,8 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
+
 *  [PrintToPdf API](/microsoft-edge/webview2/reference/win32/icorewebview2_7?view=webview2-1.0.1020.30&preserve-view=true#printtopdf).
 
 
@@ -2528,7 +2553,8 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
+
 *  [OpenTaskManagerWindow API](/microsoft-edge/webview2/reference/win32/icorewebview2_6?view=webview2-1.0.992.28&preserve-view=true#summary).
 *  [isSwipeNavigationEnabled property](/microsoft-edge/webview2/reference/win32/icorewebview2settings6?view=webview2-1.0.992.28&preserve-view=true#summary).
 *  [BrowserProcessExited API](/microsoft-edge/webview2/reference/win32/icorewebview2browserprocessexitedeventargs?view=webview2-1.0.992.28&preserve-view=true#summary).
@@ -2602,7 +2628,8 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-The following APIs are promoted to stable in this prerelease SDK:
+The following APIs have been promoted from experimental to prerelease stable.
+
 *  `IsSwipeNavigationEnabled`
 *  `BrowserProcessExited`
 *  `OpenBrowserTaskManager`
@@ -2629,7 +2656,8 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now stable:
+The following APIs have been promoted from prerelease stable to release.
+
 *  [Client Certificate API](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.961.33&preserve-view=true#add_clientcertificaterequested).
 
 
@@ -2669,7 +2697,10 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 *  Fixed bug where the title bar on the default pop-up wasn't displayed completely. This change is Runtime-specific. ([Issue #1016](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1016))
 
 ###### Promotions
-*  [add_ClientCertificateRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.955-prerelease&preserve-view=true#add_clientcertificaterequested) was promoted to stable.
+
+The following APIs have been promoted from experimental to prerelease stable.
+
+*  [add_ClientCertificateRequested](/microsoft-edge/webview2/reference/win32/icorewebview2_5?view=webview2-1.0.955-prerelease&preserve-view=true#add_clientcertificaterequested)
 
 #### .NET
 
@@ -2699,7 +2730,7 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 ###### Promotions
 
-The following items are now in stable:
+The following APIs have been promoted from prerelease stable to release.
 
 *  [add_FrameCreated](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902.49&preserve-view=true#add_framecreated).
 *  [get_IsGeneralAutofillEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings4?view=webview2-1.0.902.49&preserve-view=true#get_isgeneralautofillenabled).
@@ -2745,11 +2776,13 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 
 ###### Promotions
 
-*  [Download API](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902-prerelease&preserve-view=true#add_downloadstarting) is now promoted to stable.
-*  [PinchZoom API](/microsoft-edge/webview2/reference/win32/icorewebview2settings5?view=webview2-1.0.902-prerelease&preserve-view=true#get_ispinchzoomenabled) is now promoted to stable.
-*  [AddFrameCreated](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902-prerelease&preserve-view=true#add_framecreated) is now promoted to stable.
+The following APIs have been promoted from experimental to prerelease stable.
+
+*  [Download API](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902-prerelease&preserve-view=true#add_downloadstarting).
+*  [PinchZoom API](/microsoft-edge/webview2/reference/win32/icorewebview2settings5?view=webview2-1.0.902-prerelease&preserve-view=true#get_ispinchzoomenabled).
+*  [AddFrameCreated](/microsoft-edge/webview2/reference/win32/icorewebview2_4?view=webview2-1.0.902-prerelease&preserve-view=true#add_framecreated).
 *  [AddHostObjectToScriptWithOrigins](/microsoft-edge/webview2/reference/win32/icorewebview2frame?view=webview2-1.0.902-prerelease&preserve-view=true#addhostobjecttoscriptwithorigins) API promoted to stable with iframe element support.
-*  [Autofill API](/microsoft-edge/webview2/reference/win32/icorewebview2settings4?view=webview2-1.0.902-prerelease&preserve-view=true#get_isgeneralautofillenabled) is now promoted to stable.
+*  [Autofill API](/microsoft-edge/webview2/reference/win32/icorewebview2settings4?view=webview2-1.0.902-prerelease&preserve-view=true#get_isgeneralautofillenabled).
    > [!NOTE]
    > There is no current API to delete the locally stored general autofill and password autosave information.  Please provide a control to delete the data, which will involve deleting the entire user data folder.
 
@@ -2781,12 +2814,16 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 *  Improve `NewWindowRequested` documentation. ([Issue #448](https://github.com/MicrosoftEdge/WebViewFeedback/issues/448)).
 
 ###### Promotions
+
+The following APIs have been promoted from prerelease stable to release.
+
 *  [UserAgent API](/microsoft-edge/webview2/reference/win32/icorewebview2settings2?view=webview2-1.0.864.35&preserve-view=true#get_useragent) is now stable.
 *  [AreBrowserkeysenabled](/microsoft-edge/webview2/reference/win32/icorewebview2settings3?view=webview2-1.0.864.35&preserve-view=true#get_arebrowseracceleratorkeysenabled) is now stable.
 
 #### .NET
 
 ###### Bug fixes
+
 *  Fixed a bug in WebView2 .NET controls that first header is missing when iterating `CoreWebView2WebResourceRequest` headers collection. ([Issue #1123](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1123)).
 
 
@@ -2871,10 +2908,17 @@ For full API compatibility, this prerelease version of the WebView2 SDK requires
 *  Added experimental [AreBrowserAcceleratorKeysEnabled](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalsettings2?view=webview2-1.0.824&preserve-view=true#get_arebrowseracceleratorkeysenabled) setting.  You can prevent the browser from responding to keyboard shortcuts related to navigation, printing, saving, and other browser-specific functions.
 *  Added `iframe` element support for `AddScriptToExecuteOnDocumentCreated`.
 
-###### Promotion
+###### Promotions
 
-*  [UserAgent](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived) API is now promoted to Stable.
-*  Rasterization Scale APIs ([RasterizationScale](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_rasterizationscale) property,  [RasterizationScaleChanged](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#add_rasterizationscalechanged) event, [BoundsMode property](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_boundsmode), and [ShouldDetectMonitorScaleChanges](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_shoulddetectmonitorscalechanges) property) are now promoted to Stable.
+The following APIs have been promoted from experimental to prerelease stable.
+
+*  [UserAgent](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived).
+
+*  Rasterization Scale APIs:
+   *  [RasterizationScale property](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_rasterizationscale)
+   *  [RasterizationScaleChanged event](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#add_rasterizationscalechanged)
+   *  [BoundsMode property](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_boundsmode)
+   *  [ShouldDetectMonitorScaleChanges property](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_shoulddetectmonitorscalechanges)
 
 ###### Bug fixes
 
@@ -2905,7 +2949,8 @@ For full API compatibility, this version of the WebView2 SDK requires WebView2 R
 
 <!-- todo: change version number in links to match heading? -->
 
-*  The following experimental APIs are now promoted to Stable.
+The following APIs have been promoted from prerelease stable to release.
+
    *  [DPI support](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived) related APIs
    *  Visual hosting APIs
    *  [SetVirtualHostNameToFolderMapping](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.790-prerelease&preserve-view=true#setvirtualhostnametofoldermapping)
@@ -2960,9 +3005,10 @@ This prerelease version of the WebView2 SDK requires Microsoft Edge version 86.0
 
 ###### Promotions
 
-*  The following experimental APIs are now promoted to Stable:
-   *  Visual Hosting APIs
-   *  [SetVirtualHostNameToFolderMapping](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.790-prerelease&preserve-view=true#setvirtualhostnametofoldermapping)
+The following APIs have been promoted from experimental to prerelease stable.
+
+*  Visual Hosting APIs
+*  [SetVirtualHostNameToFolderMapping](/microsoft-edge/webview2/reference/win32/icorewebview2_3?view=webview2-1.0.790-prerelease&preserve-view=true#setvirtualhostnametofoldermapping)
 
 #### .NET
 
@@ -2985,7 +3031,8 @@ This version of the WebView2 SDK requires WebView2 Runtime version 86.0.616.0 or
 
 ###### Promotions
 
-*  The following experimental APIs are now promoted to Stable:
+The following APIs have been promoted from prerelease stable to release.
+
    *  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
    *  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
    *  [Cookie management API](/microsoft-edge/webview2/reference/win32/icorewebview2cookiemanager?view=webview2-1.0.721-prerelease&preserve-view=true)
@@ -3023,12 +3070,16 @@ This prerelease version of the WebView2 SDK requires Microsoft Edge version 86.0
    *  Added [ShouldDetectMonitorScaleChanges](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_shoulddetectmonitorscalechanges) property to automatically update `RasterizationScale` property if needed.
    *  Added [BoundsMode property](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcontroller?view=webview2-1.0.721-prerelease&preserve-view=true#get_boundsmode) to specify that the bounds are logic pixels and allow WebView2 to use `RasterizationScale` for WebView2 pixel display, and WebView2 use the `RasterizationScale` with the `Bounds` to get the physical size.
 *  Updated `NewWindowRequested` event to handle **Ctrl+click** and **Shift+click**.  ([Issue #168](https://github.com/MicrosoftEdge/WebViewFeedback/issues/168) and [Issue #371](https://github.com/MicrosoftEdge/WebViewFeedback/issues/371)).
-*  The following experimental APIs are now promoted to Stable.
-   *  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
-   *  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
-   *  [Cookie management API](/microsoft-edge/webview2/reference/win32/icorewebview2cookiemanager?view=webview2-1.0.721-prerelease&preserve-view=true)
-   *  [DOMContentLoaded API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_domcontentloaded)
-   *  [Environment property](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#get_environment)
+
+###### Promotions
+
+The following APIs have been promoted from experimental to prerelease stable.
+
+*  [WebResourceResponseReceived API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_webresourceresponsereceived)
+*  [NavigateWithWebResourceRequest API](/microsoft-edge/webview2/reference/win32/icorewebview2environment2?view=webview2-1.0.721-prerelease&preserve-view=true#createwebresourcerequest)
+*  [Cookie management API](/microsoft-edge/webview2/reference/win32/icorewebview2cookiemanager?view=webview2-1.0.721-prerelease&preserve-view=true)
+*  [DOMContentLoaded API](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#add_domcontentloaded)
+*  [Environment property](/microsoft-edge/webview2/reference/win32/icorewebview2_2?view=webview2-1.0.721-prerelease&preserve-view=true#get_environment)
 
 #### .NET
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -32,7 +32,7 @@ WebView2 shares code and binaries with the Microsoft Edge browser, and is releas
 
 *  For Microsoft Edge updates, see [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Beta Channel](/deployedge/microsoft-edge-relnote-beta-channel).
 
-*  To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](./concepts/distribution.md).
+*  To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](./concepts/distribution.md).  To view or get the latest WebView2 Runtime versions, see [Download the WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/#download-section) in the _Microsoft Edge WebView2_ page at developer.microsoft.com.
 
 *  To update the WebView2 SDK, see [Selecting which type of SDK to use](#selecting-which-type-of-sdk-to-use), below.
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -6,18 +6,19 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/24/2023
+ms.date: 04/25/2023
 ---
 # Release Notes for the WebView2 SDK
 
-The WebView2 team updates the [WebView2 SDK](https://www.nuget.org/packages/Microsoft.Web.WebView2) on a four-week cadence.  This article contains the latest information on product announcements, additions, modifications, and breaking changes to the APIs.
+The WebView2 team updates the WebView2 SDK on a four-week cadence.  This article contains the latest information on product announcements, additions, modifications, and breaking changes to the APIs.
+
+You can view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
 
 Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).
 
-<!-- terminology:
-APIs are Experimental or Stable
-SDKs/packages are Prerelease or Release
--->
+
+<!-- ------------------------------ -->
+#### Updating the Runtime and SDK
 
 WebView2 changes may require an update to the Runtime, SDK, or both.  Most new APIs require both Runtime and SDK updates.  Starting with the February 2023 release, the update requirement for each bug fix is indicated as follows:
 
@@ -27,19 +28,21 @@ WebView2 changes may require an update to the Runtime, SDK, or both.  Most new A
 | **Runtime-only** | Only the Runtime needs to be updated. |
 | **SDK-only** | Only the SDK needs to be updated. |
 
-WebView2 shares code and binaries with the Microsoft Edge browser, and is released around the same time.  As a result, WebView2 Runtime releases generally also include Microsoft Edge updates.  For Microsoft Edge updates, see [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Beta Channel](/deployedge/microsoft-edge-relnote-beta-channel).
+WebView2 shares code and binaries with the Microsoft Edge browser, and is released around the same time.  As a result, WebView2 Runtime releases generally also include Microsoft Edge updates.
+
+*  For Microsoft Edge updates, see [Release notes for Microsoft Edge Stable Channel](/deployedge/microsoft-edge-relnote-stable-channel) and [Release notes for Microsoft Edge Beta Channel](/deployedge/microsoft-edge-relnote-beta-channel).
+
+*  To update the WebView2 Runtime on your development machine and on user machines, see [Distribute your app and the WebView2 Runtime](./concepts/distribution.md).
+
+*  To update the WebView2 SDK, see [Selecting which type of SDK to use](#selecting-which-type-of-sdk-to-use), below.
 
 
 <!-- ------------------------------ -->
-#### Phases of introducing APIs
+#### Selecting which type of SDK to use
 
-New APIs are introduced in phases as follows:
+To select which version of WebView2 SDK NuGet package a Visual Studio project uses, in Visual Studio, right-click a project, select **Manage NuGet Packages**, select or clear the **Include prerelease** checkbox, select the **Microsoft.Web.WebView2** package, and then in the **Version** dropdown list, select a version of the **Microsoft.Web.WebView2** NuGet package.
 
-| API status | Description |
-|---|---|
-| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
-| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
-| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
+For details, see [Install the WebView2 SDK](./how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  You can also view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
 
 
 <!-- ------------------------------ -->
@@ -83,6 +86,23 @@ General event pattern:
 Async methods:
 - Win32: XYZ method + XYZCompletedHandler
 - .NET/WinRT: XYZAsync
+-->
+
+
+<!-- ------------------------------ -->
+#### Phases of introducing APIs
+
+New APIs are introduced in phases as follows:
+
+| API status | Description |
+|---|---|
+| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
+| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
+| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
+
+<!-- terminology:
+APIs are Experimental or Stable
+SDKs/packages are Prerelease or Release
 -->
 
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: webview
-ms.date: 04/25/2023
+ms.date: 04/27/2023
 ---
 # Release Notes for the WebView2 SDK
 
@@ -14,7 +14,7 @@ The WebView2 team updates the WebView2 SDK on a four-week cadence.  This article
 
 You can view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
 
-Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).
+Generally, release notes apply across the supported platforms, which are listed in [WebView2 API Reference](webview2-api-reference.md).  For an outline of APIs that are in Release SDK packages, see [Overview of WebView2 features and APIs](./concepts/overview-features-apis.md).
 
 
 <!-- ------------------------------ -->
@@ -82,25 +82,16 @@ Async methods:
 
 
 <!-- ------------------------------ -->
-#### Phases of introducing APIs
+#### Experimental APIs, Prerelease SDKs, and Release SDKs
 
-<!-- todo: duplicated information across various pages:
-experimental/stable in prerelease/stable in release table
-selecting what SDK to use
--->
-
-New APIs are introduced in phases as follows:
-
-| API status | Description |
-|---|---|
-| _Experimental_ | 1. First an API is Experimental in a Prerelease SDK.  You can test these APIs and provide feedback.  The API isn't in a Release SDK yet. |
-| _Stable in a Prerelease SDK_ | 2. Then the API is promoted to Stable in the Prerelease SDK.  The API isn't in a Release SDK yet. |
-| _Stable in a Release SDK_ | 3. Then the Stable API is promoted to be included in the Release SDK.  This typically happens 1 month after the API is promoted to Stable in a Prerelease SDK.  The API also remains in the Prerelease SDK. |
+APIs are initially introduced as Experimental APIs.  Then they become Stable APIs in a Prerelease SDK package, and soon after, they become Stable APIs in a Release SDK package.  For more information, see [Phases of introducing APIs](./concepts/versioning.md) in _Understand the different WebView2 SDK versions_.
 
 <!-- terminology:
 APIs are Experimental or Stable
 SDKs/packages are Prerelease or Release
 -->
+
+The following sections cover either a Release SDK package (1.0.####.##) or a Prerelease SDK package (1.0.####-prerelease).
 
 
 <!-- ====================================================================== -->
@@ -3504,4 +3495,5 @@ Initial developer preview release.
 <!-- ====================================================================== -->
 ## See also
 
-*  [Contacting the Microsoft Edge WebView2 team](contact.md)
+* [Overview of WebView2 features and APIs](./concepts/overview-features-apis.md) - outlines many of the APIs, by feature area, that are in Release SDK packages.
+* [Contacting the Microsoft Edge WebView2 team](contact.md)

--- a/microsoft-edge/webview2/samples/webview2samplewincomp.md
+++ b/microsoft-edge/webview2/samples/webview2samplewincomp.md
@@ -161,7 +161,7 @@ This step is optional.  The sample has preinstalled:
 
 1. Click the **Updates** tab.
 
-1. If a newer prerelease of the **Microsoft.Web.WebView2** SDK is listed, you can optionally click the **Update** button.  A prerelease has a "-prerelease" suffix, such as **1.0.1248-prerelease**.  If you want to see details about this step, in a separate window or tab, see [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+1. If a newer prerelease of the **Microsoft.Web.WebView2** SDK is listed, you can optionally click the **Update** button.  A prerelease has a "-prerelease" suffix, such as **1.0.1248-prerelease**.  If you want to see details about this step, in a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
    ![The Updates tab of NuGet Package Manager after initially opening the WebView2SampleWinComp solution](webview2samplewincomp-images/updates-tab-initial-state.png)
 

--- a/microsoft-edge/webview2/samples/webview2samplewincomp.md
+++ b/microsoft-edge/webview2/samples/webview2samplewincomp.md
@@ -161,7 +161,7 @@ This step is optional.  The sample has preinstalled:
 
 1. Click the **Updates** tab.
 
-1. If a newer prerelease of the **Microsoft.Web.WebView2** SDK is listed, you can optionally click the **Update** button.  A prerelease has a "-prerelease" suffix, such as **1.0.1248-prerelease**.  If you want to see details about this step, in a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+1. If a newer prerelease of the **Microsoft.Web.WebView2** SDK is listed, you can optionally click the **Update** button.  A prerelease has a "-prerelease" suffix, such as **1.0.1248-prerelease**.  If you want to see details about this step, in a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
    ![The Updates tab of NuGet Package Manager after initially opening the WebView2SampleWinComp solution](webview2samplewincomp-images/updates-tab-initial-state.png)
 

--- a/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
@@ -129,7 +129,7 @@ Microsoft .NET Framework 4.6.2 Developer Pack is now installed on your machine.
 
 <!-- a checkin comment at repo says "Update projects to use latest WebView2 SDK 1.0.781-prerelease (#74)" -->
 
-1. **WebView2 SDK** - Update or install the WebView2 SDK on the project node (not the solution node) in Solution Explorer.  In a separate window or tab, see [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+1. **WebView2 SDK** - Update or install the WebView2 SDK on the project node (not the solution node) in Solution Explorer.  In a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
    <!-- this same png is used multiple times in this file -->
    ![The WebView2WindowsFormsBrowser project in Visual Studio](media/webview2windowsformsbrowser-in-visual-studio.png)

--- a/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2windowsformsbrowser.md
@@ -129,7 +129,7 @@ Microsoft .NET Framework 4.6.2 Developer Pack is now installed on your machine.
 
 <!-- a checkin comment at repo says "Update projects to use latest WebView2 SDK 1.0.781-prerelease (#74)" -->
 
-1. **WebView2 SDK** - Update or install the WebView2 SDK on the project node (not the solution node) in Solution Explorer.  In a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+1. **WebView2 SDK** - Update or install the WebView2 SDK on the project node (not the solution node) in Solution Explorer.  In a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
    <!-- this same png is used multiple times in this file -->
    ![The WebView2WindowsFormsBrowser project in Visual Studio](media/webview2windowsformsbrowser-in-visual-studio.png)

--- a/microsoft-edge/webview2/samples/webview2wpfbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2wpfbrowser.md
@@ -103,7 +103,7 @@ At the top of Visual Studio, set the build target, as follows:
 <!-- ====================================================================== -->
 ## Step 7 - Update the WebView2 SDK
 
-1. Update the prerelease WebView2 SDK on the project node (not the solution node) in Solution Explorer.  Install the latest prerelease of the WebView2 SDK, so that you can try the latest features.  In a separate window or tab, see [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+1. Update the prerelease WebView2 SDK on the project node (not the solution node) in Solution Explorer.  Install the latest prerelease of the WebView2 SDK, so that you can try the latest features.  In a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
 1. Build and run the project again.
 

--- a/microsoft-edge/webview2/samples/webview2wpfbrowser.md
+++ b/microsoft-edge/webview2/samples/webview2wpfbrowser.md
@@ -103,7 +103,7 @@ At the top of Visual Studio, set the build target, as follows:
 <!-- ====================================================================== -->
 ## Step 7 - Update the WebView2 SDK
 
-1. Update the prerelease WebView2 SDK on the project node (not the solution node) in Solution Explorer.  Install the latest prerelease of the WebView2 SDK, so that you can try the latest features.  In a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+1. Update the prerelease WebView2 SDK on the project node (not the solution node) in Solution Explorer.  Install the latest prerelease of the WebView2 SDK, so that you can try the latest features.  In a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
 1. Build and run the project again.
 

--- a/microsoft-edge/webview2/samples/wv2cdpextensionwpfsample.md
+++ b/microsoft-edge/webview2/samples/wv2cdpextensionwpfsample.md
@@ -127,7 +127,7 @@ At the top of Visual Studio, set the build target, as follows:
 
 1. If a newer release of the **Microsoft.Web.WebView2** SDK is listed, click the **Update** button.  A prerelease has a "-prerelease" suffix, such as **1.0.1248-prerelease**.  Prerelease SDKs allow you to try the latest WebView2 features and APIs.
 
-If you want to see details about this step, in a separate window or tab, see [Install the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+If you want to see details about this step, in a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
 For more information, see [WebView2 SDK NuGet package](https://aka.ms/webviewnuget).
 

--- a/microsoft-edge/webview2/samples/wv2cdpextensionwpfsample.md
+++ b/microsoft-edge/webview2/samples/wv2cdpextensionwpfsample.md
@@ -127,7 +127,7 @@ At the top of Visual Studio, set the build target, as follows:
 
 1. If a newer release of the **Microsoft.Web.WebView2** SDK is listed, click the **Update** button.  A prerelease has a "-prerelease" suffix, such as **1.0.1248-prerelease**.  Prerelease SDKs allow you to try the latest WebView2 features and APIs.
 
-If you want to see details about this step, in a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
+If you want to see details about this step, in a separate window or tab, see [Install or update the WebView2 SDK](../how-to/machine-setup.md#install-or-update-the-webview2-sdk) in _Set up your Dev environment for WebView2_.  Follow the steps in that section, and then return to this page and continue below.
 
 For more information, see [WebView2 SDK NuGet package](https://aka.ms/webviewnuget).
 


### PR DESCRIPTION
This PR reformats "Overview of APIs", and states that the scope as only Release APIs (not Experimental, not Stable Only In Prerelease).
This PR also clarifies phases of WebView 2 APIs: Experimental (in Prerelease), Stable (in Prerelease), then Stable  (in Prerelease) -- in RelNotes & in versioning.md.

**Rendered "Oveview of APIs" article:**
https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/overview-features-apis?branch=pr-en-us-2555 
[[gh rendered](https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/overview-apis-spacing/microsoft-edge/webview2/concepts/overview-features-apis.md)]
Before: https://learn.microsoft.com/microsoft-edge/webview2/concepts/overview-features-apis

Applied latest patterns.  
* Types are always left-justified.  No longer nest an EventArgs type as a child of another type.
* Members are always indented.
* Members always have a parent type above, as a visual container to group items and give context.
* Group members of a type together.
* Removed spacing between types.
* For C++, use the actual names of the get_/put_ property-methods & add_/remove_ event-methods, to match API Ref and enable/fix Find In Page for Win32/C++ audience.
* Stated scope of "Overview of APIs": Release, not Experimental or Prerelease-stable only.

**Rendered RelNotes:** 
https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes?branch=pr-en-us-2555#phases-of-introducing-apis [[gh rendered](https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/overview-apis-spacing/microsoft-edge/webview2/release-notes.md#phases-of-introducing-apis)]
*  Introduced the 3 status phases: Experimental, Stable (in Prerelease), Stable (in Release).
*  Clarified lead-in sentences in "Promotions" headings.
*  Clarified/disambiguated Stable status: Stable (in Prerelease SDK/package) vs. Stable (in Release SDK/package).

**Rendered versioning.md article:**
https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/versioning?branch=pr-en-us-2555 [[gh rendered](https://github.com/mikehoffms/edge-developer/blob/user/mikehoffms/overview-apis-spacing/microsoft-edge/webview2/concepts/versioning.md)]
*  Introduced the 3 status phases: Experimental, Stable in Prerelease, Stable in Release.
*  Clarified/disambiguated Stable status (in Prerelease SDK) vs. Release status (stable APIs in Release SDK).