### PR TITLE
Add a note about devtools extension tabs order

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/about-tools.md
+++ b/microsoft-edge/devtools-guide-chromium/about-tools.md
@@ -108,7 +108,7 @@ To close a tool tab that's on a toolbar, right-click the tab, and then select **
 
 ![The right-click menu for the Network tool in the Activity Bar, including the 'Remove from Activity Bar' command](./about-tools-images/remove-from-activitybar.png)
 
-The **Elements**, **Console**, and **Sources** tools are permanent tabs and cannot be closed or moved from the Activity Bar to the **Quick View** panel.  You can drag their tabs to reorder them in the **Activity Bar**.
+The **Elements**, **Console**, and **Sources** tools are permanent tabs and cannot be closed or moved from the **Activity Bar** to the **Quick View** panel.  You can drag their tabs to reorder them in the **Activity Bar**.
 
 The **Console** tool is also a permanent tab on the **Quick View** toolbar.  In contrast, the **Issues** tool on the **Quick View** toolbar can be removed.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/emulate-vision-deficiencies.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/emulate-vision-deficiencies.md
@@ -30,7 +30,7 @@ To simulate how a person with a vision deficiency would see your webpage, use th
 
 1. To open DevTools, right-click the webpage, and then select **Inspect**.  Or, press **Ctrl+Shift+I** (Windows, Linux) or **Command+Option+I** (macOS).  DevTools opens.
 
-1. In DevTools, on the Activity Bar, select the **Rendering** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./emulate-vision-deficiencies-images/more-tools-icon.png)) button. The **Rendering** tool opens.
+1. In DevTools, on the **Activity Bar**, select the **Rendering** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./emulate-vision-deficiencies-images/more-tools-icon.png)) button. The **Rendering** tool opens.
 
 1. Scroll down to the **Emulate vision deficiencies** section:
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/lighthouse.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/lighthouse.md
@@ -38,7 +38,7 @@ To audit a page using the Lighthouse tool:
 
 1. To open DevTools, right-click the webpage, and then select **Inspect**.  Or, press **Ctrl+Shift+I** (Windows, Linux) or **Command+Option+I** (macOS).  DevTools opens.
 
-1. In DevTools, on the Activity Bar, select the **Lighthouse** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./lighthouse-images/more-tools-icon.png)) button.
+1. In DevTools, on the **Activity Bar**, select the **Lighthouse** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./lighthouse-images/more-tools-icon.png)) button.
 
    The **Lighthouse** tool configuration options are displayed:
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-reduced-ui-motion.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-reduced-ui-motion.md
@@ -22,7 +22,7 @@ To check whether the page is usable with animations turned off:
 
 1. Right-click anywhere in the webpage and then select **Inspect**.  Or, press **F12**.  DevTools opens next to the webpage.
 
-1. In DevTools, on the Activity Bar, select the **Sources** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./test-reduced-ui-motion-images/more-tools-icon.png)) button.
+1. In DevTools, on the **Activity Bar**, select the **Sources** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./test-reduced-ui-motion-images/more-tools-icon.png)) button.
 
 1. In the **Sources** tool's **Navigation** pane on the left, select `styles.css`.  The CSS file appears in the **Editor** pane.
 

--- a/microsoft-edge/devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer.md
@@ -51,7 +51,7 @@ To activate and use the Source Order Viewer, with the demo page:
 
 1. To open DevTools, right-click the webpage, and then select **Inspect**.  Or, press **Ctrl+Shift+I** (Windows, Linux) or **Command+Option+I** (macOS).  DevTools opens.
 
-1. In DevTools, on the Activity Bar, select the **Elements** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./test-tab-key-source-order-viewer-images/more-tools-icon.png)) button.
+1. In DevTools, on the **Activity Bar**, select the **Elements** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./test-tab-key-source-order-viewer-images/more-tools-icon.png)) button.
 
 1. In the **Elements** tool, to the right of the **Styles** tab, select the **Accessibility** tab.
 

--- a/microsoft-edge/devtools-guide-chromium/customize/index.md
+++ b/microsoft-edge/devtools-guide-chromium/customize/index.md
@@ -65,6 +65,8 @@ For example, by default, the **Network** tool is the fifth tab on the **Activity
 
 ![Custom order of DevTools in a toolbar](./index-images/network-first-position.png)
 
