### PR TITLE
[WebView2] Add concepts doc: process-related events

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -4,7 +4,7 @@
 # =============================================================================
     - name: Develop for the web with Microsoft Edge
       href: develop-web-microsoft-edge.md
-      displayName: 
+      displayName:
 
     - name: Microsoft Edge DevTools
       items:
@@ -364,7 +364,7 @@
                 - name: Test Progressive Web App (PWA) protocol handling
                   href: devtools-guide-chromium/progressive-web-apps/protocol-handlers.md
                   displayName: Application tool
-                  
+
                 - name: Debug background services
                   href: devtools-guide-chromium/javascript/background-services.md
                   displayName: Application tool
@@ -498,7 +498,7 @@
               items:
                 - name: Compose and send web API requests using the Network Console tool
                   href: devtools-guide-chromium/network-console/network-console-tool.md
-                  displayName: 
+                  displayName:
 # Network request blocking tool -----------------------------------------------
             - name: Network request blocking tool
               items:
@@ -684,7 +684,7 @@
 # Inspect tool (distinct from Tools > Inspect tool bucket)
             - name: Use the Inspect tool to detect accessibility issues by hovering over the webpage  # added article
               href: devtools-guide-chromium/accessibility/test-inspect-tool.md
-              displayName: Inspect tool  # tests Screen reader support, Keyboard support, Text contrast 
+              displayName: Inspect tool  # tests Screen reader support, Keyboard support, Text contrast
 
 # Lighthouse tool (distinct from Tools > Lighthouse tool bucket)
             - name: Test accessibility using Lighthouse  # was part of "Accessibility features reference"
@@ -820,37 +820,37 @@
 
                 - name: Get started by right-clicking an HTML file
                   href: visual-studio-code/microsoft-edge-devtools-extension/get-started-right-click-html.md
-                  displayName: 
+                  displayName:
 
                 - name: Get started by clicking the Launch Instance button
                   href: visual-studio-code/microsoft-edge-devtools-extension/get-started-launch-instance.md
-                  displayName: 
+                  displayName:
 
                 - name: Get started by clicking the Launch Project button
                   href: visual-studio-code/microsoft-edge-devtools-extension/get-started-launch-project.md
-                  displayName: 
+                  displayName:
 
                 - name: Opening DevTools and the DevTools browser
                   href: visual-studio-code/microsoft-edge-devtools-extension/open-devtools-and-embedded-browser.md
-                  displayName: 
+                  displayName:
 
             - name: Tools and features
               items:
                 - name: Integration with Visual Studio Code debugging
                   href: visual-studio-code/microsoft-edge-devtools-extension/debugging-a-webpage.md
-                  displayName: 
+                  displayName:
 
                 - name: Opening source files from the Elements tool
                   href: visual-studio-code/microsoft-edge-devtools-extension/opening-source-files-from-elements-tool.md
-                  displayName: 
+                  displayName:
 
                 - name: Inline and live issue analysis
                   href: visual-studio-code/microsoft-edge-devtools-extension/inline-live-issue-analysis.md
-                  displayName: 
+                  displayName:
 
                 - name: Device and state emulation
                   href: visual-studio-code/microsoft-edge-devtools-extension/device-state-emulation.md
-                  displayName: 
+                  displayName:
 
                 - name: Update .css files from within the Styles tab (CSS mirror editing)
                   href: visual-studio-code/microsoft-edge-devtools-extension/css-mirror-editing-styles-tab.md
@@ -858,29 +858,29 @@
 
                 - name: Network tool integration
                   href: visual-studio-code/microsoft-edge-devtools-extension/network-tool-integration.md
-                  displayName: 
+                  displayName:
 
                 - name: Console integration
                   href: visual-studio-code/microsoft-edge-devtools-extension/console-integration.md
-                  displayName: 
+                  displayName:
 
                 - name: Application tool integration
                   href: visual-studio-code/microsoft-edge-devtools-extension/application-tool-integration.md
-                  displayName: 
+                  displayName:
 
             - name: Customize
               items:
                 - name: Changing the extension settings
                   href: visual-studio-code/microsoft-edge-devtools-extension/change-extension-settings.md
-                  displayName: 
+                  displayName:
 
                 - name: The launch.json file for the DevTools extension
                   href: visual-studio-code/microsoft-edge-devtools-extension/launch-json.md
-                  displayName: 
+                  displayName:
 
                 - name: Using an external browser window
                   href: visual-studio-code/microsoft-edge-devtools-extension/external-browser-window.md
-                  displayName: 
+                  displayName:
 
                 - name: Troubleshooting the DevTools extension
                   href: visual-studio-code/microsoft-edge-devtools-extension/troubleshooting.md
@@ -888,7 +888,7 @@
 
             - name: Getting in touch with the Microsoft Edge DevTools Extension team
               href: visual-studio-code/microsoft-edge-devtools-extension/contact-devtools-extension-team.md
-              displayName: 
+              displayName:
 # /DevTools
 
 # =============================================================================
@@ -942,7 +942,7 @@
 
             - name: Create an extension that customizes the DevTools UI
               href: extensions-chromium/developer-guide/devtools-extension.md
-              
+
             - name: Best Practices
               href: extensions-chromium/developer-guide/best-practices.md
               displayName: Best Practices for extensions  # full title
@@ -1115,7 +1115,7 @@
       items:
         - name: Introduction to Microsoft Edge WebView2  # existing firstchild article
           href: webview2/index.md
-          displayName: 
+          displayName:
 
         - name: Overview of WebView2 features and APIs
           href: webview2/concepts/overview-features-apis.md
@@ -1125,7 +1125,7 @@
 # machine setup
         - name: Set up your Dev environment for WebView2
           href: webview2/how-to/machine-setup.md
-          displayName: 
+          displayName:
 
 # -----------------------------------------------------------------------------
 # Getting Started tutorials
@@ -1165,7 +1165,7 @@
           items:
             - name: Sample apps
               href: webview2/code-samples-links.md
-              displayName: 
+              displayName:
 
             - name: Win32 sample app
               href: webview2/samples/webview2apissample.md
@@ -1206,7 +1206,7 @@
           items:
             - name: Deployment samples
               href: webview2/samples/deployment-samples.md
-              displayName: 
+              displayName:
 
             - name: WebView2 Deployment Visual Studio installer
               href: webview2/samples/wv2deploymentvsinstallersample.md
@@ -1225,15 +1225,19 @@
           items:
             - name: Differences between Microsoft Edge and WebView2
               href: webview2/concepts/browser-features.md
-              displayName: 
+              displayName:
 
             - name: "Main classes for WebView2: Environment, Controller, and Core"
               href: webview2/concepts/environment-controller-core.md
-              displayName: 
+              displayName:
 
             - name: Navigation events
               href: webview2/concepts/navigation-events.md
               displayName: Navigation events for WebView2 apps  # top-of-page title
+
+            - name: Process-related events
+              href: webview2/concepts/process-related-events.md
+              displayName: Handling Process-related Events in WebView2  # top-of-page title
 
             - name: Basic authentication
               href: webview2/concepts/basic-authentication.md
@@ -1241,7 +1245,7 @@
 
             - name: Windowed vs. visual hosting of WebView2
               href: webview2/concepts/windowed-vs-visual-hosting.md
-              displayName: 
+              displayName:
 
             - name: Custom management of network requests
               href: webview2/how-to/webresourcerequested.md
@@ -1267,7 +1271,7 @@
 
                 - name: How WinRT types and members are represented in JavaScript
                   href: webview2/how-to/winrt-js-conversion.md
-                  displayName: 
+                  displayName:
 
             - name: Using frames
               href: webview2/concepts/frames.md
