### PR TITLE
Fix link to Content Policies anchor

### DIFF
--- a/microsoft-edge/extensions-chromium/store-policies/developer-policies.md
+++ b/microsoft-edge/extensions-chromium/store-policies/developer-policies.md
@@ -530,7 +530,8 @@ If your extension provides content (such as user-generated, retail, or other web
 <!-- ------------------------------ -->
 #### 2.13 Videos
 
-If you submit a promotional video in the listing, then it should strictly adhere to our [content guidelines](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/store-policies/developer-policies#2-content-policies).
+If you submit a promotional video in the listing, it should strictly adhere to these [content policies](/microsoft-edge/extensions-chromium/store-policies/developer-policies#2-content-policies).
+
 
 <!-- ====================================================================== -->
 ## Complaint and appeal process for Microsoft Edge Add-ons certification 


### PR DESCRIPTION
Rendered article section for review:
https://review.learn.microsoft.com/microsoft-edge/extensions-chromium/store-policies/developer-policies?branch=pr-en-us-2982#213-videos

* This PR removes 1 warning and 1 suggestion from all PRs in this repo, in full webpage build report.
* This PR makes link text match destination heading, per style guides.  Important for navigation.
* Removes focus on "our/us/we"; keeps focus on the policies.
* Remove superfluous "then" that's usually omitted ([style guide](https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/i/if-vs-whether-vs-when)); streamlined for flow.

AB#48230843