### PR TITLE
Corrected "Ctrl+W" to "Windows logo key + W"

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/ie-mode/index.md
+++ b/microsoft-edge/devtools-guide-chromium/ie-mode/index.md
@@ -46,7 +46,7 @@ If a tab uses IE mode, the tab has the following limitations:
 
 If Internet Explorer isn't available on your computer, to debug the content of an IE mode tab, use IEChooser to open Internet Explorer DevTools, as follows:
 
-1. In Windows, open the **Run** dialog.  For example, press the `Windows logo key` + `R`.
+1. In Windows, open the **Run** dialog.  For example, press **Windows logo key + R**.
 
 1. Enter `%systemroot%\system32\f12\IEChooser.exe`, and then click **OK**.
 

--- a/microsoft-edge/progressive-web-apps-chromium/how-to/widgets.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/widgets.md
@@ -415,7 +415,7 @@ PWAmp is a music player PWA demo application that defines a widget. The PWAmp wi
 
 1. Follow the instructions in [enable widgets in Microsoft Edge](#enable-widgets-in-microsoft-edge).
 1. Go to [PWAmp](https://microsoftedge.github.io/Demos/pwamp/) and install the app on Windows 11.
-1. Open the Windows 11 widgets board by pressing **🪟 Windows key+W**.
+1. Open the Windows 11 widgets board by pressing **Windows logo key + W**.
 1. Click **Add widgets** to open the **widgets settings** screen, scroll to the **PWAmp mini player** widget and add it.
 1. Close the **widgets settings** screen. The **PWAmp mini player** is now displayed in the widgets board.
 

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -114,7 +114,7 @@ Your WebView2 control must open the Chrome Developer Protocol (CDP) port to allo
 
 You will also need to add a new REGKEY `*--remote-debugging-port=9222` under `Computer\HKEY_CURRENT_USER\Software\Policies\Microsoft\Edge\WebView2\AdditionalBrowserArguments` so that the debugger can find the proper port. To add this registry key:
 
-1. Open the Registry Editor by clicking the `Windows logo key` and searching for **Registry Editor**. Open the Registry Editor application and select **Yes** to allow editing.
+1. Open the Registry Editor by pressing the **Windows logo key** and then searching for **registry editor**. Open the **Registry Editor** application, and then select **Yes** to allow editing.
 
 1. Set the registry key `HKEY_CURRENT_USER\Software\Policies\Microsoft\Edge\WebView2\AdditionalBrowserArguments` equal to `--remote-debugging-port=9222`.
 
@@ -182,7 +182,7 @@ If you're debugging Office Add-ins, open the add-in source code in a separate in
 
 1. Install a WebView2 Runtime version past `106.0.1370.34`.
 
-1. Open the Registry Editor by clicking the **Windows Key** and searching for **Registry Editor**. Open the **Registry Editor** application and select **Yes** to allow editing.
+1. Open the Registry Editor by pressing the **Windows logo key** and then searching for **registry editor**. Open the **Registry Editor** application and select **Yes** to allow editing.
 
 1. Set the registry key `HKEY_CURRENT_USER\Software\Policies\Microsoft\Edge\WebView2\AdditionalBrowserArguments` equal to `--remote-debugging-pipe`.  To do this, follow the steps outlined in the [Debug running processes](#debug-running-processes) section above.
 

--- a/microsoft-edge/webview2/samples/wv2deploymentwixburnbundlesample.md
+++ b/microsoft-edge/webview2/samples/wv2deploymentwixburnbundlesample.md
@@ -68,7 +68,7 @@ If you haven't installed WiX tools, the WiX deployment projects in Solution Expl
 
 1. Click the **OK** button.  The WiX installer window closes.
 
-1. Press the **Windows** key ![Windows key logo](./wv2deploymentwixburnbundlesample-images/windows-keyboard-logo.png) on your keyboard, type **Windows Features**, and then press **Enter**.  The **Turn Windows features on or off** dialog appears.
+1. Press the **Windows logo key** ![Windows logo key](./wv2deploymentwixburnbundlesample-images/windows-keyboard-logo.png), type **Windows features**, and then press **Enter**.  The **Turn Windows features on or off** dialog appears.
 
 1. Select the **.NET Framework 3.5 (includes .NET 2.0 and 3.0)** check box:
 

--- a/microsoft-edge/webview2/samples/wv2deploymentwixcustomactionsample.md
+++ b/microsoft-edge/webview2/samples/wv2deploymentwixcustomactionsample.md
@@ -59,7 +59,7 @@ If not done yet, install WiX Toolset:
 
 1. Click the **OK** button.  The WiX installer window closes.
 
-1. Press the **Windows** key ![Windows key logo](./wv2deploymentwixcustomactionsample-images/windows-keyboard-logo.png) on your keyboard, type **Windows Features**, and then press **Enter**.  The **Turn Windows features on or off** dialog appears.
+1. Press the **Windows logo key** ![Windows logo key](./wv2deploymentwixcustomactionsample-images/windows-keyboard-logo.png), type **Windows features**, and then press **Enter**.  The **Turn Windows features on or off** dialog appears.
 
 1. Select the **.NET Framework 3.5 (includes .NET 2.0 and 3.0)** check box:
 


### PR DESCRIPTION
This PR:
* Fixes "Ctrl+W", changing it to "Windows logo key + W".
* Normalizes formatting & wording around Windows key globally in repo.

Rendered article section for review:
GitHub rendered:
https://github.com/tanmay-veer/edge-developer/blob/main/microsoft-edge/progressive-web-apps-chromium/how-to/widgets.md#demo-app
Internal review site rendered:
https://review.learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps-chromium/how-to/widgets?branch=pr-en-us-2758#demo-app

Style guide:
https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/keys-keyboard-shortcuts#key-names - "Windows logo key" row

AB#45829798