### PR TITLE
Fixed typo in webview2 local content article

### DIFF
--- a/microsoft-edge/webview2/concepts/working-with-local-content.md
+++ b/microsoft-edge/webview2/concepts/working-with-local-content.md
@@ -428,7 +428,7 @@ When loading local content via `WebResourceRequested`, you specify the local con
 
 ###### Additional web resources
 
-`WebResourceRequested` modifies the content that's loaded via HTTP or HTTPS URLs, which support relative URL resolution. This menas that the resulting document can have references to additional web resources such as CSS, script, or image files that are also served via `WebResourceRequested`.
+`WebResourceRequested` modifies the content that's loaded via HTTP or HTTPS URLs, which support relative URL resolution. This means that the resulting document can have references to additional web resources such as CSS, script, or image files that are also served via `WebResourceRequested`.
 
 
 ###### Additional web resources resolved in WebView2 process


### PR DESCRIPTION
This is just a very quick fix for the typo reported in #2888. PR made by editing the file directly on github.com.

AB#47221270