### PR TITLE
Added a tip to autocomplete styles using values

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/css/reference.md
+++ b/microsoft-edge/devtools-guide-chromium/css/reference.md
@@ -216,8 +216,7 @@ To add an inline declaration:
 
 1. Enter a valid value for that property and press **Enter**.  In the **DOM Tree**, a `style` attribute has been added to the element.
 
-> [!TIP]
-> Alternatively, you can also enter the value in the property field, and DevTools will suggest a list of matching **property: value** pairs to select from. For example, if you enter `bold` in the property field then DevTools will suggest `font-weight: bold` and `font-weight: bolder` as the possible rules. Press **Enter** to apply the rule.
+Alternatively, enter the value in the property field, and DevTools will then suggest a list of matching **property: value** pairs to select from. For example, if you enter `bold` in the property field, DevTools suggests `font-weight: bold` and `font-weight: bolder` as the possible rules. Press **Enter** to apply the rule.
 
 In the following figure, the `margin-top` and `background-color` properties have been applied to the selected element.  In the **DOM Tree**, the declarations are reflected in the element's `style` attribute.
 

--- a/microsoft-edge/devtools-guide-chromium/css/reference.md
+++ b/microsoft-edge/devtools-guide-chromium/css/reference.md
@@ -216,6 +216,9 @@ To add an inline declaration:
 
 1. Enter a valid value for that property and press **Enter**.  In the **DOM Tree**, a `style` attribute has been added to the element.
 
+> [!TIP]
+> Alternatively, you can also enter the value in the property field, and DevTools will suggest a list of matching **property: value** pairs to select from. For example, if you enter `bold` in the property field then DevTools will suggest `font-weight: bold` and `font-weight: bolder` as the possible rules. Press **Enter** to apply the rule.
+
 In the following figure, the `margin-top` and `background-color` properties have been applied to the selected element.  In the **DOM Tree**, the declarations are reflected in the element's `style` attribute.
 
 ![Add inline declarations](./reference-images/css-elements-styles-margin-top-background-color.png)


### PR DESCRIPTION
Rendered article section for review:
https://review.learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/css/reference?branch=pr-en-us-2996#adding-an-inline-css-declaration-to-an-element -- new paragraph like:

Alternatively, enter the value in the property field, and DevTools will then suggest a list of matching property: value pairs to select from. For example, if you enter bold in the property field, ...

AB#48295949