@@ -1285,22 +1289,22 @@
             # update needed?
             - name: Test upcoming APIs and features
               href: webview2/how-to/set-preview-channel.md
-              displayName: 
+              displayName:
 
             - name: Distribute your app and the WebView2 Runtime
               href: webview2/concepts/distribution.md
-              displayName: 
+              displayName:
 
             - name: Working with local content in WebView2 apps
               href: webview2/concepts/working-with-local-content.md
-              displayName: 
+              displayName:
 
 # -----------------------------------------------------------------------------
         - name: Debug WebView2 apps
-          items: 
+          items:
             - name: Debug WebView2 apps
               href: webview2/how-to/debug.md
-              displayName: 
+              displayName:
 
             - name: Microsoft Edge DevTools
               href: webview2/how-to/debug-devtools.md
@@ -1328,7 +1332,7 @@
 
             # - name: Architecture of WebView2
             #   href: webview2/concepts/architecture.md
-            #   displayName: 
+            #   displayName:
 
             - name: Process model
               href: webview2/concepts/process-model.md
@@ -1347,11 +1351,11 @@
 
             - name: Support multiple profiles under a single user data folder
               href: webview2/concepts/multi-profile-support.md
-              displayName: 
+              displayName:
 
             - name: Clear browsing data from the user data folder
               href: webview2/concepts/clear-browsing-data.md
-              displayName: 
+              displayName:
 
 # -----------------------------------------------------------------------------
         - name: Advanced Topics and Best Practices
@@ -1362,7 +1366,7 @@
 
             - name: Develop secure WebView2 apps
               href: webview2/concepts/security.md
-              displayName: 
+              displayName:
 
             # - name: Customize the UI   # not needed?  flatten
             #   items:
@@ -1381,7 +1385,7 @@
             - name: Automate and test with Microsoft Edge WebDriver
               href: webview2/how-to/webdriver.md
               displayName: Automate and test WebView2 apps with Microsoft Edge WebDriver  # top-of-page title
-            
+
             - name: Data and privacy
               href: webview2/concepts/data-privacy.md
               displayName: Data and privacy in WebView2  # top-of-page title
@@ -1411,7 +1415,7 @@
 
         - name: WebView2 Roadmap
           href: webview2/roadmap.md
-          displayName: 
+          displayName:
 
         - name: WebView2 Reference
           items:
@@ -1453,7 +1457,7 @@
               items:
                 - name: Win32 C++ WebView2 API conventions
                   href: webview2/concepts/win32-api-conventions.md
-                  displayName: 
+                  displayName:
 
                 - name: Win32 C++ API Reference
                   href: /microsoft-edge/webview2/reference/win32/index
@@ -1461,7 +1465,7 @@
 
             - name: JavaScript
               uid: WebView2Script!
-              displayName: 
+              displayName:
               items:
                 - name: HostObjectAsyncProxy
                   uid: 'WebView2Script!HostObjectAsyncProxy:class'
@@ -1495,23 +1499,23 @@
       items:
         - name: Test and automation in Microsoft Edge  # new firstchild article
           href: test-and-automation/test-and-automation.md
-          displayName: 
+          displayName:
 
         - name: DevTools Protocol
           href: test-and-automation/devtools-protocol.md
-          displayName: 
+          displayName:
 
         - name: Use Origin Trials in Microsoft Edge
           href: origin-trials/index.md
-          displayName: 
+          displayName:
 
         - name: Use Playwright to automate and test in Microsoft Edge
           href: playwright/index.md
-          displayName: 
+          displayName:
 
         - name: Puppeteer overview
           href: puppeteer/index.md
-          displayName: 
+          displayName:
 
         - name: WebDriver
           items:
@@ -1528,7 +1532,7 @@
 
         - name: webhint extension for Visual Studio Code
           href: test-and-automation/webhint.md
-          displayName: 
+          displayName:
 
 # =============================================================================
 # if top-of-page title is longer, add it to displayName comma-delimited list of lookup keywords
@@ -1536,31 +1540,31 @@
       items:
         - name: Development tips for Microsoft Edge
           href: web-platform/web-platform.md
-          displayName: 
+          displayName:
 
         - name: Site compatibility-impacting changes coming to Microsoft Edge
           href: web-platform/site-impacting-changes.md
-          displayName: 
+          displayName:
 
         - name: Move users to Microsoft Edge from Internet Explorer
           href: web-platform/ie-to-microsoft-edge-redirection.md
-          displayName: 
+          displayName:
 
         - name: Tracking prevention in Microsoft Edge
           href: web-platform/tracking-prevention.md
-          displayName: 
+          displayName:
 
         - name: Detect Microsoft Edge from your website
           href: web-platform/user-agent-guidance.md
-          displayName: 
+          displayName:
 
         - name: Detect Windows 11 using User-Agent Client Hints
           href: web-platform/how-to-detect-win11.md
-          displayName: 
+          displayName:
 
         - name: Customize the password reveal button
           href: web-platform/password-reveal.md
-          displayName: 
+          displayName:
 
         - name: Operating System Regional Data Display
           href: web-platform/os-regional-settings.md
@@ -1576,7 +1580,7 @@
       items:
         - name: Microsoft Edge IDE integration
           href: visual-studio-code/ide-integration.md
-          displayName: 
+          displayName:
 
         - name: DevTools extension for Visual Studio Code # aux jump page
           href: visual-studio-code/microsoft-edge-devtools-extension/devtools-extension.md
@@ -1587,11 +1591,11 @@
 
         - name: Debug Microsoft Edge in Visual Studio Code
           href: visual-studio-code/debugger-for-edge.md
-          displayName: 
+          displayName:
 
         - name: Visual Studio for web development
           href: visual-studio/index.md
-          displayName: 
+          displayName:
 
 # =============================================================================
 # if top-of-page title is longer, add it to displayName comma-delimited list of lookup keywords
@@ -1599,23 +1603,23 @@
       items:
         - name: Accessibility in Microsoft Edge  # existing firstchild article
           href: accessibility/index.md
-          displayName: 
+          displayName:
 
         - name: Design accessible websites
           href: accessibility/design.md
-          displayName: 
+          displayName:
 
         - name: Build accessible websites
           href: accessibility/build/index.md
-          displayName: 
+          displayName:
 
         - name: ARIA and UI automation
           href: accessibility/build/ARIA-and-UI-Automation.md
-          displayName: 
+          displayName:
 
         - name: Accessibility testing
           href: accessibility/test.md
-          displayName: 
+          displayName:
 
 # =============================================================================
 # bottom leaf nodes
@@ -1625,8 +1629,8 @@
 
     - name: Privacy whitepaper
       href: privacy-whitepaper/index.md
-      displayName: 
+      displayName:
 
     - name: The Web We Want initiative
       href: web-we-want/index.md
-      displayName: 
+      displayName:

