### PR TITLE
Updated macOS command to use Edge

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/overview.md
+++ b/microsoft-edge/devtools-guide-chromium/overview.md
@@ -121,10 +121,10 @@ To have DevTools automatically open whenever you open a new tab in the browser:
    Start-Process -FilePath "msedge" -ArgumentList "--auto-open-devtools-for-tabs"
    ```
    
-   bash shell on macOS:
+   macOS Terminal:
    
    ```bash
-   /Applications/Microsoft\ Edge\ Beta.app/Contents/MacOS/Microsoft\ Edge\ Beta --auto-open-devtools-for-tabs
+   /Applications/Microsoft\ Edge.app/Contents/MacOS/Microsoft\ Edge --auto-open-devtools-for-tabs
    ```
    
    bash shell on Linux:


### PR DESCRIPTION
Fixes #2895 
Tested the macOS command in the Terminal, evidence below,

![open-devtools-new-tab-edge](https://github.com/MicrosoftDocs/edge-developer/assets/38640616/14ee2427-3bc3-4c0e-851b-e6a01643a2da)


AB#47282670