### PR TITLE
Adding missing semicolon in two C# code samples

### DIFF
--- a/microsoft-edge/webview2/how-to/context-menus.md
+++ b/microsoft-edge/webview2/how-to/context-menus.md
@@ -448,7 +448,7 @@ webView.CoreWebView2.ContextMenuRequested += delegate (object sender,
             {
                 MessageBox.Show(pageUri, "Page Uri", MessageBoxButton.OK);
             }, null);
-        }
+        };
     menuList.Insert(menuList.Count, newItem);
 };
 ``` 

--- a/microsoft-edge/webview2/how-to/webresourcerequested.md
+++ b/microsoft-edge/webview2/how-to/webresourcerequested.md
@@ -165,7 +165,7 @@ webView.CoreWebView2.WebResourceRequested += delegate (
    }
    CoreWebView2HttpRequestHeaders requestHeaders = args.Request.Headers;
    requestHeaders.SetHeader("Custom", "Value");
-}
+};
 ```
 
 ##### [Win32](#tab/win32)


### PR DESCRIPTION
Fixes #3008.

I don't know C# myself, but every other examples of `delegate` usage in the repo, and on github seems to also require a semi-colon.