### PR TITLE
Skip aka-type link for VS Code DevTools extension

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/whats-new/2019/12/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2019/12/devtools.md
@@ -132,7 +132,7 @@ The DevTools team has also released some extensions for [Visual Studio Code](htt
 
 <!-- dup entries: 2019/12, 2020/01 -->
 
-Use the Elements tool from within Visual Studio Code by adding the [Elements for Microsoft Edge ](https://aka.ms/elements4code) Visual Studio Code extension.
+Use the Elements tool from within Visual Studio Code by adding the [Elements for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools) Visual Studio Code extension.
 
 ![The Elements tool in Visual Studio Code using the Elements for Microsoft Edge extension](./devtools-images/elements-for-edge.png)
 
@@ -145,7 +145,8 @@ For more information, check out [Microsoft Edge DevTools extension for Visual St
 
 <!-- dup entries: 2019/12, 2020/01 -->
 
-With the [Debugger for Microsoft Edge](https://aka.ms/debugger4code) Visual Studio Code extension, debug JavaScript running in Microsoft Edge directly from Visual Studio Code.
+With the Debugger for Microsoft Edge Visual Studio Code extension, debug JavaScript running in Microsoft Edge directly from Visual Studio Code.
+<!-- old url: https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge -->
 
 ![The Debugger for Microsoft Edge Extension in Visual Studio Code](./devtools-images/vscode-debugger.png)
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2020/01/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2020/01/devtools.md
@@ -158,7 +158,6 @@ For more information, check out [Microsoft Edge DevTools extension for Visual St
 
 With the Debugger for Microsoft Edge Visual Studio Code extension, debug JavaScript running in Microsoft Edge directly from Visual Studio Code.
 <!-- old url: https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge -->
-<!-- todo: consult w SME on desired presentation here -->
 
 ![The Debugger for Microsoft Edge Extension in Visual Studio Code](./devtools-images/vscode-debugger.png)
 


### PR DESCRIPTION
This PR fixes two quasi-404 links reported by doc build.