### PR TITLE
Add more info about the `userVisibleOnly` info used when subscribing to Push notifications

### DIFF
--- a/microsoft-edge/progressive-web-apps-chromium/how-to/push.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/push.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.prod: microsoft-edge
 ms.technology: pwa
-ms.date: 08/03/2023
+ms.date: 11/13/2023
 ---
 # Re-engage users with push messages
 
@@ -101,6 +101,8 @@ function urlBase64ToUint8Array(base64String) {
 
 The VAPID key that's mentioned in the previous code snippet is a public key that's used to identify the server that sends the push messages and encrypt the push message payload.  See [Step 3 - Send push messages from your server](#step-3---send-push-messages-from-your-server) for more information about VAPID keys.
 
+The `userVisibleOnly` configuration option of the `registration.pushManager.subscribe` function must be present and set to `true`.  This option indicates that the push message must be displayed to the user.  Microsoft Edge doesn't support push messages that aren't displayed to the user.
+
 
 <!-- ====================================================================== -->
 ## Step 3 - Send push messages from your server
@@ -138,6 +140,9 @@ self.addEventListener('push', event => {
   }
 });
 ```
+
+If your PWA doesn't display a notification when a push message is received, Microsoft Edge displays a generic notification that indicates that a push message was received.
+
 
 <!-- ====================================================================== -->
 ## See also


### PR DESCRIPTION
The `userVisibleOnly` configuration option used when subscribing to Push notifications is, in fact, mandatory and can only be set to true (i.e. silent push messages aren't allowed).

This is important to document to avoid users going through the trouble of setting everything up and only at the end realizing they can't do silent push.

Also, even if set to true, if the code doesn't display a notification, the browser displays a generic one. This should also be documented.