### PR TITLE
Normalize "Quick View" strings in repo

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/about-tools.md
+++ b/microsoft-edge/devtools-guide-chromium/about-tools.md
@@ -87,7 +87,7 @@ The **More tools** (**+**) menu in the **Activity Bar** and in the **Quick View*
 <!-- ====================================================================== -->
 ## Activity Bar tools vs. Quick View tools
 
-_Activity Bar tools_ are tools that open in the **Activity Bar** (upper pane) by default.  _Quick View_ tools are tools that open in the **Quick View** (lower pane) by default.  To show or hide **Quick View**, when focus is on DevTools, press **Esc**.
+_Activity Bar tools_ are tools that open in the **Activity Bar** (the upper pane) by default.  _Quick View_ tools are tools that open in the **Quick View** panel (the lower pane) by default.  To show or hide the **Quick View** panel: when focus is on DevTools, press **Esc**.
 
 The **Command Menu** first lists the **Activity Bar** tools (indicated by the **Panel** label), and then the **Quick View** tools:
 
@@ -107,9 +107,9 @@ To close a tool tab that's on a toolbar, right-click the tab, and then select **
 
 ![The right-click menu for the Network tool in the Activity Bar, including the 'Remove from Activity Bar' command](./about-tools-images/remove-from-activitybar.png)
 
-The **Elements**, **Console**, and **Sources** tools are permanent tabs and cannot be closed or moved from the Activity Bar to the Quick View panel.  You can drag their tabs to reorder them in the **Activity Bar**.
+The **Elements**, **Console**, and **Sources** tools are permanent tabs and cannot be closed or moved from the Activity Bar to the **Quick View** panel.  You can drag their tabs to reorder them in the **Activity Bar**.
 
