### PR TITLE
Some predefined CSS cursors don't work

### DIFF
--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -380,9 +380,9 @@ On WinUI 2, transparency is achieved by setting the color to `00FFFFFF`.
 
 
 <!-- ------------------------------ -->
-#### Custom cursors
+#### CSS cursors
 
-On WinUI 2, you cannot use [CSS cursors](https://developer.mozilla.org/docs/Web/CSS/cursor) by specifying a URL of an image as the cursor. You can use CSS cursors to change the cursor to a predefined cursor, such as `cursor: wait;` or `cursor: crosshair;`, but not to an image URL, such as `cursor: url(https://contoso.com/cursor.png), pointer;`. See [CSS - cursor loaded from URL doesn't work](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1925).
+On WinUI 2, you cannot use [CSS cursors](https://developer.mozilla.org/docs/Web/CSS/cursor) by specifying a URL of an image as the cursor and only some of the predefined cursors work. You can use CSS cursors to change the cursor to some predefined cursors, such as `cursor: wait;` or `cursor: crosshair;`, but not to others such as `cursor: progress` or `cursor: none` and not to an image URL, such as `cursor: url(https://contoso.com/cursor.png), pointer;`. See [CSS - cursor loaded from URL doesn't work](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1925).
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -382,7 +382,66 @@ On WinUI 2, transparency is achieved by setting the color to `00FFFFFF`.
 <!-- ------------------------------ -->
 #### CSS cursors
 
-On WinUI 2, you cannot use [CSS cursors](https://developer.mozilla.org/docs/Web/CSS/cursor) by specifying a URL of an image as the cursor and only some of the predefined cursors work. You can use CSS cursors to change the cursor to some predefined cursors, such as `cursor: wait;` or `cursor: crosshair;`, but not to others such as `cursor: progress` or `cursor: none` and not to an image URL, such as `cursor: url(https://contoso.com/cursor.png), pointer;`. See [CSS - cursor loaded from URL doesn't work](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1925).
+On WinUI 2 (UWP), CSS cursors have the following limitations.
+
+
+###### Image URLs
+
+The CSS cursor cannot be an image URL, such as `cursor: url(https://contoso.com/cursor.png), pointer;`.  See [CSS - cursor loaded from URL doesn't work](https://github.com/MicrosoftEdge/WebView2Feedback/issues/1925).
+
+
+###### Predefined CSS cursors
+
+On WinUI 2 (UWP), some of the predefined CSS cursors are not supported.  You can use CSS cursors to change the cursor to some of the predefined cursors, such as `cursor: wait;` or `cursor: crosshair;`, but not to others, such as `cursor: progress` or `cursor: none`.
+
+| Keyword | Supported? |
+|---|:---:|
+| **General** |  |
+| auto | ✔️ |
+| default | ✔️ |
+| none | ❌ |
+| **Links & status** |  |
+| context-menu | ✔️ |
+| help | ✔️ |
+| pointer | ✔️ |
+| progress | ❌ |
+| wait | ✔️ |
+| **Selection** |  |
+| cell | ❌ |
+| crosshair | ✔️ |
+| text | ✔️ |
+| vertical-text | ❌ |
+| **Drag & drop** |  |
+| alias | ❌ |
+| copy | ❌ |
+| move | ✔️ |
+| no-drop | ✔️ |
+| not-allowed | ✔️ |
+| grab | ❌ |
+| grabbing | ❌ |
+| **Resizing & scrolling** |  |
+| all-scroll | ✔️ |
+| col-resize | ❌ |
+| row-resize | ❌ |
+| n-resize | ✔️ |
+| e-resize | ✔️ |
+| s-resize | ✔️ |
+| w-resize | ✔️ |
+| ne-resize | ✔️ |
+| nw-resize | ✔️ |
+| se-resize | ✔️ |
+| sw-resize | ✔️ |
+| ew-resize | ✔️ |
+| ns-resize | ✔️ |
+| nesw-resize | ✔️ |
+| nwse-resize | ✔️ |
+| **Zooming** |  |
+| zoom-in | ❌ |
+| zoom-out | ❌ |
+
+See also:
+* [CSS cursors](https://developer.mozilla.org/docs/Web/CSS/cursor#values) - the **Values** section describes the above keyword values.
+<!-- known limitation: destination page doesn't scroll to anchor -->
 
 
 <!-- ------------------------------ -->


### PR DESCRIPTION
Update the WinUI2 section describing limitations of CSS cursors to note that in addition to custom CSS cursors via image URLs, also some predefined CSS cursors do not work.

AB#44768759