--- a/microsoft-edge/webview2/concepts/process-related-events.md
+++ b/microsoft-edge/webview2/concepts/process-related-events.md
@@ -175,7 +175,7 @@ Your application can use and collect information from [Process Failure Details](
 > [!NOTE]
 > Some process failures might raise the `ProcessFailed` event across different WebView2 controls in your application (see [Unexpected Exits](<link>) for more information). You must decide how often to gather details and how to handle duplicates for these cases.
 
-Additionally, most process crashes will generate dumps in the [User Data Folder](user-data-folder.md) or the configured `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
+Additionally, most process crashes will generate dumps in the [User Data Folder](user-data-folder.md), under the directory returned by `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
 
 ## Main Browser Process Crashes
 When the main browser process in the _WebView2 Process Group_ exits unexpectedly, **both** events discussed in this document will be raised:

--- a/microsoft-edge/webview2/concepts/process-related-events.md
+++ b/microsoft-edge/webview2/concepts/process-related-events.md
@@ -1,0 +1,171 @@
+# Overview
+The WebView2 API provides the `CoreWebView2.ProcessFailed` and `CoreWebView2Environment.BrowserProcessExited` events for your application to react to different scenarios. Use this document to learn how to use these events to react when these scenarios present.
+
+  * `CoreWebView2.ProcessFailed`. Use this event for diagnostics and recovery from failures in the WebView2 processes.
+  * `CoreWebView2Environment.BrowserProcessExited`. Use this event to synchronize operations involving WebView2 Runtime resources and lifetime, such as User Data Folder management and updates.
+
+To improve the reliability of your WebView2 application, it is recommended that it handles at least the following events:
+  * [The browser process has exited unexpectedly](<link>).
+  * [A renderer process has exited unexpectedly](<link>).
+  * [A renderer process has become unresponsive](<link>).
+
+> **Note:** this document is a high-level overview of the aforementioned events. Ultimately, the reference documentation for each individual API mentioned in this document shall prevail.
+
+# WebView2 Process Model and related APIs
+The [WebView2 Process Model](<link>) uses the WebView2 Runtime to support your WebView2 application. Because most of the magic in the WebView2 controls in your application happens out-of-process (in the WebView2 Runtime), failures and general information about these processes are passed to your application through different WebView2 APIs. The APIs used to report this information to your application include:
+
+  * CoreWebView2
+    - `BrowserProcessId` property
+    - `ProcessFailed` event
+  * CoreWebView2Environment
+    - `BrowserProcessExited` event
+    - `ProcessInfosChanged` event
+    - `GetProcessInfos` method
+
+  > **Note:** this is an overview at the conceptual level. For detailed API names and related types in your app's framework, see [Process Management](<link>).
+
+In this document, we discuss how to handle process exits and failures, using the `CoreWebView2.ProcessFailed` and `CoreWebView2Environment.BrowserProcessExited` events.
+
+# Process Events
+The WebView2 Runtime is composed of different types of processes, including:
+  * Browser process
+  * Renderer processes
+  * Utility processes
+  * GPU process
+
+  > **Note:** This is an illustrative and incomplete list of process kinds. The purpose and management details for these processes is part of the Chromium architecture and beyond the scope of this document, or the WebView2 architecture.
+
+When you create and initialize a WebView2 control, WebView2 will ensure there's a WebView2 Runtime to power your control and connect to its [WebView2 Process Group](<link>). Once this connection is established, your control will start monitoring these processes for the following events:
+
+  * **Browser process exits.** If the browser process exits for _any reason_, the `CoreWebView2Environment` will raise the `BrowserProcessExited` event. Use this event to synchronize operations involving the WebView2 Runtime resources and lifetime, such as _User Data Folder_ management and updates. See [Browser Process Exits](<link>) below for more details.
+  * **Any process failure.** When _any of the processes_ in the WebView2 Runtime fails, the CoreWebView2 will raise the `ProcessFailed` event. Use this event for diagnostics and recovery from failures in the WebView2 processes. See [Process Failures](<link>) below for more details.
+
+  > **Note:** there is some overlap between these two events. For example, a browser process crash will produce both a `ProcessFailed` event and a `BrowserProcessExited` event, since the browser process _exited_ because of a failure. See [Browser Process Crashes](<link>) for more information about this case.
+
+`CoreWebView2` and `CoreWebView2Environment` report these events so your application can react accordingly. There are multiple scenarios your application can handle through these events.
+
+# Browser Process Exits
+The `BrowserProcessExited` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that the browser process has exited and its resources (including its child processes) have been released. This can happen for the following reasons:
+
+  * All WebView2 controls from the CoreWebView2Environment have been closed. Example app scenarios include:
+    - **Clearing the [User Data Folder](<link>).** Your application needs to wait until the WebView2 Runtime has released the _User Data Folder_ before it can delete its contents. After closing all WebView2 controls, the `BrowserProcessExited` event indicates this has happened and your application can proceed with the operation.
+    - **Updating the WebView2 Runtime.** In order to make use of the latest WebView2 Runtime after an update, your application needs to close all WebView2 controls and create a new `CoreWebView2Environment`. To ensure the new version is used, your application must wait for the `BrowserProcessExited` event; otherwise, the browser process might stay alive when the new environment is created and switching to the new version would fail.
+    - **Restarting with a different environment configuration.** Most of the configuration used for a `CoreWebView2Environment` is bound to the browser process lifetime. In order to make changes to this configuration (for example, to language), your application needs to close existing WebView2 controls and wait for `BrowserProcessExited` before recreating the controls; otherwise, initializing the WebView2 controls from the new CoreWebView2Environment might fail with incompatible configuration.
+    - **Clearing auth cache.** Auth cache is bound to the browser process lifetime. To clear the cache, your application must recreate its WebView2 controls from a new browser process instance. To ensure a new browser process instance is used when recreating the controls, your application must wait for the `BrowserProcessExited` event before proceeding; otherwise, the browser process might stay alive when the cotrols are recreated and preserve the auth cache.
+  * The browser process failed. See [Browser Process Crashes](<link>) below to handle this case.
+
+This event provides the _exit kind_ and the _process ID_ so your application can determine when and how to handle the event. For more information about these, see:
+  * COM: [ICoreWebView2BrowserProcessExitedEventArgs](<link>)
+  * .NET: [CoreWebView2BrowserProcessExitedEventArgs](<link>)
+  * WinRT: [CoreWebView2BrowserProcessExitedEventArgs](<link>)
+
+# Process Failures
+The `ProcessFailed` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that _any_ of the processes in the _WebView2 Process Group_ has encountered one of the following situations:
+
+  * **Unexpected exit.** The process indicated by the event has exited unexpectedly (usually due to a crash). The failure might or might not be recoverable and some failures are auto-recoverable. See [Unexpected Exits](<link>) below for details about which of these can be handled by your application.
+    > **Note:** When the impacted process is the browser process, a `BrowserProcessExited` event will raise too. See [Browser Process Crashes](<link>) below to handle this case.
+  * **Unresponsiveness.** A **renderer process** might become unresponsive to user input. This is only reported for renderer processes. See [Unresponsive Renderers](<link>) below for more details about this case.
+
+These situations can be identified through the details provided in the event. See the section below for how your application can do this.
+
+## Process Failure Details
+The `ProcessFailed` event provides information about the **kind of failure** and the **reason** why it occurred. Your application can interpret these details in the following manner:
+
+  * **Failure kind.** Due to historical reasons, this is a combination of process kind (browser, renderer, gpu, ...) and failure (exit, unresponsiveness). Your application can use _failure kind_ to determine the process that has failed. Renderer processes are further divided in _main frame_ renderer (`RenderProcessExited`, `RenderProcessUnresponsive`) and _subframe_ renderer (`FrameRenderProcessExited`). For more details about the conditions under which each specific _failure kind_ is used, see:
+    - COM: [COREWEBVIEW2_PROCESS_FAILED_KIND](<link>)
+    - .NET: [CoreWebView2ProcessFailedKind](<link>)
+    - WinRT: [CoreWebView2ProcessFailedKind](<link>)
+  * **Failure reason.** When the _failure kind_ is for an unexpected exit, _failure reason_ indicates the category of the problem causing the exit. Some of the _failure reasons_ are only applicable to specific _failure kinds_. For more details about what each of the _failure reasons_ means, see:
+    - COM: [COREWEBVIEW2_PROCESS_FAILED_REASON](<link>)
+    - .NET: [CoreWebView2ProcessFailedReason](<link>)
+    - WinRT: [CoreWebView2ProcessFailedReason](<link>)
+
+    > **Note:** for unresponsive renderer _failure kind_, the _failure reason_ is always `unresponsive`.
+
+Additionally, the `ProcessFailed` event provides more detailed information about the reported failure, including:
+  * Exit code
+  * Process description (utility only)
+  * Frames information (renderer only)
+
+Your application can leverage this information for diagnostics and other scenarios. For more information about when these details are provided and how your application can use them, see:
+  - COM: [ICoreWebView2ProcessFailedEventArgs](<link>), [ICoreWebView2ProcessFailedEventArgs2](<link>)
+  - .NET: [CoreWebView2ProcessFailedEventArgs](<link>)
+  - WinRT: [CoreWebView2ProcessFailedEventArgs](<link>)
+
+## Unexpected Exits
+The processes in the _WebView2 Process Group_ can be associated to one or many WebView2 controls in your application. For example:
+
+  * **Browser process.** There is a single browser process in the _WebView2 Process Group_. Every WebView2 control with the same environment configuration will share this process.
+  * **Renderer process.** Renderer processes can be associated many-to-many with the WebView2 controls in your application. The details about how this works depend on many factors, including what sites are loaded in the WebView2 control (main frame and subframes), system resources, and runtime configuration. A single renderer process in the _WebView2 Process Group_ can be associated with one or many WebView2 controls in your app.
+  * **GPU process.** There is a single GPU process in the _WebView2 Process Group_. It is associated with all WebView2 controls using this _WebView2 Process Group_.
+  * **Utility processes.** Utility processes host one or more _services_ in the _WebView2 Process Group_. Each utility process supports the entire _WebView2 Process Group_ and is thus associated with all WebView2 controls using this _WebView2 Process Group_.
+
+  > **Note:** do not rely on the details about how processes are associated to each WebView2 control, as they are part of the evolving Chromium architecture and subject to change even due to configuration and system conditions. For more information see [Process Model](<link>).
+
+When a process in the _WebView2 Process Group_ exits unexpectedly (for example, due to a crash), every WebView2 control **associated** to it will raise a `ProcessFailed` event. You can use the [Process Failure Details](<link>) to decide how to handle each case. The following are some examples of what these cases can be:
+
+* **The browser process has exited unexpectedly.** All the WebView2 controls in your application using the same environment configuration will receive the `ProcessFailed` event with:
+    - **Failure kind:** `BrowserProcessExited` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
+    - **Failure reason:** any, except `Unresponsive` and `LaunchFailed`.
+
+  All associated WebView2 controls will be closed and your application must handle recovery from this failure. The WebView2 controls need to be recreated.
+
+  A single `BrowserProcessExited` event will be raised from the `CoreWebview2Environment` too. See [Browser Process Crashes](<link>) for more details.
+
+* **A process rendering content in the WebView2 control has exited unexpectedly.** The content in impacted frames (main or subframe) is replaced with an error page. Every WebView2 control where content is impacted will receive the `ProcessFailed` event with:
+    - **Failure kind:** `RenderProcessExited` or `FrameRenderProcessExited` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
+    - **Failure reason:** any, except `Unresponsive` and `ProfileDeleted`.
+
+  Your application must handle recovery from this failure. If the main frame is impacted (`RenderProcessExited`), you can use the `Reload` API ([COM](<link>), [.NET](<link>), [WinRT](<link>)) to reload content in your controls. Alternatively, you can `Close` ([COM](<link>), [.NET](<link>), [WinRT](<link>)) and recreate the WebView2 controls.
+
+  If the main frame is not impacted (`FrameRenderProcessExited`), your application can communicate with the main frame to recover content in the impacted frames. The `ProcessFailed` event will provide details for the impacted frames through `FrameInfosForFailedProcess` ([COM](<link>), [.NET](<link>), [WinRT](<link>)).
+
+* **The GPU process has exited unexpectedly.** The content in your WebView2 controls might flash as the process is automatically recreated. Every WebView2 control in the _WebView2 Process Group_ will receive the `ProcessFailed` event with:
+    - **Failure kind:** `GpuProcessExited` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
+    - **Failure reason:** any, except `Unresponsive` and `ProfileDeleted`.
+
+  This is the most common WebView2 process failure and is auto-recoverable. Your application does **not** need to handle recovery for this event, but can collect information to understand any persistent issues, or if there is an underlying cause for repeated GPU process exits. See [Gathering Details](<link>) for more information.
+
+* **A utility process has exited unexpectedly.** There might be some interruptions (for example, if the utility process was hosting the audio service) necessary processes are automatically recreated. Every WebView2 control in the _WebView2 Process Group_ will receive the `ProcessFailed` event with:
+    - **Failure kind:** `UtilityProcessExited` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
+    - **Failure reason:** any, except `Unresponsive` and `ProfileDeleted`.
+
+  This process failure is not fatal and is auto-recoverable. Your application does **not** need to handle recovery for this event, but can collect information to understand any persistent issues. See [Gathering Details](<link>) for more information.
+
+* **Any other process has exited unexpectedly.** Most processes in the _WebView2 Process Group_ are associated to all WebView2 controls using it and will raise `ProcessFailed` to each control with:
+    - **Failure kind:** any, except for the ones mentioned above.
+    - **Failure reason:** any, except `Unresponsive` and `ProfileDeleted`.
+
+  These process failures are not fatal and your application does **not** need to handle recovery for any of them, but can collect information to understand any persistent issues. See [Gathering Details](<link>) for more information.
+
+## Unresponsive Renderers
+When the renderer process for the main frame in a WebView2 control becomes unresponsive to user input, the `ProcessFailed` event will be raised with:
+
+  - **Failure kind:** `RenderProcessUnresponsive` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
+  - **Failure reason:** `Unresponsive`
+
+The event will continue to be raised every set period of time as long as the process remains unresponsive. Renderer process unresponsiveness can happen for the following reasons:
+
+  * There is a **long-running script** being executed. For example, the web content in your WebView2 control might be performing a synchronous XHR, or have entered an infinite loop. Reloading ([COM](<link>), [.NET](<link>), [WinRT](<link>)) the WebView2 control might make it responsive again.
+  * The **system is busy**.
+
+As this event will be raised repeatedly, you must decide the threshold for your application to act upon it.
+
+## Gathering Details
+Your application can use and collect information from [Process Failure Details](<link>) to identify the most frequent issues for your application.
+
+> **Note:** some process failures might raise the `ProcessFailed` event across different WebView2 controls in your application (see [Unexpected Exits](<link>) for more information). You must decide how often to gather details and how to handle duplicates for these cases.
+
+Additionally, most process crashes will generate dumps in the [User Data Folder](<link>) or the configured `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
+
+# Browser Process Crashes
+When the browser process in the _WebView2 Process Group_ exits unexpectedly, **both** events discussed in this document will be raised:
+
+  * `CoreWebView2.ProcessFailed`
+  * `CoreWebView2Environment.BrowserProcessExited`
+
+`ProcessFailed` will be raised for every WebView2 control in the application that has been impacted by the failure, while `BrowserProcessExited` will be raised from each CoreWebView2Environment that is associated with the failing process. The order of these events is not guaranteed.
+
+You can use the `ProcessFailed` event to handle recovery for your application. For example, by re-creating your WebView2 controls when the event is received with **failure kind** of `BrowserProcessExited`.
+
+While a `BrowserProcessexited` **event** will be raised too, this event is intended for operations involving the WebView2 Runtime resources (such as the _User Data Folder_) and lifetime (such as updates, re-launch). The _exit kind_ event argument ([COM](<link>), [.NET](<link>), [WinRT](<link>)) is provided so your application can identify this scenario and coordinate with your `ProcessFailed` event handlers. For example, you might want to prevent racing conditions that could arise from attempting recovery while also trying to remove the _User Data Folder_.

--- a/microsoft-edge/webview2/concepts/process-related-events.md
+++ b/microsoft-edge/webview2/concepts/process-related-events.md
@@ -9,7 +9,8 @@ To improve the reliability of your WebView2 application, it is recommended that 
   * [A renderer process has exited unexpectedly](<link>).
   * [A renderer process has become unresponsive](<link>).
 
-> **Note:** this document is a high-level overview of the aforementioned events. Ultimately, the reference documentation for each individual API mentioned in this document shall prevail.
+> [!NOTE]
+> This document is a high-level overview of the aforementioned events. Ultimately, the reference documentation for each individual API mentioned in this document shall prevail.
 
 # WebView2 Process Model and related APIs
 The [WebView2 Process Model](<link>) uses the WebView2 Runtime to support your WebView2 application. Because most of the magic in the WebView2 controls in your application happens out-of-process (in the WebView2 Runtime), failures and general information about these processes are passed to your application through different WebView2 APIs. The APIs used to report this information to your application include:
@@ -22,7 +23,8 @@ The [WebView2 Process Model](<link>) uses the WebView2 Runtime to support your W
     - `ProcessInfosChanged` event
     - `GetProcessInfos` method
 
-  > **Note:** this is an overview at the conceptual level. For detailed API names and related types in your app's framework, see [Process Management](<link>).
+  > [!NOTE]
+  > This is an overview at the conceptual level. For detailed API names and related types in your app's framework, see [Process Management](<link>).
 
 In this document, we discuss how to handle process exits and failures, using the `CoreWebView2.ProcessFailed` and `CoreWebView2Environment.BrowserProcessExited` events.
 
@@ -33,14 +35,16 @@ The WebView2 Runtime is composed of different types of processes, including:
   * Utility processes
   * GPU process
 
-  > **Note:** This is an illustrative and incomplete list of process kinds. The purpose and management details for these processes is part of the Chromium architecture and beyond the scope of this document, or the WebView2 architecture.
+  > [!NOTE]
+  > This is an illustrative and incomplete list of process kinds. The purpose and management details for these processes is part of the Chromium architecture and beyond the scope of this document, or the WebView2 architecture.
 
 When you create and initialize a WebView2 control, WebView2 will ensure there's a WebView2 Runtime to power your control and connect to its [WebView2 Process Group](<link>). Once this connection is established, your control will start monitoring these processes for the following events:
 
   * **Browser process exits.** If the browser process exits for _any reason_, the `CoreWebView2Environment` will raise the `BrowserProcessExited` event. Use this event to synchronize operations involving the WebView2 Runtime resources and lifetime, such as _User Data Folder_ management and updates. See [Browser Process Exits](<link>) below for more details.
   * **Any process failure.** When _any of the processes_ in the WebView2 Runtime fails, the CoreWebView2 will raise the `ProcessFailed` event. Use this event for diagnostics and recovery from failures in the WebView2 processes. See [Process Failures](<link>) below for more details.
 
-  > **Note:** there is some overlap between these two events. For example, a browser process crash will produce both a `ProcessFailed` event and a `BrowserProcessExited` event, since the browser process _exited_ because of a failure. See [Browser Process Crashes](<link>) for more information about this case.
+  > [!NOTE]
+  > There is some overlap between these two events. For example, a browser process crash will produce both a `ProcessFailed` event and a `BrowserProcessExited` event, since the browser process _exited_ because of a failure. See [Browser Process Crashes](<link>) for more information about this case.
 
 `CoreWebView2` and `CoreWebView2Environment` report these events so your application can react accordingly. There are multiple scenarios your application can handle through these events.
 
@@ -63,7 +67,8 @@ This event provides the _exit kind_ and the _process ID_ so your application can
 The `ProcessFailed` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that _any_ of the processes in the _WebView2 Process Group_ has encountered one of the following situations:
 
   * **Unexpected exit.** The process indicated by the event has exited unexpectedly (usually due to a crash). The failure might or might not be recoverable and some failures are auto-recoverable. See [Unexpected Exits](<link>) below for details about which of these can be handled by your application.
-    > **Note:** When the impacted process is the browser process, a `BrowserProcessExited` event will raise too. See [Browser Process Crashes](<link>) below to handle this case.
+    > [!NOTE]
+    > When the impacted process is the browser process, a `BrowserProcessExited` event will raise too. See [Browser Process Crashes](<link>) below to handle this case.
   * **Unresponsiveness.** A **renderer process** might become unresponsive to user input. This is only reported for renderer processes. See [Unresponsive Renderers](<link>) below for more details about this case.
 
 These situations can be identified through the details provided in the event. See the section below for how your application can do this.
@@ -80,7 +85,8 @@ The `ProcessFailed` event provides information about the **kind of failure** and
     - .NET: [CoreWebView2ProcessFailedReason](<link>)
     - WinRT: [CoreWebView2ProcessFailedReason](<link>)
 
-    > **Note:** for unresponsive renderer _failure kind_, the _failure reason_ is always `unresponsive`.
+    > [!NOTE]
+    > For unresponsive renderer _failure kind_, the _failure reason_ is always `unresponsive`.
 
 Additionally, the `ProcessFailed` event provides more detailed information about the reported failure, including:
   * Exit code
@@ -100,7 +106,8 @@ The processes in the _WebView2 Process Group_ can be associated to one or many W
   * **GPU process.** There is a single GPU process in the _WebView2 Process Group_. It is associated with all WebView2 controls using this _WebView2 Process Group_.
   * **Utility processes.** Utility processes host one or more _services_ in the _WebView2 Process Group_. Each utility process supports the entire _WebView2 Process Group_ and is thus associated with all WebView2 controls using this _WebView2 Process Group_.
 
-  > **Note:** do not rely on the details about how processes are associated to each WebView2 control, as they are part of the evolving Chromium architecture and subject to change even due to configuration and system conditions. For more information see [Process Model](<link>).
+  > [!NOTE]
+  > Do not rely on the details about how processes are associated to each WebView2 control, as they are part of the evolving Chromium architecture and subject to change even due to configuration and system conditions. For more information see [Process Model](<link>).
 
 When a process in the _WebView2 Process Group_ exits unexpectedly (for example, due to a crash), every WebView2 control **associated** to it will raise a `ProcessFailed` event. You can use the [Process Failure Details](<link>) to decide how to handle each case. The following are some examples of what these cases can be:
 
@@ -154,7 +161,8 @@ As this event will be raised repeatedly, you must decide the threshold for your 
 ## Gathering Details
 Your application can use and collect information from [Process Failure Details](<link>) to identify the most frequent issues for your application.
 
-> **Note:** some process failures might raise the `ProcessFailed` event across different WebView2 controls in your application (see [Unexpected Exits](<link>) for more information). You must decide how often to gather details and how to handle duplicates for these cases.
+> [!NOTE]
+> Some process failures might raise the `ProcessFailed` event across different WebView2 controls in your application (see [Unexpected Exits](<link>) for more information). You must decide how often to gather details and how to handle duplicates for these cases.
 
 Additionally, most process crashes will generate dumps in the [User Data Folder](<link>) or the configured `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
 

--- a/microsoft-edge/webview2/concepts/process-related-events.md
+++ b/microsoft-edge/webview2/concepts/process-related-events.md
@@ -24,7 +24,7 @@ To improve the reliability of your WebView2 application, it is recommended that 
 > This document is a high-level overview of the aforementioned events. Ultimately, the reference documentation for each individual API mentioned in this document shall prevail.
 
 ## WebView2 Process Model and related APIs
-The [WebView2 Process Model](<link>) uses the WebView2 Runtime to support your WebView2 application. Because most of the magic in the WebView2 controls in your application happens out-of-process (in the WebView2 Runtime), failures and general information about these processes are passed to your application through different WebView2 APIs. The APIs used to report this information to your application include:
+The [WebView2 Process Model](process-model.md) uses the WebView2 Runtime to support your WebView2 application. Because most of the magic in the WebView2 controls in your application happens out-of-process (in the WebView2 Runtime), failures and general information about these processes are passed to your application through different WebView2 APIs. The APIs used to report this information to your application include:
 
   * CoreWebView2
     - `BrowserProcessId` property
@@ -35,7 +35,7 @@ The [WebView2 Process Model](<link>) uses the WebView2 Runtime to support your W
     - `GetProcessInfos` method
 
   > [!NOTE]
-  > This is an overview at the conceptual level. For detailed API names and related types in your app's framework, see [Process Management](<link>).
+  > This is an overview at the conceptual level. For detailed API names and related types in your app's framework, see [Process Management](overview-features-apis.md#process-management).
 
 In this document, we discuss how to handle process exits and failures, using the `CoreWebView2.ProcessFailed` and `CoreWebView2Environment.BrowserProcessExited` events.
 
@@ -49,7 +49,7 @@ The WebView2 Runtime is composed of different types of processes, including:
   > [!NOTE]
   > This is an illustrative and incomplete list of process kinds. The purpose and management details for these processes is part of the Chromium architecture and beyond the scope of this document, or the WebView2 architecture.
 
-When you create and initialize a WebView2 control, WebView2 will ensure there's a WebView2 Runtime to power your control and connect to its [WebView2 Process Group](<link>). Once this connection is established, your control will start monitoring these processes for the following events:
+When you create and initialize a WebView2 control, WebView2 will ensure there's a WebView2 Runtime to power your control and connect to its [WebView2 Process Group](process-model.md#processes-in-the-webview2-runtime). Once this connection is established, your control will start monitoring these processes for the following events:
 
   * **Main browser process exits.** If the main browser process exits for _any reason_, the `CoreWebView2Environment` will raise the `BrowserProcessExited` event. Use this event to synchronize operations involving the WebView2 Runtime resources and lifetime, such as _User Data Folder_ management and updates. See [Main Browser Process Exits](<link>) below for more details.
   * **Any process failure.** When _any of the processes_ in the WebView2 Runtime fails, the CoreWebView2 will raise the `ProcessFailed` event. Use this event for diagnostics and recovery from failures in the WebView2 processes. See [Process Failures](<link>) below for more details.
@@ -63,7 +63,7 @@ When you create and initialize a WebView2 control, WebView2 will ensure there's 
 The `BrowserProcessExited` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that the main browser process has exited and its resources (including its child processes) have been released. This can happen for the following reasons:
 
   * All WebView2 controls from the CoreWebView2Environment have been closed. Example app scenarios include:
-    - **Clearing the [User Data Folder](<link>).** Your application needs to wait until the WebView2 Runtime has released the _User Data Folder_ before it can delete its contents. After closing all WebView2 controls, the `BrowserProcessExited` event indicates this has happened and your application can proceed with the operation.
+    - **Clearing the [User Data Folder](user-data-folder.md).** Your application needs to wait until the WebView2 Runtime has released the _User Data Folder_ before it can delete its contents. After closing all WebView2 controls, the `BrowserProcessExited` event indicates this has happened and your application can proceed with the operation.
     - **Updating the WebView2 Runtime.** In order to make use of the latest WebView2 Runtime after an update, your application needs to close all WebView2 controls and create a new `CoreWebView2Environment`. To ensure the new version is used, your application must wait for the `BrowserProcessExited` event; otherwise, the main browser process might stay alive when the new environment is created and switching to the new version would fail.
     - **Restarting with a different environment configuration.** Most of the configuration used for a `CoreWebView2Environment` is bound to the main browser process lifetime. In order to make changes to this configuration (for example, to language), your application needs to close existing WebView2 controls and wait for `BrowserProcessExited` before recreating the controls; otherwise, initializing the WebView2 controls from the new CoreWebView2Environment might fail with incompatible configuration.
     - **Clearing auth cache.** Auth cache is bound to the main browser process lifetime. To clear the cache, your application must recreate its WebView2 controls from a new main browser process instance. To ensure a new main browser process instance is used when recreating the controls, your application must wait for the `BrowserProcessExited` event before proceeding; otherwise, the main browser process might stay alive when the cotrols are recreated and preserve the auth cache.
@@ -118,7 +118,7 @@ The processes in the _WebView2 Process Group_ can be associated to one or many W
   * **Utility processes.** Utility processes host one or more _services_ in the _WebView2 Process Group_. Each utility process supports the entire _WebView2 Process Group_ and is thus associated with all WebView2 controls using this _WebView2 Process Group_.
 
   > [!NOTE]
-  > Do not rely on the details about how processes are associated to each WebView2 control, as they are part of the evolving Chromium architecture and subject to change even due to configuration and system conditions. For more information see [Process Model](<link>).
+  > Do not rely on the details about how processes are associated to each WebView2 control, as they are part of the evolving Chromium architecture and subject to change even due to configuration and system conditions. For more information see [Process Model](process-model.md).
 
 When a process in the _WebView2 Process Group_ exits unexpectedly (for example, due to a crash), every WebView2 control **associated** to it will raise a `ProcessFailed` event. You can use the [Process Failure Details](<link>) to decide how to handle each case. The following are some examples of what these cases can be:
 
@@ -175,7 +175,7 @@ Your application can use and collect information from [Process Failure Details](
 > [!NOTE]
 > Some process failures might raise the `ProcessFailed` event across different WebView2 controls in your application (see [Unexpected Exits](<link>) for more information). You must decide how often to gather details and how to handle duplicates for these cases.
 
-Additionally, most process crashes will generate dumps in the [User Data Folder](<link>) or the configured `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
+Additionally, most process crashes will generate dumps in the [User Data Folder](user-data-folder.md) or the configured `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
 
 ## Main Browser Process Crashes
 When the main browser process in the _WebView2 Process Group_ exits unexpectedly, **both** events discussed in this document will be raised:

--- a/microsoft-edge/webview2/concepts/process-related-events.md
+++ b/microsoft-edge/webview2/concepts/process-related-events.md
@@ -1,4 +1,15 @@
-# Overview
+---
+title: Handling Process-related Events in WebView2
+description: Process-related events in WebView2 and how apps can handle them for recovery and improved reliability.
+author: MSEdgeTeam
+ms.author: msedgedevrel
+ms.topic: conceptual
+ms.prod: microsoft-edge
+ms.technology: webview
+ms.date: 06/20/2023
+---
+# Handling Process-related Events in WebView2
+## Overview
 The WebView2 API provides the `CoreWebView2.ProcessFailed` and `CoreWebView2Environment.BrowserProcessExited` events for your application to react to different scenarios. Use this document to learn how to use these events to react when these scenarios present.
 
   * `CoreWebView2.ProcessFailed`. Use this event for diagnostics and recovery from failures in the WebView2 processes.
@@ -12,7 +23,7 @@ To improve the reliability of your WebView2 application, it is recommended that 
 > [!NOTE]
 > This document is a high-level overview of the aforementioned events. Ultimately, the reference documentation for each individual API mentioned in this document shall prevail.
 
-# WebView2 Process Model and related APIs
+## WebView2 Process Model and related APIs
 The [WebView2 Process Model](<link>) uses the WebView2 Runtime to support your WebView2 application. Because most of the magic in the WebView2 controls in your application happens out-of-process (in the WebView2 Runtime), failures and general information about these processes are passed to your application through different WebView2 APIs. The APIs used to report this information to your application include:
 
   * CoreWebView2
@@ -28,7 +39,7 @@ The [WebView2 Process Model](<link>) uses the WebView2 Runtime to support your W
 
 In this document, we discuss how to handle process exits and failures, using the `CoreWebView2.ProcessFailed` and `CoreWebView2Environment.BrowserProcessExited` events.
 
-# Process Events
+## Process Events
 The WebView2 Runtime is composed of different types of processes, including:
   * Main browser process
   * Renderer processes
@@ -48,7 +59,7 @@ When you create and initialize a WebView2 control, WebView2 will ensure there's 
 
 `CoreWebView2` and `CoreWebView2Environment` report these events so your application can react accordingly. There are multiple scenarios your application can handle through these events.
 
-# Main Browser Process Exits
+## Main Browser Process Exits
 The `BrowserProcessExited` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that the main browser process has exited and its resources (including its child processes) have been released. This can happen for the following reasons:
 
   * All WebView2 controls from the CoreWebView2Environment have been closed. Example app scenarios include:
@@ -63,7 +74,7 @@ This event provides the _exit kind_ and the _process ID_ so your application can
   * .NET: [CoreWebView2BrowserProcessExitedEventArgs](<link>)
   * WinRT: [CoreWebView2BrowserProcessExitedEventArgs](<link>)
 
-# Process Failures
+## Process Failures
 The `ProcessFailed` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that _any_ of the processes in the _WebView2 Process Group_ has encountered one of the following situations:
 
   * **Unexpected exit.** The process indicated by the event has exited unexpectedly (usually due to a crash). The failure might or might not be recoverable and some failures are auto-recoverable. See [Unexpected Exits](<link>) below for details about which of these can be handled by your application.
@@ -73,7 +84,7 @@ The `ProcessFailed` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indic
 
 These situations can be identified through the details provided in the event. See the section below for how your application can do this.
 
-## Process Failure Details
+### Process Failure Details
 The `ProcessFailed` event provides information about the **kind of failure** and the **reason** why it occurred. Your application can interpret these details in the following manner:
 
   * **Failure kind.** Due to historical reasons, this is a combination of process kind (browser, renderer, gpu, ...) and failure (exit, unresponsiveness). Your application can use _failure kind_ to determine the process that has failed. Renderer processes are further divided in _main frame_ renderer (`RenderProcessExited`, `RenderProcessUnresponsive`) and _subframe_ renderer (`FrameRenderProcessExited`). For more details about the conditions under which each specific _failure kind_ is used, see:
@@ -98,7 +109,7 @@ Your application can leverage this information for diagnostics and other scenari
   - .NET: [CoreWebView2ProcessFailedEventArgs](<link>)
   - WinRT: [CoreWebView2ProcessFailedEventArgs](<link>)
 
-## Unexpected Exits
+### Unexpected Exits
 The processes in the _WebView2 Process Group_ can be associated to one or many WebView2 controls in your application. For example:
 
   * **Main browser process.** There is a single main browser process in the _WebView2 Process Group_. Every WebView2 control with the same environment configuration will share this process.
@@ -145,7 +156,7 @@ When a process in the _WebView2 Process Group_ exits unexpectedly (for example, 
 
   These process failures are not fatal and your application does **not** need to handle recovery for any of them, but can collect information to understand any persistent issues. See [Gathering Details](<link>) for more information.
 
-## Unresponsive Renderers
+### Unresponsive Renderers
 When the renderer process for the main frame in a WebView2 control becomes unresponsive to user input, the `ProcessFailed` event will be raised with:
 
   - **Failure kind:** `RenderProcessUnresponsive` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
@@ -158,7 +169,7 @@ The event will continue to be raised every set period of time as long as the pro
 
 As this event will be raised repeatedly, you must decide the threshold for your application to act upon it.
 
-## Gathering Details
+### Gathering Details
 Your application can use and collect information from [Process Failure Details](<link>) to identify the most frequent issues for your application.
 
 > [!NOTE]
@@ -166,7 +177,7 @@ Your application can use and collect information from [Process Failure Details](
 
 Additionally, most process crashes will generate dumps in the [User Data Folder](<link>) or the configured `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
 
-# Main Browser Process Crashes
+## Main Browser Process Crashes
 When the main browser process in the _WebView2 Process Group_ exits unexpectedly, **both** events discussed in this document will be raised:
 
   * `CoreWebView2.ProcessFailed`

--- a/microsoft-edge/webview2/concepts/process-related-events.md
+++ b/microsoft-edge/webview2/concepts/process-related-events.md
@@ -5,7 +5,7 @@ The WebView2 API provides the `CoreWebView2.ProcessFailed` and `CoreWebView2Envi
   * `CoreWebView2Environment.BrowserProcessExited`. Use this event to synchronize operations involving WebView2 Runtime resources and lifetime, such as User Data Folder management and updates.
 
 To improve the reliability of your WebView2 application, it is recommended that it handles at least the following events:
-  * [The browser process has exited unexpectedly](<link>).
+  * [The main browser process has exited unexpectedly](<link>).
   * [A renderer process has exited unexpectedly](<link>).
   * [A renderer process has become unresponsive](<link>).
 
@@ -30,7 +30,7 @@ In this document, we discuss how to handle process exits and failures, using the
 
 # Process Events
 The WebView2 Runtime is composed of different types of processes, including:
-  * Browser process
+  * Main browser process
   * Renderer processes
   * Utility processes
   * GPU process
@@ -40,23 +40,23 @@ The WebView2 Runtime is composed of different types of processes, including:
 
 When you create and initialize a WebView2 control, WebView2 will ensure there's a WebView2 Runtime to power your control and connect to its [WebView2 Process Group](<link>). Once this connection is established, your control will start monitoring these processes for the following events:
 
-  * **Browser process exits.** If the browser process exits for _any reason_, the `CoreWebView2Environment` will raise the `BrowserProcessExited` event. Use this event to synchronize operations involving the WebView2 Runtime resources and lifetime, such as _User Data Folder_ management and updates. See [Browser Process Exits](<link>) below for more details.
+  * **Main browser process exits.** If the main browser process exits for _any reason_, the `CoreWebView2Environment` will raise the `BrowserProcessExited` event. Use this event to synchronize operations involving the WebView2 Runtime resources and lifetime, such as _User Data Folder_ management and updates. See [Main Browser Process Exits](<link>) below for more details.
   * **Any process failure.** When _any of the processes_ in the WebView2 Runtime fails, the CoreWebView2 will raise the `ProcessFailed` event. Use this event for diagnostics and recovery from failures in the WebView2 processes. See [Process Failures](<link>) below for more details.
 
   > [!NOTE]
-  > There is some overlap between these two events. For example, a browser process crash will produce both a `ProcessFailed` event and a `BrowserProcessExited` event, since the browser process _exited_ because of a failure. See [Browser Process Crashes](<link>) for more information about this case.
+  > There is some overlap between these two events. For example, a main browser process crash will produce both a `ProcessFailed` event and a `BrowserProcessExited` event, since the main browser process _exited_ because of a failure. See [Main Browser Process Crashes](<link>) for more information about this case.
 
 `CoreWebView2` and `CoreWebView2Environment` report these events so your application can react accordingly. There are multiple scenarios your application can handle through these events.
 
-# Browser Process Exits
-The `BrowserProcessExited` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that the browser process has exited and its resources (including its child processes) have been released. This can happen for the following reasons:
+# Main Browser Process Exits
+The `BrowserProcessExited` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indicates that the main browser process has exited and its resources (including its child processes) have been released. This can happen for the following reasons:
 
   * All WebView2 controls from the CoreWebView2Environment have been closed. Example app scenarios include:
     - **Clearing the [User Data Folder](<link>).** Your application needs to wait until the WebView2 Runtime has released the _User Data Folder_ before it can delete its contents. After closing all WebView2 controls, the `BrowserProcessExited` event indicates this has happened and your application can proceed with the operation.
-    - **Updating the WebView2 Runtime.** In order to make use of the latest WebView2 Runtime after an update, your application needs to close all WebView2 controls and create a new `CoreWebView2Environment`. To ensure the new version is used, your application must wait for the `BrowserProcessExited` event; otherwise, the browser process might stay alive when the new environment is created and switching to the new version would fail.
-    - **Restarting with a different environment configuration.** Most of the configuration used for a `CoreWebView2Environment` is bound to the browser process lifetime. In order to make changes to this configuration (for example, to language), your application needs to close existing WebView2 controls and wait for `BrowserProcessExited` before recreating the controls; otherwise, initializing the WebView2 controls from the new CoreWebView2Environment might fail with incompatible configuration.
-    - **Clearing auth cache.** Auth cache is bound to the browser process lifetime. To clear the cache, your application must recreate its WebView2 controls from a new browser process instance. To ensure a new browser process instance is used when recreating the controls, your application must wait for the `BrowserProcessExited` event before proceeding; otherwise, the browser process might stay alive when the cotrols are recreated and preserve the auth cache.
-  * The browser process failed. See [Browser Process Crashes](<link>) below to handle this case.
+    - **Updating the WebView2 Runtime.** In order to make use of the latest WebView2 Runtime after an update, your application needs to close all WebView2 controls and create a new `CoreWebView2Environment`. To ensure the new version is used, your application must wait for the `BrowserProcessExited` event; otherwise, the main browser process might stay alive when the new environment is created and switching to the new version would fail.
+    - **Restarting with a different environment configuration.** Most of the configuration used for a `CoreWebView2Environment` is bound to the main browser process lifetime. In order to make changes to this configuration (for example, to language), your application needs to close existing WebView2 controls and wait for `BrowserProcessExited` before recreating the controls; otherwise, initializing the WebView2 controls from the new CoreWebView2Environment might fail with incompatible configuration.
+    - **Clearing auth cache.** Auth cache is bound to the main browser process lifetime. To clear the cache, your application must recreate its WebView2 controls from a new main browser process instance. To ensure a new main browser process instance is used when recreating the controls, your application must wait for the `BrowserProcessExited` event before proceeding; otherwise, the main browser process might stay alive when the cotrols are recreated and preserve the auth cache.
+  * The main browser process failed. See [Main Browser Process Crashes](<link>) below to handle this case.
 
 This event provides the _exit kind_ and the _process ID_ so your application can determine when and how to handle the event. For more information about these, see:
   * COM: [ICoreWebView2BrowserProcessExitedEventArgs](<link>)
@@ -68,7 +68,7 @@ The `ProcessFailed` event ([COM](<link>), [.NET](<link>), [WinRT](<link>)) indic
 
   * **Unexpected exit.** The process indicated by the event has exited unexpectedly (usually due to a crash). The failure might or might not be recoverable and some failures are auto-recoverable. See [Unexpected Exits](<link>) below for details about which of these can be handled by your application.
     > [!NOTE]
-    > When the impacted process is the browser process, a `BrowserProcessExited` event will raise too. See [Browser Process Crashes](<link>) below to handle this case.
+    > When the impacted process is the main browser process, a `BrowserProcessExited` event will raise too. See [Main Browser Process Crashes](<link>) below to handle this case.
   * **Unresponsiveness.** A **renderer process** might become unresponsive to user input. This is only reported for renderer processes. See [Unresponsive Renderers](<link>) below for more details about this case.
 
 These situations can be identified through the details provided in the event. See the section below for how your application can do this.
@@ -101,7 +101,7 @@ Your application can leverage this information for diagnostics and other scenari
 ## Unexpected Exits
 The processes in the _WebView2 Process Group_ can be associated to one or many WebView2 controls in your application. For example:
 
-  * **Browser process.** There is a single browser process in the _WebView2 Process Group_. Every WebView2 control with the same environment configuration will share this process.
+  * **Main browser process.** There is a single main browser process in the _WebView2 Process Group_. Every WebView2 control with the same environment configuration will share this process.
   * **Renderer process.** Renderer processes can be associated many-to-many with the WebView2 controls in your application. The details about how this works depend on many factors, including what sites are loaded in the WebView2 control (main frame and subframes), system resources, and runtime configuration. A single renderer process in the _WebView2 Process Group_ can be associated with one or many WebView2 controls in your app.
   * **GPU process.** There is a single GPU process in the _WebView2 Process Group_. It is associated with all WebView2 controls using this _WebView2 Process Group_.
   * **Utility processes.** Utility processes host one or more _services_ in the _WebView2 Process Group_. Each utility process supports the entire _WebView2 Process Group_ and is thus associated with all WebView2 controls using this _WebView2 Process Group_.
@@ -111,13 +111,13 @@ The processes in the _WebView2 Process Group_ can be associated to one or many W
 
 When a process in the _WebView2 Process Group_ exits unexpectedly (for example, due to a crash), every WebView2 control **associated** to it will raise a `ProcessFailed` event. You can use the [Process Failure Details](<link>) to decide how to handle each case. The following are some examples of what these cases can be:
 
-* **The browser process has exited unexpectedly.** All the WebView2 controls in your application using the same environment configuration will receive the `ProcessFailed` event with:
+* **The main browser process has exited unexpectedly.** All the WebView2 controls in your application using the same environment configuration will receive the `ProcessFailed` event with:
     - **Failure kind:** `BrowserProcessExited` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
     - **Failure reason:** any, except `Unresponsive` and `LaunchFailed`.
 
   All associated WebView2 controls will be closed and your application must handle recovery from this failure. The WebView2 controls need to be recreated.
 
-  A single `BrowserProcessExited` event will be raised from the `CoreWebview2Environment` too. See [Browser Process Crashes](<link>) for more details.
+  A single `BrowserProcessExited` event will be raised from the `CoreWebview2Environment` too. See [Main Browser Process Crashes](<link>) for more details.
 
 * **A process rendering content in the WebView2 control has exited unexpectedly.** The content in impacted frames (main or subframe) is replaced with an error page. Every WebView2 control where content is impacted will receive the `ProcessFailed` event with:
     - **Failure kind:** `RenderProcessExited` or `FrameRenderProcessExited` ([COM](<link>), [.NET](<link>), [WinRT](<link>))
@@ -166,8 +166,8 @@ Your application can use and collect information from [Process Failure Details](
 
 Additionally, most process crashes will generate dumps in the [User Data Folder](<link>) or the configured `FailureReportFolderPath` ([COM](<link>), [.NET](<link>), [WinRT](<link>)). You can use these dumps to understand crashes and provide additional information when contacting the WebView2 team.
 
-# Browser Process Crashes
-When the browser process in the _WebView2 Process Group_ exits unexpectedly, **both** events discussed in this document will be raised:
+# Main Browser Process Crashes
+When the main browser process in the _WebView2 Process Group_ exits unexpectedly, **both** events discussed in this document will be raised:
 
   * `CoreWebView2.ProcessFailed`
   * `CoreWebView2Environment.BrowserProcessExited`


### PR DESCRIPTION
Add WebView2 concepts doc: Process-related Events to provide app developers a better understanding of `ProcessFailed` and `BrowserProcessExited` events and how to handle them for recoverability and improved reliability.

### TODO
> To prevent churn, these are to be addressed after content-related issues are resolved.

- [ ] Links for APIs (COM, NET, WinRT)
- [ ] Links for internal references

AB#45161859