### PR TITLE
Removed step to select Screenshots checkbox

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -65,7 +65,7 @@ Mobile devices have much less CPU power than desktops and laptops.  Whenever you
 
    ![CPU throttle](./index-images/capture-settings.png)
 
-   If you want to ensure that pages work well on low-end mobile devices, set **CPU** to **6x slowdown**.  The demo doesn't work well with 6x slowdown, so it just uses 4x slowdown for instructional purposes.
+   If you want to ensure that pages work well on low-end mobile devices, set **CPU** to **6x slowdown**.
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md
@@ -59,8 +59,6 @@ Mobile devices have much less CPU power than desktops and laptops.  Whenever you
 
 1. In DevTools, open the **Performance** tool.
 
-1. Select the **Screenshots** checkbox.
-
 1. Click **Capture settings** (![Capture settings](./index-images/capture-settings-icon.png)).  DevTools reveals settings related to how it captures performance metrics.
 
 1. For **CPU**, select **4x slowdown**.  DevTools throttles your CPU so that it's 4 times slower than usual.


### PR DESCRIPTION
Rendered article section for review: 
Internal, fully rendered:
https://review.learn.microsoft.com/microsoft-edge/devtools-guide-chromium/evaluate-performance/?branch=pr-en-us-3032#simulate-a-mobile-cpu
Public GitHub Markdown preview:
https://github.com/pankajparashar/edge-developer/blob/patch-4/microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md#simulate-a-mobile-cpu

Live/Before: 
https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/evaluate-performance/#simulate-a-mobile-cpu

Fixes #3027 

Tested the simulation with Screenshot unchecked and 6x slowdown:

https://github.com/MicrosoftDocs/edge-developer/assets/38640616/8cd0d609-f669-4332-a873-5d1cb21e9b24




AB#48649534