-The **Console** tool is also a permanent tab on the Quick View toolbar.  In contrast, the **Issues** tool on the Quick View toolbar can be removed.
+The **Console** tool is also a permanent tab on the **Quick View** toolbar.  In contrast, the **Issues** tool on the **Quick View** toolbar can be removed.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-color-blindness.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-color-blindness.md
@@ -25,9 +25,9 @@ To check whether a webpage is usable by people with color blindness:
 
 1. Open the webpage in a new window or tab, such as the [accessibility-testing demo webpage](https://microsoftedge.github.io/Demos/devtools-a11y-testing/).
 
-1. Right-click anywhere in the webpage and then select **Inspect**.  Or, press **F12**.  DevTools opens next to the webpage.  By default, Quick View is open at the bottom of DevTools.
+1. Right-click anywhere in the webpage and then select **Inspect**.  Or, press **F12**.  DevTools opens next to the webpage.  By default, the **Quick View** panel is open at the bottom of DevTools.
 
-1. If Quick View isn't open already, press **Esc** to open Quick View.  In Quick View, click **More tools** (**+**), and then select the **Rendering** tool.
+1. If the **Quick View** panel isn't open already, press **Esc** to open the **Quick View** (when focus is on DevTools).  In the **Quick View** panel, click the **More tools** (**+**) button, and then select the **Rendering** tool.
 
 1. Scroll down to the **Emulate vision deficiencies** dropdown list, and then select **Protanopia (no red)**.  _Protanopia_ is reduced sensitivity to red light, making it hard to differentiate green, red, and yellow:
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-color-blindness.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-color-blindness.md
@@ -27,7 +27,7 @@ To check whether a webpage is usable by people with color blindness:
 
 1. Right-click anywhere in the webpage and then select **Inspect**.  Or, press **F12**.  DevTools opens next to the webpage.  By default, the **Quick View** panel is open at the bottom of DevTools.
 
-1. If the **Quick View** panel isn't open already, press **Esc** to open the **Quick View** (when focus is on DevTools).  In the **Quick View** panel, click the **More tools** (**+**) button, and then select the **Rendering** tool.
+1. If the **Quick View** panel isn't open already, press **Esc** to open the **Quick View** panel (when focus is on DevTools).  In the **Quick View** panel, click the **More tools** (**+**) button, and then select the **Rendering** tool.
 
 1. Scroll down to the **Emulate vision deficiencies** dropdown list, and then select **Protanopia (no red)**.  _Protanopia_ is reduced sensitivity to red light, making it hard to differentiate green, red, and yellow:
 

--- a/microsoft-edge/devtools-guide-chromium/console/index.md
+++ b/microsoft-edge/devtools-guide-chromium/console/index.md
@@ -23,7 +23,7 @@ You can open the **Console** tool in the top or bottom of DevTools; it's shown h
 
 ![The Console tool open in the upper panel](./index-images/console-main.png)
 
-The **Console** is shown here in the lower part of DevTools (the **Quick View**), with the **Elements** tool open above it:
+The **Console** is shown here in the lower part of DevTools (the **Quick View** panel), with the **Elements** tool open above it:
 
 ![The Console in the lower panel with the Elements tool open above it](./index-images/console-quick-view.png)
 

--- a/microsoft-edge/devtools-guide-chromium/customize/index.md
+++ b/microsoft-edge/devtools-guide-chromium/customize/index.md
@@ -40,19 +40,19 @@ To open Settings, in DevTools, click the **Customize and control DevTools** icon
 
 In the **Quick View** toolbar in the bottom of DevTools, you can select which tools to display.
 
-To open (or close) the **Quick View**, press **Esc**.
+To open (or close) the **Quick View** panel, press **Esc** when focus is on DevTools.
 
 ![The Drawer](./index-images/quick-view.png)
 
-You can move tools between the **Activity Bar** (at the top) and the **Quick View** (at the bottom).
+You can move tools between the **Activity Bar** (at the top) and the **Quick View** toolbar (at the bottom).
 
-*  To move a tool from the **Quick View** to the **Activity Bar**, right-click a tool, and then select **Move to top Activity Bar**:
+*  To move a tool from the **Quick View** toolbar to the **Activity Bar**, right-click a tool, and then select **Move to top Activity Bar**:
 
-   ![Moving a tool from the Quick View to the Activity Bar](./index-images/move-from-quick-view.png)
+   ![Moving a tool from the Quick View toolbar to the Activity Bar](./index-images/move-from-quick-view.png)
 
-*  To move a tool from the **Activity Bar** to the **Quick View**, right-click a tool, and then select **Move to bottom Quick View**:
+*  To move a tool from the **Activity Bar** to the **Quick View** toolbar, right-click a tool, and then select **Move to bottom Quick View**:
 
-   ![Moving a tool from the Activity Bar to the Quick View](./index-images/move-to-quick-view.png)
+   ![Moving a tool from the Activity Bar to the Quick View toolbar](./index-images/move-to-quick-view.png)
 
 
 <!-- ====================================================================== -->
@@ -68,7 +68,7 @@ For example, by default, the **Network** tool is the fifth tab on the Activity B
 <!-- ====================================================================== -->
 ## Open and close tools
 
-To keep the DevTools interface streamlined, many of the tools aren't opened by default.  To open a tool in the **Activity Bar** or the **Quick View**, click the **More Tools** (![More Tools](./index-images/open-tab-icon.png)) button to the right of the tabs, and then select a tool from the list:
+To keep the DevTools interface streamlined, many of the tools aren't opened by default.  To open a tool in the **Activity Bar** or the **Quick View** toolbar, click the **More Tools** (![More Tools](./index-images/open-tab-icon.png)) button to the right of the tabs, and then select a tool from the list:
 
 ![The More Tools (+) button to open a new tool](./index-images/open-tool-in-activity-bar.png)
 

--- a/microsoft-edge/devtools-guide-chromium/dom/index.md
+++ b/microsoft-edge/devtools-guide-chromium/dom/index.md
@@ -256,7 +256,7 @@ When you inspect a node, the `== $0` text next to the node means that you can re
 
 1. In the rendered webpage, under **Reference the currently-selected node with $0**, right-click **The Left Hand of Darkness** and then select **Inspect**.
 
-1. Press the **Esc** key to open the **Console** tool in the Quick View panel.
+1. Press the **Esc** key to open the **Console** tool in the **Quick View** panel.
 
 1. Type `$0` and press **Enter**.  The result of the expression shows that `$0` evaluates to `<p>The Left Hand of Darkness</p>`:
 

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -61,7 +61,6 @@ The following experimental features are turned on by default. You can use these 
 * [Enable background page selector (e.g. for prerendering debugging)](#enable-background-page-selector-eg-for-prerendering-debugging)
 * [Enable webhint](#enable-webhint)
 * [Show issues in Elements](#show-issues-in-elements)
-* [Focus Mode](#focus-mode) - selected by default on some machines.
 * [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
 * [View console.profile() results in the Performance panel for Node.js](#view-consoleprofile-results-in-the-performance-panel-for-nodejs)
 * [Enable Preloading Status Panel in Application panel](#enable-preloading-status-panel-in-application-panel)
@@ -80,7 +79,6 @@ The following experimental features are turned on by default. You can use these 
 * [Enable background page selector (e.g. for prerendering debugging)](#enable-background-page-selector-eg-for-prerendering-debugging)
 * [Enable webhint](#enable-webhint)
 * [Show issues in Elements](#show-issues-in-elements)
-* [Focus Mode](#focus-mode) - selected by default on some machines.
 * [Open source files in Visual Studio Code](#open-source-files-in-visual-studio-code)
 * [View console.profile() results in the Performance panel for Node.js](#view-consoleprofile-results-in-the-performance-panel-for-nodejs)
 * [Enable Preloading Status Panel in Application panel](#enable-preloading-status-panel-in-application-panel)

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -222,7 +222,7 @@ To monitor the messages sent and received by DevTools to debug the inspected pag
 
 1. Click the **Reload DevTools** button that appears next to the message.
 
-1. The **Protocol monitor** tool is displayed in **Quick View** or the **Drawer** at the bottom of DevTools.
+1. The **Protocol monitor** tool is displayed in the **Quick View** panel at the bottom of DevTools.
 
 Status:
 * This checkbox is present in Microsoft Edge Canary 120.
@@ -737,7 +737,7 @@ Focus Mode is a new user interface for DevTools.  Focus Mode is designed to simp
 
 Focus Mode replaces the main row of tabs with an **Activity Bar**, which is a compact toolbar with distinctive icons.  The **Activity Bar** makes it possible to pin, rearrange, and open your favorite tools, for quick access.  The **Activity Bar** also provides access to user settings, help, and other features.
 
-Focus Mode also provides a **Quick View** list, to open a second tool alongside the tool that's already selected in the **Activity Bar**.
+Focus Mode also provides a **Quick View** panel at the bottom of DevTools, to open a second tool alongside the tool that's already selected in the **Activity Bar**.
 
 See [Reduce the complexity of DevTools with Focus Mode](focus-mode.md).
 

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -730,23 +730,6 @@ Status:
 
 
 <!-- ====================================================================== -->
-## Focus Mode
-<!-- checkbox has a (?) link to this anchor wording -->
-
-Focus Mode is a new user interface for DevTools.  Focus Mode is designed to simplify and streamline the DevTools UI, without compromising its feature set.
-
-Focus Mode replaces the main row of tabs with an **Activity Bar**, which is a compact toolbar with distinctive icons.  The **Activity Bar** makes it possible to pin, rearrange, and open your favorite tools, for quick access.  The **Activity Bar** also provides access to user settings, help, and other features.
-
-Focus Mode also provides a **Quick View** panel at the bottom of DevTools, to open a second tool alongside the tool that's already selected in the **Activity Bar**.
-
-See [Reduce the complexity of DevTools with Focus Mode](focus-mode.md).
-
-Status:
-* This checkbox is present in Microsoft Edge Canary 120.
-* This checkbox is present in Microsoft Edge Stable 118.
-
-
-<!-- ====================================================================== -->
 ## Open source files in Visual Studio Code
 <!-- checkbox has a (?) link to this anchor wording -->
 

--- a/microsoft-edge/devtools-guide-chromium/issues/index.md
+++ b/microsoft-edge/devtools-guide-chromium/issues/index.md
@@ -48,9 +48,9 @@ Feedback in the **Issues** tool is provided by several sources, including the Ch
    <!--After a few seconds, the **Issues counter** (![Issues counter](./index-images/issues-counter-icon.png)) appears in the upper right corner of DevTools.
    1. Refresh the page, because some issues are reported based on network requests.  Notice the updated count in the **Issues counter**.-->
 
-1. In the Quick View toolbar at the bottom of DevTools, select the **Issues** tab, which is present by default.
+1. In the **Quick View** toolbar at the bottom of DevTools, select the **Issues** tab, which is present by default.
 
-   If Quick View isn't displayed, select **Customize and control DevTools** (**...**), and then select **Toggle Quick View panel** (**Esc**).  If the **Quick View** toolbar doesn't have the **Issues** tab, in the **Quick View** toolbar, click the **More tools** (**+**) button, and then select **Issues**.
+   If the **Quick View** panel isn't displayed, select **Customize and control DevTools** (**...**), and then select **Toggle Quick View panel** (**Esc**).  If the **Quick View** toolbar doesn't have the **Issues** tab, in the **Quick View** toolbar, click the **More tools** (**+**) button, and then select **Issues**.
 
    The **Issues** tool groups issues into categories, such as **Accessibility**, **Performance**, **Security**, and **Other**:
 
@@ -60,7 +60,7 @@ Feedback in the **Issues** tool is provided by several sources, including the Ch
 <!-- ------------------------------ -->
 #### Other ways to open the Issues tool
 
-*  In the **Activity Bar** or in **Quick View**, click the **More tools** (**+**) button, and then select **Issues**.
+*  In the **Activity Bar** or in the **Quick View** toolbar, click the **More tools** (**+**) button, and then select **Issues**.
 
 *  In the **Elements** tool, in the DOM tree, find a wavy-underlined element name, and then press and hold **Shift** and then click the element.  Or, right-click a wavy-underlined element, and then select **View issues**.  See [Open issues from the DOM tree](#open-issues-from-the-dom-tree), below.
 

--- a/microsoft-edge/devtools-guide-chromium/network-console/network-console-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/network-console/network-console-tool.md
@@ -64,7 +64,7 @@ To get to the **Network Console** tool by starting from the **Network** tool:
 
    ![Right-clicking a resource for the webpage to select 'Edit and resend' in the Network tool](./network-console-tool-images/edit-and-resend.png)
 
-   The **Network Console** tool opens in **Quick View** or the **Drawer** at the bottom of DevTools.
+   The **Network Console** tool opens in the **Quick View** panel at the bottom of DevTools.
 
 1. Click the **Hide Network Console navigator** (![The 'Hide Network Console navigator' icon](./network-console-tool-images/hide-network-console-navigator-icon.png)) button, to get more space.
 

--- a/microsoft-edge/devtools-guide-chromium/network/reference.md
+++ b/microsoft-edge/devtools-guide-chromium/network/reference.md
@@ -168,9 +168,9 @@ The **Disable Cache** checkbox:
 <!-- ---------- -->
 ###### Disable the browser cache from the Network conditions tool
 
-From the **Network** tool, you can open the **Network conditions** tool in the Quick View panel and then disable the browser cache from there:
+From the **Network** tool, you can open the **Network conditions** tool in the **Quick View** panel and then disable the browser cache from there:
 
-1. In the **Network** tool, click the **More network conditions** (![More network conditions icon](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the Quick View panel.
+1. In the **Network** tool, click the **More network conditions** (![More network conditions icon](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the **Quick View** panel.
 
 1. In the **Network conditions** tool, select the **Disable cache** checkbox:
 
@@ -219,9 +219,9 @@ See also [Simulate a slower network connection](../network/index.md#simulate-a-s
 <!-- ---------- -->
 ###### Emulate slow network connections from the Network Conditions tool
 
-From the **Network** tool, you can open the **Network conditions** tool in the Quick View panel and then throttle the network connection from there:
+From the **Network** tool, you can open the **Network conditions** tool in the **Quick View** panel and then throttle the network connection from there:
 
-1. In the **Network** tool, click the **More network conditions** (![The 'More network conditions' icon](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the Quick View panel.
+1. In the **Network** tool, click the **More network conditions** (![The 'More network conditions' icon](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the **Quick View** panel.
 
 1. In the **Network conditions** tool, in the **Network throttling** menu, select a connection speed.
 
@@ -242,7 +242,7 @@ To manually clear browser cookies at any time, right-click anywhere in the Reque
 
 To manually override the user agent:
 
-1. In the **Network** tool, click the **More network conditions** (![More network conditions icon.](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the Quick View panel.
+1. In the **Network** tool, click the **More network conditions** (![More network conditions icon.](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the **Quick View** panel.
 
 1. In the **Network conditions** tool, clear the **Use browser default** checkbox.  The other controls become available.
 
@@ -256,7 +256,7 @@ If your site employs user agent client hints and you want to test them, you can 
 
 To set user agent client hints in the **Network conditions** tool:
 
-1. In the **Network** tool, click the **More network conditions** (![The 'More network conditions' icon.](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the Quick View panel.
+1. In the **Network** tool, click the **More network conditions** (![The 'More network conditions' icon.](./reference-images/more-network-conditions-icon.png) button.  The **Network conditions** tool opens in the **Quick View** panel.
 
 1. In the **User agent** section, clear the **Use browser default** checkbox, and then expand **User agent client hints**:
 

--- a/microsoft-edge/devtools-guide-chromium/overview.md
+++ b/microsoft-edge/devtools-guide-chromium/overview.md
@@ -278,9 +278,9 @@ To change the location of the **Activity Bar**, do either of the following:
 <!-- ------------------------------ -->
 #### Change the location of Quick View
 
-By default, the **Quick View** panel is at the bottom of DevTools.  You can also put **Quick View** on the right side of DevTools.
+By default, the **Quick View** panel is at the bottom of DevTools.  You can also put the **Quick View** panel on the right side of DevTools.
 
-To display **Quick View**, press **Esc**.
+To display the **Quick View** panel, press **Esc**.
 
 To change the location of the **Quick View** panel, in the **Quick View** toolbar, click the **Dock Quick View to the right** button or the **Dock Quick View to the bottom** (![The Dock Quick View icon](./overview-images/move-quickview-icon.png)) button:
 
@@ -404,7 +404,7 @@ In the **Console** tool, you can:
 *  View and filter logged messages from network requests or from JavaScript log statements.
 *  Enter JavaScript statements to evaluate in realtime.  Expressions are evaluated in the current context, such as when the JavaScript debugger in the **Sources** tool is paused at a breakpoint.
 
-The **Console** tool is always present on the Activity Bar and on the Quick View toolbar.
+The **Console** tool is always present on the Activity Bar and on the **Quick View** toolbar.
 
 See [Console](console/index.md).
 
@@ -460,7 +460,7 @@ The **Customize and control DevTools** (![Customize and control DevTools](./over
 * Show keyboard shortcuts.
 * Change DevTools settings.
 * Open Device Emulation.
-* Toggle the Quick View panel.
+* Toggle the **Quick View** panel.
 * Run a command.
 * Search for code.
 * Open a file.
@@ -483,7 +483,7 @@ Click the **Close** DevTools (![Close DevTools icon](./overview-images/close-dev
 <!-- ====================================================================== -->
 ## Features of the Quick View toolbar
 
-Use **Quick View** to open a second tool below or to the right of the tool that's already selected in the **Activity Bar**:
+Use the **Quick View** panel to open a second tool below or to the right of the tool that's already selected in the **Activity Bar**:
 
 1. Select a tool from the **Activity Bar**.
 
@@ -520,7 +520,7 @@ The **More tools** (**+**) button is displayed both in the **Activity Bar** and 
 | Open a tool in the **Activity Bar** at the top of DevTools | In the **Activity Bar** at the top of DevTools, click **More tools** (**+**) and then select a tool. |
 | Open a tool on the **Quick View** toolbar | When DevTools has focus, press **Esc** to show the **Quick View** toolbar if it's not shown yet.  In the **Quick View** toolbar, click the **More tools** (**+**) button, and then select a tool. |
 | Move a tool from the **Quick View** toolbar to the **Activity Bar** | When DevTools has focus, press **Esc** to show the **Quick View**.  In the **Quick View** toolbar, right-click the tool's tab, and then select **Move to top Activity Bar** or **Move to left Activity Bar**. |
-| Move a tool from the **Activity Bar** to the **Quick View** Toolbar | In the **Activity Bar**, right-click the tool's tab, and then select **Move to bottom Quick View** or **Move to side Quick View**. |
+| Move a tool from the **Activity Bar** to the **Quick View** toolbar | In the **Activity Bar**, right-click the tool's tab, and then select **Move to bottom Quick View** or **Move to side Quick View**. |
 | Open a tool in its default toolbar (**Activity Bar** or **Quick View**) | When DevTools has focus, open the **Command Menu** by pressing **Ctrl+Shift+P** (Windows, Linux) or **Command+Shift+P** (macOS).  Type the name of the tool, and then select a **Show \<tool\>** command. |
 
 In addition to **Activity Bar** and **Quick View** tools, DevTools includes the following tools:
@@ -556,9 +556,9 @@ In the Command Menu, the tools are called "panels"; for example, the **Elements*
 
    ![Command menu displays the options after you type 'cha', including 'Show Changes tool in the Quick View'](./overview-images/command-menu-show-changes.png)
 
-1. Press **Enter** to select a **Show** command, such as **Show Changes**.  The selected tool opens in Quick View, at the bottom:
+1. Press **Enter** to select a **Show** command, such as **Show Changes**.  The selected tool opens in the **Quick View** panel, at the bottom:
 
-   ![DevTools with the Changes tool open in Quick View](./overview-images/showing-changes.png)
+   ![DevTools with the Changes tool open in the Quick View panel](./overview-images/showing-changes.png)
 
    The **Changes** tool is useful when you edit CSS.  In this example, the Command Menu provides a fast alternative to selecting **More tools** (**+**) and then selecting **Changes**.  This example also provides an alternative to editing a `.js` file in the **Sources** tool, and then right-clicking and selecting **Local modifications**.
 

--- a/microsoft-edge/devtools-guide-chromium/search/search-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/search/search-tool.md
@@ -27,7 +27,7 @@ To quickly open the **Search** tool:
 
    Or, press **Ctrl+Shift+F** (Windows, Linux) or **Command+Option+F** (macOS).
 
-The **Search** tool opens in the **Quick View** part of DevTools:
+The **Search** tool opens in the **Quick View** panel:
 
 ![The Search tool, with the search toolbar](./search-tool-images/search-tool-first-open.png)
 

--- a/microsoft-edge/devtools-guide-chromium/shortcuts/index.md
+++ b/microsoft-edge/devtools-guide-chromium/shortcuts/index.md
@@ -55,7 +55,7 @@ The following keyboard shortcuts are available in most DevTools panels.
 | Toggle [Device emulation](../device-mode/index.md) | **Ctrl+Shift+M** | **Command+Shift+M** |
 | Toggle **Inspect Element Mode** | **Ctrl+Shift+C** | **Command+Shift+C** |
 | Open the [Command Menu](../command-menu/index.md) | **Ctrl+Shift+P** | **Command+Shift+P** |
-| Toggle the [Quick View](../customize/index.md#quick-view) | **Esc** | **Esc** |
+| Toggle the [Quick View](../customize/index.md#quick-view) panel | **Esc** | **Esc** |
 | Normal refresh | **F5** or **Ctrl+R** | **Command+R** |
 | Hard refresh | **Ctrl+F5** or **Ctrl+Shift+R** | **Command+Shift+R** |
 | Search for text within the current panel.  Not supported in the **Audits**, **Application**, and **Security** tools | **Ctrl+F** | **Command+F** |

--- a/microsoft-edge/devtools-guide-chromium/storage/sessionstorage.md
+++ b/microsoft-edge/devtools-guide-chromium/storage/sessionstorage.md
@@ -106,7 +106,7 @@ You can run JavaScript expressions and statements in the **Console**, and the **
 
 To interact with `sessionStorage` by using the **Console**:
 
-1. In DevTools, select the **Console** tool.  For example, press **Esc** to display the Quick View panel, which always includes a **Console** tab.
+1. In DevTools, select the **Console** tool.  For example, press **Esc** to display the **Quick View** panel, which always includes a **Console** tab.
 
 1. If you want to access the `sessionStorage` key-value pairs of a domain other than the page you're on, use the **JavaScript contexts** menu to change the JavaScript context of the **Console**:
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2022/05/devtools-102.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2022/05/devtools-102.md
@@ -127,7 +127,7 @@ The **Detached Elements** tool's UI is displayed correctly in high-contrast mode
 
 ![Detached Elements tool in high-contrast mode](devtools-102-images/high-contrast-detached-elements.png)
 
-The **Activity Bar** and **Quick View** (of Focus Mode) are displayed correctly in high-contrast mode:
+The **Activity Bar** and **Quick View** panel (when using Focus Mode) are displayed correctly in high-contrast mode:
 
 ![Activity Bar in Focus Mode](devtools-102-images/high-contrast-activity-bar.png)
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2022/06/devtools-103.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2022/06/devtools-103.md
@@ -61,9 +61,9 @@ In the new **Focus Mode** DevTools UI, various bugs affecting controls and keybo
 *  Improved reliability of **Quick View** controls.
 *  Improved behavior of opening DevTools by using keyboard shortcuts.
 *  Fixed an issue with navigating to a specific line of code in the **Sources** tool by using keyboard shortcuts.
-*  Restored the keyboard shortcut to open **Search** in **Quick View**, which is **Ctrl+Shift+F** (Windows, Linux) or **Command+Option+F** (macOS):
+*  Restored the keyboard shortcut to open **Search** in the **Quick View** panel, which is **Ctrl+Shift+F** (Windows, Linux) or **Command+Option+F** (macOS):
 
-![The Search keyboard shortcut opens the Search tool in Quick View](devtools-103-images/focus-mode-search-shortcut.png)
+![The Search keyboard shortcut opens the Search tool in the Quick View panel](devtools-103-images/focus-mode-search-shortcut.png)
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2022/09/devtools-105.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2022/09/devtools-105.md
@@ -66,7 +66,7 @@ See also:
 <!-- Title: Focus Mode: Improved location controls for DevTools, Activity Bar, and Quick View -->
 <!-- Subtitle: Focus Mode: Improved location controls for DevTools, Activity Bar, and Quick View. -->
 
-In Microsoft Edge 105, several improvements to location controls have been made, including a new option for changing the orientation of **Quick View**.
+In Microsoft Edge 105, several improvements to location controls have been made, including a new option for changing the orientation of the **Quick View** panel.
 
 The **Customize and control DevTools** (**...**) menu now directly contains buttons to set the docking location of DevTools, instead of requiring opening a submenu.  The **Dock location** icons now have greater contrast, and the currently selected **Dock location** button is now highlighted.
 
@@ -80,15 +80,15 @@ Selecting the docking location in Focus Mode, in Microsoft Edge 105:
 
 ![Dock location menu icons after](./devtools-105-images/after-docking-menu.png)
 
-You can now change the orientation of the **Quick View** panel as well.  To display **Quick View** vertically instead of horizontally, click the **Dock Quick View to right** button:
+You can now change the orientation of the **Quick View** toolbar and panel as well.  To display the **Quick View** panel vertically instead of horizontally, click the **Dock Quick View to right** button:
 
 ![Docking Quick View to the right](./devtools-105-images/quickview-console.png)
 
-To return **Quick View** to the horizontal orientation, click the **Dock Quick View to bottom** button:
+To return the **Quick View** toolbar and panel to the horizontal orientation, click the **Dock Quick View to bottom** button:
 
 ![Docking Quick View to the bottom](./devtools-105-images/dock-quick-view-bottom.png)
 
-To minimize **Quick View** in either orientation, click the **Collapse Quick View** button, or press **Esc**:
+To minimize the **Quick View** panel in either orientation, click the **Collapse Quick View** button, or press **Esc**:
 
 ![Minimizing Quick View](./devtools-105-images/focus-mode-improved-location-controls.png)
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2023/01/devtools-109.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2023/01/devtools-109.md
@@ -134,11 +134,11 @@ See also:
 
 <!-- Subtitle: Quick View now allows you to pick any tool, show several tools at once and persists across sessions. -->
 
-We listened to your feedback and improved the **Quick View** options in Focus Mode.  Instead of offering only a subset of the tools in a **Quick View** drop-down list, you can now select any DevTools tool by clicking the **More Tools** (![More Tools icon](./devtools-109-images/more-tools-icon-light-theme.png)) button, like in the main toolbar of DevTools.  Load any tool in the **Quick View** pane of DevTools, to show multiple tools at the same time.
+We listened to your feedback and improved the **Quick View** options in Focus Mode.  Instead of offering only a subset of the tools in a **Quick View** drop-down list, you can now select any DevTools tool by clicking the **More Tools** (![More Tools icon](./devtools-109-images/more-tools-icon-light-theme.png)) button, like in the main toolbar of DevTools.  Load any tool in the **Quick View** panel of DevTools, to show multiple tools at the same time.
 
-The state of your **Quick View** persists across DevTools sessions.  The **Quick View** pane automatically collapses if you open the same tool in the upper pane of DevTools.
+The state of your **Quick View** toolbar persists across DevTools sessions.  The **Quick View** panel automatically collapses if you open the same tool in the upper pane of DevTools.
 
-![Add tool to Quick View](./devtools-109-images/add-tool-to-quick-view.png)
+![Adding a tool to the Quick View panel](./devtools-109-images/add-tool-to-quick-view.png)
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2023/02/devtools-110.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2023/02/devtools-110.md
@@ -32,13 +32,13 @@ See also:
 
 <!-- Subtitle: Customize both the Activity Bar and Quick View in Focus Mode to see only the tools you care about. -->
 
-Microsoft Edge 110 contains various improvements to Focus Mode in DevTools.  The following changes make it easier to customize the Activity Bar and Quick View, to show only the tools that you're currently interested in.
+Microsoft Edge 110 contains various improvements to Focus Mode in DevTools.  The following changes make it easier to customize the Activity Bar and the **Quick View** panel, to show only the tools that you're currently interested in.
 
 
 <!-- ------------------------------ -->
 #### When moving a tool, the right-click menu shows the current placement of the destination toolbar
 
-The right-click menu command for moving a tool between Quick View and the Activity Bar now indicates the placement of the destination toolbar, such as:
+The right-click menu command for moving a tool between the **Quick View** panel and the Activity Bar now indicates the placement of the destination toolbar, such as:
 * **Move to bottom Quick View**
 * **Move to side Quick View**
 * **Move to top Activity Bar**
@@ -50,9 +50,9 @@ The right-click menu command for moving a tool between Quick View and the Activi
 <!-- ------------------------------ -->
 #### The right-click menu is no longer displayed over the tool's tab in the toolbar
 
-The right-click menu for moving a tool between the Activity Bar and Quick View no longer obscures the tool's name in the toolbar.
+The right-click menu for moving a tool between the Activity Bar and the **Quick View** toolbar no longer obscures the tool's name in the toolbar.
 
-For example, the **Network Conditions** tool name remains visible when you right-click the tool's tab in Quick View:
+For example, the **Network Conditions** tool name remains visible when you right-click the tool's tab in the **Quick View** toolbar:
 
 ![The right-click menu in Quick View](./devtools-110-images/focus-mode-moving-tools-context-menu.png)
 
@@ -64,15 +64,15 @@ As another example, the **Network** tool name remains visible when you right-cli
 <!-- ------------------------------ -->
 #### Focus is preserved in Activity Bar or Quick View when moving a tool between them
 
-For keyboard shortcut and assistive technology users, focus is preserved in the Activity Bar or Quick View when moving the currently selected tool from one toolbar to the other, or when removing a tool from the toolbar.
+For keyboard shortcut and assistive technology users, focus is preserved in the Activity Bar or **Quick View** toolbar when moving the currently selected tool from one toolbar to the other, or when removing a tool from the toolbar.
 
-For example, suppose the **Network** tool has been moved to Quick View, and you right-click the **Network** tab on the Quick View toolbar:
+For example, suppose the **Network** tool has been moved to the **Quick View** toolbar, and you right-click the **Network** tab on the **Quick View** toolbar:
 
 ![Right-clicking the Network tool in Quick View](./devtools-110-images/right-click-network-tool-to-move.png)
 
-If you then select **Remove from Quick View**, focus stays in the Quick View toolbar and moves to the **Network conditions** tool, which is the next tool in Quick View:
+If you then select **Remove from Quick View**, focus stays in the **Quick View** toolbar and moves to the **Network conditions** tool, which is the next tool in the **Quick View** toolbar:
 
-![Focus stays in Quick View and moves to another tool in Quick View](./devtools-110-images/focus-moves-to-other-tool-same-toolbar.png)
+![Focus stays in the Quick View toolbar and moves to another tool in the Quick View toolbar](./devtools-110-images/focus-moves-to-other-tool-same-toolbar.png)
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2023/03/devtools-111.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2023/03/devtools-111.md
@@ -125,9 +125,9 @@ See also:
 <!-- ====================================================================== -->
 ## In Focus Mode, assistive technology announces when you move a tool to Quick View
 
-In previous versions of Microsoft Edge, assistive technology, such as screen readers, didn't announce confirmation when moving a tool from the Activity Bar to Quick View.  In Microsoft Edge 111, this issue has been fixed.  Screen readers now announce "Successfully added Network to Quick View" when you move the **Network** tool from the Activity Bar to Quick View:
+In previous versions of Microsoft Edge, assistive technology, such as screen readers, didn't announce confirmation when moving a tool from the Activity Bar to the **Quick View** toolbar.  In Microsoft Edge 111, this issue has been fixed.  Screen readers now announce "Successfully added Network to Quick View" when you move the **Network** tool from the Activity Bar to the **Quick View** toolbar:
 
-![Moving the Network tool from the Activity Bar to Quick View](./devtools-111-images/move-network-tool-to-quickview.png)
+![Moving the Network tool from the Activity Bar to the Quick View toolbar](./devtools-111-images/move-network-tool-to-quickview.png)
 
 See also:
 * [Navigate DevTools with assistive technology](../../../accessibility/navigation.md)

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2023/04/devtools-112.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2023/04/devtools-112.md
@@ -109,15 +109,15 @@ See also:
 <!-- ------------------------------ -->
 #### Pressing Esc shows or entirely hides Quick View
 
-In previous versions of Microsoft Edge, in **Focus Mode**, **Quick View** was always displayed, as either collapsed or expanded.  Pressing **Esc** expanded **Quick View** if it was collapsed, and vice versa.  However, when the **Console** tool was selected in the **Activity Bar**, pressing **Esc** when the **Quick View** was collapsed displayed a blank view.  In Microsoft Edge 112, this issue has been fixed.
+In previous versions of Microsoft Edge, in **Focus Mode**, the **Quick View** panel was always displayed, as either collapsed or expanded.  Pressing **Esc** expanded the **Quick View** panel if it was collapsed, and vice versa.  However, when the **Console** tool was selected in the **Activity Bar**, pressing **Esc** when the **Quick View** panel was collapsed displayed a blank view.  In Microsoft Edge 112, this issue has been fixed.
 
-Pressing **Esc** now shows or entirely hides **Quick View**.  If **Quick View** is currently hidden, pressing **Esc** shows **Quick View**, expanded:
+Pressing **Esc** now shows or entirely hides the **Quick View** panel.  If the **Quick View** panel is currently hidden, pressing **Esc** shows the **Quick View** panel, expanded:
 
-![Quick View expanded, by pressing Esc](./devtools-112-images/focus-mode-esc-shows-quick-view.png)
+![The Quick View panel expanded, by pressing Esc](./devtools-112-images/focus-mode-esc-shows-quick-view.png)
 
-If **Quick View** is currently shown (whether collapsed or expanded), pressing **Esc** entirely hides **Quick View**:
+If the **Quick View** toolbar is currently displayed (whether the **Quick View** panel is collapsed or expanded), pressing **Esc** entirely hides the **Quick View** toolbar and panel:
 
-![Quick View entirely hidden by pressing Esc, not just collapsed](./devtools-112-images/focus-mode-esc-hides-quick-view.png)
+![The Quick View toolbar and panel entirely hidden by pressing Esc](./devtools-112-images/focus-mode-esc-hides-quick-view.png)
 
 
 <!-- ------------------------------ -->


### PR DESCRIPTION
This PR is based on the big Focus Mode PR, and targets that PR.

Changes made by this PR:
* Did a full-text search on Quick View in repo.  Inspected all hits and did a consistency sweep of verbiage and bold formatting.  Largely changed to either of:
   * the **Quick View** panel
   * the **Quick View** toolbar