### PR TITLE
Update winui2.md to use `SetEnvironmentVariable` from Environment class for setting default background colour

### DIFF
--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -365,7 +365,7 @@ XAML Island support requires additional work and may be considered for future re
 On WinUI 2, the `DefaultBackgroundColor` property is not exposed directly.  You can set the default background color by setting an environment variable, as follows:
 
 ```csharp
-Environment.SetVariable("WEBVIEW2_DEFAULT_BACKGROUND_COLOR", "FF000000");
+Environment.SetEnvironmentVariable("WEBVIEW2_DEFAULT_BACKGROUND_COLOR", "FF000000");
 ```
 
 See also:


### PR DESCRIPTION
Rendered article section for review:
https://review.learn.microsoft.com/microsoft-edge/webview2/get-started/winui2?branch=pr-en-us-2863#setting-defaultbackgroundcolor
[[GitHub's preview](https://github.com/SnowNooDLe/edge-developer/blob/patch-1/microsoft-edge/webview2/get-started/winui2.md#setting-defaultbackgroundcolor)]
[[Before](https://learn.microsoft.com/microsoft-edge/webview2/get-started/winui2#setting-defaultbackgroundcolor)]

fixes #2862 


Updating the document to use the existing method, `SetEnvironmentVariable` instead of the `SetVariable` in the section of setting the default background colour.

Edit: It doesn't seem like I can link the issue I just opened. But this is related to #2862 


By looking at the Environment class, it doesn't seem like it has the method named `SetVariable`, and I can see the usage of `SetEnvironmentVariable` with SmartScreen. 

![image](https://github.com/MicrosoftDocs/edge-developer/assets/7849113/50530f0d-ed7c-40be-a640-de32016ca24a)


AB#46964293