+Tabs added by DevTools extensions are always added to the end of the **Activity Bar**.  You can reorder them, but they will always be moved to the end of the **Activity Bar** when DevTools is opened.
+
 
 <!-- ====================================================================== -->
 ## Open and close tools

--- a/microsoft-edge/devtools-guide-chromium/customize/index.md
+++ b/microsoft-edge/devtools-guide-chromium/customize/index.md
@@ -65,7 +65,7 @@ For example, by default, the **Network** tool is the fifth tab on the **Activity
 
 ![Custom order of DevTools in a toolbar](./index-images/network-first-position.png)
 
-Tabs added by DevTools extensions are always added to the end of the **Activity Bar**.  You can reorder them, but they will always be moved to the end of the **Activity Bar** when DevTools is opened.
+Tabs that are added by DevTools extensions are always added to the end of the **Activity Bar**.  You can reorder them during a DevTools session, but they will always be at the end of the **Activity Bar** again when DevTools is opened.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/overview.md
+++ b/microsoft-edge/devtools-guide-chromium/overview.md
@@ -353,7 +353,7 @@ Besides the permanent **Elements**, **Console**, and **Sources** tools, you can 
 
    ![The More tools menu in the Activity Bar, with the expanded list of all tools](./overview-images/more-tools.png)
 
-1. Select a tool to pin it to the **Activity Bar**.  The tool is then present in the Activity Bar whenever DevTools is opened.
+1. Select a tool to pin it to the **Activity Bar**.  The tool is then present in the **Activity Bar** whenever DevTools is opened.
 
 If there isn't enough space in the **Activity Bar** to display all of the pinned tools, some tools may overflow into the **More tools** menu:
 
@@ -626,7 +626,7 @@ See also:
 
 1. To open DevTools, right-click the webpage, and then select **Inspect**.  Or, press **Ctrl+Shift+I** (Windows, Linux) or **Command+Option+I** (macOS).  DevTools opens.
 
-1. In DevTools, on the Activity Bar, select the **__** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./overview-images/more-tools-icon-light-theme.png)) button.
+1. In DevTools, on the **Activity Bar**, select the **__** tab.  If that tab isn't visible, click the **More tools** (![More tools icon](./overview-images/more-tools-icon-light-theme.png)) button.
 
 1. To the right of the **Styles** tab, click the **Accessibility** tab.  If the **Accessibility** tab isn't visible, click the **More tools** (![More tools icon](./overview-images/more-tools-icon-light-theme.png)) button.
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2022/12/devtools-108.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2022/12/devtools-108.md
@@ -94,7 +94,7 @@ In previous versions of Microsoft Edge, in Focus Mode, disabling JavaScript in t
 
    ![Using Command Menu to select Disable JavaScript](./devtools-108-images/disable-javascript.png)
 
-   A yellow warning icon is added to the **Sources** tool icon on the Activity Bar to indicate that JavaScript is disabled:
+   A yellow warning icon is added to the **Sources** tool icon on the **Activity Bar** to indicate that JavaScript is disabled:
 
    ![JavaScript Disabled indicator next to Sources tool icon on Activity Bar](./devtools-108-images/javascript-disabled.png)
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2023/02/devtools-110.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2023/02/devtools-110.md
@@ -39,7 +39,7 @@ Microsoft Edge 110 contains various improvements to Focus Mode in DevTools.  The
 <!-- ------------------------------ -->
 #### When moving a tool, the right-click menu shows the current placement of the destination toolbar
 
-The right-click menu command for moving a tool between the **Quick View** panel and the Activity Bar now indicates the placement of the destination toolbar, such as:
+The right-click menu command for moving a tool between the **Quick View** panel and the **Activity Bar** now indicates the placement of the destination toolbar, such as:
 * **Move to bottom Quick View**
 * **Move to side Quick View**
 * **Move to top Activity Bar**


### PR DESCRIPTION
Fixes #2998.

This PR adds a short note to the end of the [Reorder tools](https://learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/customize/#reorder-tools) section about the fact that tabs added by extensions don't get their order persisted.

Preview: https://review.learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/customize/?branch=pr-en-us-3036#reorder-tools

Live/Before: https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/customize/#reorder-tools

PR also adds bold globally to "Activity Bar", like was done in incoming paragraph. -mh

AB#48691284