### PR TITLE
Fixed code snippet to actually create a large strings in the heap snapshot article

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/memory-problems/heap-snapshots.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/heap-snapshots.md
@@ -189,8 +189,8 @@ Name the functions, so that you can easily distinguish between closures in the s
 
 ```javascript
 function createLargeClosure() {
-    var largeStr = new Array(1000000).join('x');
-    var lC = function() { // this is NOT a named function
+    var largeStr = 'x'.repeat(1000000).toLowerCase();
+    var lC = function() { // This is not a named function
         return largeStr;
     };
     return lC;
@@ -201,8 +201,8 @@ The following code uses named functions, to easily distinguish between closures 
 
 ```javascript
 function createLargeClosure() {
-    var largeStr = new Array(1000000).join('x');
-    var lC = function lC() { // this IS a named function
+    var largeStr = 'x'.repeat(1000000).toLowerCase();
+    var lC = function lC() { // This is a named function
         return largeStr;
     };
     return lC;


### PR DESCRIPTION
Fixes #2851.

This should land at the same time as https://github.com/MicrosoftEdge/Demos/pull/31 which changes the corresponding demo code.

Before: https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/memory-problems/heap-snapshots#naming-functions-to-differentiate-between-closures-in-the-snapshot
After: https://review.learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/memory-problems/heap-snapshots?branch=pr-en-us-2889#naming-functions-to-differentiate-between-closures-in-the-snapshot

AB#47200652