### PR TITLE
Convert to relative links in hub & landing pages

### DIFF
--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Landing
-
+# landing page for entire docset
 title: Microsoft Edge Developer documentation # < 60 chars
 summary: Development using Microsoft Edge DevTools, Microsoft Edge extensions, Progressive Web Apps, WebDriver automation, WebView2, and more. # < 160 chars
 
@@ -50,31 +50,31 @@ landingContent:
       - linkListType: overview
         links:
           - text: Develop for the web with Microsoft Edge  # topmost article
-            url: /microsoft-edge/develop-web-microsoft-edge
+            url: ../develop-web-microsoft-edge.md
 
           - text: Microsoft Edge DevTools documentation  # DevTools landing page
-            url: /microsoft-edge/devtools-guide-chromium/landing/index
+            url: ../devtools-guide-chromium/landing/index.md
 
           - text: Overview of DevTools  # renamed from index.md
-            url: /microsoft-edge/devtools-guide-chromium/overview
+            url: ../devtools-guide-chromium/overview.md
 
       - linkListType: whats-new
         links:
           - text: What's New in Microsoft Edge DevTools
-            url: /microsoft-edge/devtools-guide-chromium/whats-new/whats-new
+            url: ../devtools-guide-chromium/whats-new/whats-new.md
 
       - linkListType: how-to-guide
         links:
           - text: Command Menu
-            url: /microsoft-edge/devtools-guide-chromium/command-menu/index
+            url: ../devtools-guide-chromium/command-menu/index.md
 
           - text: View and change CSS
-            url: /microsoft-edge/devtools-guide-chromium/css/index
+            url: ../devtools-guide-chromium/css/index.md
 
       - linkListType: reference
         links:
           - text: Keyboard shortcuts
-            url: /microsoft-edge/devtools-guide-chromium/shortcuts
+            url: ../devtools-guide-chromium/shortcuts.md
 # =============================================================================
 # Card r1c2
   - title: DevTools for Visual Studio Code
@@ -82,7 +82,7 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: DevTools extension for Visual Studio Code
-            url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
+            url: ../visual-studio-code/microsoft-edge-devtools-extension.md
 # =============================================================================
 # Card r1c3
   - title: Microsoft Edge extensions
@@ -90,26 +90,26 @@ landingContent:
       - linkListType: overview
         links:
           - text: Extensions overview
-            url: /microsoft-edge/extensions-chromium/index
+            url: ../extensions-chromium/index.md
 
           - text: Getting started tutorial
-            url: /microsoft-edge/extensions-chromium/getting-started/index
+            url: ../extensions-chromium/getting-started/index.md
 
           - text: Port a Chromium extension to Microsoft Edge
-            url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
+            url: ../extensions-chromium/developer-guide/port-chrome-extension.md
       - linkListType: how-to-guide
         links:
           - text: Alternate methods of distributing extensions
-            url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
+            url: ../extensions-chromium/developer-guide/alternate-distribution-options.md
 
           - text: Step-wise publishing process
-            url: /microsoft-edge/extensions-chromium/publish/publish-extension
+            url: ../extensions-chromium/publish/publish-extension.md
 
           - text: Register as a Microsoft Edge extension developer
-            url: /microsoft-edge/extensions-chromium/publish/create-dev-account
+            url: ../extensions-chromium/publish/create-dev-account.md
 
           - text: Create a simple extension
-            url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
+            url: ../extensions-chromium/getting-started/part1-simple-extension.md
 # =============================================================================
 # Row 2 with 3 cards
 # =============================================================================
@@ -119,29 +119,29 @@ landingContent:
       - linkListType: overview
         links:
           - text: Progressive Web Apps overview
-            url: /microsoft-edge/progressive-web-apps-chromium/index
+            url: ../progressive-web-apps-chromium/index.md
 
           - text: Get started with Progressive Web Apps
-            url: /microsoft-edge/progressive-web-apps-chromium/how-to/index
+            url: ../progressive-web-apps-chromium/how-to/index.md
 
           - text: Debug Progressive Web Apps
-            url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
+            url: ../devtools-guide-chromium/progressive-web-apps.md
 
       - linkListType: whats-new
         links:
           - text: What's New in Progressive Web Apps
-            url: /microsoft-edge/progressive-web-apps-chromium/whats-new/pwa
+            url: ../progressive-web-apps-chromium/whats-new/pwa.md
 
       - linkListType: concept
         links:
           - text: Offline scenarios
-            url: /microsoft-edge/progressive-web-apps-chromium/how-to/offline
+            url: ../progressive-web-apps-chromium/how-to/offline.md
 
           - text: Service Workers
-            url: /microsoft-edge/progressive-web-apps-chromium/how-to/service-workers
+            url: ../progressive-web-apps-chromium/how-to/service-workers.md
 
           - text: Web App Manifests
-            url: /microsoft-edge/progressive-web-apps-chromium/how-to/web-app-manifests
+            url: ../progressive-web-apps-chromium/how-to/web-app-manifests.md
 # =============================================================================
 # Card r2c2
   - title: WebView2
@@ -149,29 +149,30 @@ landingContent:
       - linkListType: overview
         links:
           - text: Introduction to Microsoft Edge WebView2
-            url: /microsoft-edge/webview2/index
+            url: ../webview2/index.md
       - linkListType: concept
         links:
           - text: Differences between Microsoft Edge and WebView2
-            url: /microsoft-edge/webview2/concepts/browser-features
+            url: ../webview2/concepts/browser-features.md
+
           - text: Development best practices
-            url: /microsoft-edge/webview2/concepts/developer-guide
+            url: ../webview2/concepts/developer-guide.md
       - linkListType: get-started
         links:
           - text: Get started with WebView2
-            url: /microsoft-edge/webview2/get-started/get-started
+            url: ../webview2/get-started/get-started.md
       - linkListType: download
         links:
           - text: Sample Code
-            url: /microsoft-edge/webview2/code-samples-links
+            url: ../webview2/code-samples-links.md
       - linkListType: whats-new
         links:
           - text: Release Notes for the WebView2 SDK
-            url: /microsoft-edge/webview2/release-notes
+            url: ../webview2/release-notes.md
       - linkListType: reference
         links:
           - text: WebView2 API Reference
-            url: /microsoft-edge/webview2/webview2-api-reference
+            url: ../webview2/webview2-api-reference.md
 # =============================================================================
 # Card r2c3
   - title: Development tips for Microsoft Edge
@@ -179,16 +180,16 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Development tips for Microsoft Edge
-            url: /microsoft-edge/web-platform/web-platform
+            url: ../web-platform/web-platform.md
 
           - text: Site compatibility-impacting changes
-            url: /microsoft-edge/web-platform/site-impacting-changes
+            url: ../web-platform/site-impacting-changes.md
 
           - text: Detect Microsoft Edge from your website
-            url: /microsoft-edge/web-platform/user-agent-guidance
+            url: ../web-platform/user-agent-guidance.md
 
           - text: Detect Windows 11 using User-Agent Client Hints
-            url: /microsoft-edge/web-platform/how-to-detect-win11
+            url: ../web-platform/how-to-detect-win11.md
 # =============================================================================
 # Row 3 with 3 cards
 # =============================================================================
@@ -198,15 +199,17 @@ landingContent:
       - linkListType: overview
         links:
           - text: Microsoft Edge IDE integration
-            url: /microsoft-edge/visual-studio-code/ide-integration
+            url: ../visual-studio-code/ide-integration.md
+
           - text: Debug Microsoft Edge in Visual Studio Code
-            url: /microsoft-edge/visual-studio-code/debugger-for-edge
+            url: ../visual-studio-code/debugger-for-edge.md
       - linkListType: how-to-guide
         links:
           - text: Open source files in Visual Studio Code
-            url: /microsoft-edge/devtools-guide-chromium/sources/opening-sources-in-vscode
+            url: ../devtools-guide-chromium/sources/opening-sources-in-vscode.md
+
           - text: Visual Studio for web development
-            url: /microsoft-edge/visual-studio/
+            url: ../visual-studio/.md
 # =============================================================================
 # Card r3c2
   - title: Accessibility in Microsoft Edge
@@ -214,13 +217,14 @@ landingContent:
       - linkListType: overview
         links:
           - text: Accessibility-testing features
-            url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+            url: ../devtools-guide-chromium/accessibility/reference.md
+
           - text: Accessibility in Microsoft Edge
-            url: /microsoft-edge/accessibility/
+            url: ../accessibility/.md
       - linkListType: how-to-guide
         links:
           - text: Accessibility testing
-            url: /microsoft-edge/accessibility/test
+            url: ../accessibility/test.md
 # =============================================================================
 # Card r3c3
   - title: Test and automation
@@ -228,22 +232,22 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Test and automation in Microsoft Edge  # new firstchild article
-            url: /microsoft-edge/test-and-automation/test-and-automation
+            url: ../test-and-automation/test-and-automation.md
 
           - text: DevTools Protocol
-            url: /microsoft-edge/devtools-protocol-chromium
+            url: ./test-and-automation/devtools-protocol.md
 
           - text: Origin Trials
-            url: /microsoft-edge/origin-trials/index
+            url: ../origin-trials/index.md
 
           - text: Playwright
-            url: /microsoft-edge/playwright/index
+            url: ../playwright/index.md
 
           - text: Puppeteer
-            url: /microsoft-edge/puppeteer
+            url: ../puppeteer.md
 
           - text: WebDriver
-            url: /microsoft-edge/webdriver-chromium
+            url: ../webdriver-chromium.md
 
           - text: webhint extension for Visual Studio Code
-            url: /microsoft-edge/visual-studio-code/webhint
+            url: ../visual-studio-code/webhint.md

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -235,7 +235,7 @@ landingContent:
             url: ../test-and-automation/test-and-automation.md
 
           - text: DevTools Protocol
-            url: ./devtools-protocol-chromium/index.md
+            url: ../devtools-protocol-chromium/index.md   # https://learn.microsoft.com/microsoft-edge/devtools-protocol-chromium/
 
           - text: Origin Trials
             url: ../origin-trials/index.md

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -53,7 +53,7 @@ landingContent:
             url: ../develop-web-microsoft-edge.md
 
           - text: Microsoft Edge DevTools documentation  # DevTools landing page
-            url: ../devtools-guide-chromium/landing/index.md
+            url: ../devtools-guide-chromium/landing/index.yml
 
           - text: Overview of DevTools  # renamed from index.md
             url: ../devtools-guide-chromium/overview.md
@@ -74,7 +74,7 @@ landingContent:
       - linkListType: reference
         links:
           - text: Keyboard shortcuts
-            url: ../devtools-guide-chromium/shortcuts.md
+            url: ../devtools-guide-chromium/shortcuts/index.md
 # =============================================================================
 # Card r1c2
   - title: DevTools for Visual Studio Code
@@ -125,7 +125,7 @@ landingContent:
             url: ../progressive-web-apps-chromium/how-to/index.md
 
           - text: Debug Progressive Web Apps
-            url: ../devtools-guide-chromium/progressive-web-apps.md
+            url: ../devtools-guide-chromium/progressive-web-apps/index.md
 
       - linkListType: whats-new
         links:
@@ -209,7 +209,7 @@ landingContent:
             url: ../devtools-guide-chromium/sources/opening-sources-in-vscode.md
 
           - text: Visual Studio for web development
-            url: ../visual-studio/.md
+            url: ../visual-studio/index.md
 # =============================================================================
 # Card r3c2
   - title: Accessibility in Microsoft Edge
@@ -220,7 +220,7 @@ landingContent:
             url: ../devtools-guide-chromium/accessibility/reference.md
 
           - text: Accessibility in Microsoft Edge
-            url: ../accessibility/.md
+            url: ../accessibility/index.md
       - linkListType: how-to-guide
         links:
           - text: Accessibility testing
@@ -235,7 +235,7 @@ landingContent:
             url: ../test-and-automation/test-and-automation.md
 
           - text: DevTools Protocol
-            url: ./test-and-automation/devtools-protocol.md
+            url: ./devtools-protocol-chromium/index.md
 
           - text: Origin Trials
             url: ../origin-trials/index.md
@@ -244,10 +244,10 @@ landingContent:
             url: ../playwright/index.md
 
           - text: Puppeteer
-            url: ../puppeteer.md
+            url: ../puppeteer/index.md
 
           - text: WebDriver
-            url: ../webdriver-chromium.md
+            url: ../webdriver-chromium/index.md
 
           - text: webhint extension for Visual Studio Code
             url: ../visual-studio-code/webhint.md

--- a/microsoft-edge/devtools-guide-chromium/landing/index.yml
+++ b/microsoft-edge/devtools-guide-chromium/landing/index.yml
@@ -41,25 +41,24 @@ landingContent:
     linkLists:
       - linkListType: get-started
         links:
-
           - text: Overview of DevTools
-            url: /microsoft-edge/devtools-guide-chromium/overview
+            url: ../overview
 
           - text: Change DevTools placement (Undock, Dock to bottom, Dock to left)
-            url: /microsoft-edge/devtools-guide-chromium/customize/placement
+            url: ../customize/placement
 
           - text: Run commands in the Command Menu
-            url: /microsoft-edge/devtools-guide-chromium/command-menu/index
+            url: ../command-menu/index
 
           - text: Console overview
-            url: /microsoft-edge/devtools-guide-chromium/console/index
+            url: ../console/index
       - linkListType: whats-new
         links:
           - text: What's New in Microsoft Edge DevTools 
-            url: /microsoft-edge/devtools-guide-chromium/whats-new/whats-new
+            url: ../whats-new/whats-new
 
           - text: Contact the Microsoft Edge DevTools team
-            url: /microsoft-edge/devtools-guide-chromium/contact
+            url: ../contact
 
 # =============================================================================
 # Card r1c2
@@ -68,19 +67,21 @@ landingContent:
       - linkListType: get-started
         links:
           - text: Customize DevTools
-            url: /microsoft-edge/devtools-guide-chromium/customize/index
+            url: ../customize/index
+
           - text: Apply a color theme to DevTools
-            url: /microsoft-edge/devtools-guide-chromium/customize/theme
+            url: ../customize/theme
       - linkListType: whats-new
         links:
           - text: Experimental features in Microsoft Edge DevTools
-            url: /microsoft-edge/devtools-guide-chromium/experimental-features/index
+            url: ../experimental-features/index
       - linkListType: how-to-guide
         links:
           - text: Change DevTools language settings
-            url: /microsoft-edge/devtools-guide-chromium/customize/localization
+            url: ../customize/localization
+
           - text: Customize keyboard shortcuts
-            url: /microsoft-edge/devtools-guide-chromium/customize/shortcuts
+            url: ../customize/shortcuts
 
 # =============================================================================
 # Card r1c3
@@ -89,25 +90,30 @@ landingContent:
       - linkListType: quickstart
         links:
           - text: Analyze pages using the Inspect tool
-            url: /microsoft-edge/devtools-guide-chromium/css/inspect
+            url: ../css/inspect
       - linkListType: tutorial
         links:
           - text: Get started viewing and changing CSS
-            url: /microsoft-edge/devtools-guide-chromium/css/index
+            url: ../css/index
+
           - text: Get started viewing and changing the DOM
-            url: /microsoft-edge/devtools-guide-chromium/dom/index
+            url: ../dom/index
       - linkListType: how-to-guide
         links:
           - text: Find and fix problems using the Issues tool
-            url: /microsoft-edge/devtools-guide-chromium/issues/index
+            url: ../issues/index
+
           - text: Navigate webpage layers, z-index, and DOM using the 3D View tool
-            url: /microsoft-edge/devtools-guide-chromium/3d-view/index
+            url: ../3d-view/index
+
           - text: Inspect animations
-            url: /microsoft-edge/devtools-guide-chromium/inspect-styles/animations
+            url: ../inspect-styles/animations
+
           - text: Debug Progressive Web Apps (PWAs)
-            url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps/index
+            url: ../progressive-web-apps/index
+
           - text: Inspect network activity
-            url: /microsoft-edge/devtools-guide-chromium/network/index
+            url: ../network/index
 
 # =============================================================================
 # Card r2c1
@@ -116,19 +122,25 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Emulate mobile devices (Device Emulation)
-            url: /microsoft-edge/devtools-guide-chromium/device-mode/index
+            url: ../device-mode/index
+
           - text: Accessibility-testing features
-            url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+            url: ../accessibility/reference
+
           - text: Emulate dark or light schemes in the rendered page
-            url: /microsoft-edge/devtools-guide-chromium/accessibility/preferred-color-scheme-simulation
+            url: ../accessibility/preferred-color-scheme-simulation
+
           - text: Test keyboard support using the Source Order Viewer
-            url: /microsoft-edge/devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer
+            url: ../accessibility/test-tab-key-source-order-viewer
+
           - text: Force print preview mode
-            url: /microsoft-edge/devtools-guide-chromium/css/print-preview
+            url: ../css/print-preview
+
           - text: Emulate vision deficiencies
-            url: /microsoft-edge/devtools-guide-chromium/accessibility/emulate-vision-deficiencies
+            url: ../accessibility/emulate-vision-deficiencies
+
           - text: Simulate reduced motion
-            url: /microsoft-edge/devtools-guide-chromium/accessibility/reduced-motion-simulation
+            url: ../accessibility/reduced-motion-simulation
 
 # =============================================================================
 # Card r2c2
@@ -137,23 +149,31 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Run JavaScript in the Console
-            url: /microsoft-edge/devtools-guide-chromium/console/console-javascript
+            url: ../console/console-javascript
+
           - text: Fix JavaScript errors that are reported in the Console
-            url: /microsoft-edge/devtools-guide-chromium/console/console-debug-javascript
+            url: ../console/console-debug-javascript
+
           - text: Sources tool overview
-            url: /microsoft-edge/devtools-guide-chromium/sources/index
+            url: ../sources/index
+
           - text: JavaScript debugging features
-            url: /microsoft-edge/devtools-guide-chromium/javascript/reference
+            url: ../javascript/reference
+
           - text: Find unused JavaScript and CSS code with the Coverage tool
-            url: /microsoft-edge/devtools-guide-chromium/coverage/index
+            url: ../coverage/index
+
           - text: Fix memory problems
-            url: /microsoft-edge/devtools-guide-chromium/memory-problems/index
+            url: ../memory-problems/index
+
           - text: Debug DOM memory leaks with the Detached Elements tool
-            url: /microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks
+            url: ../memory-problems/dom-leaks
+
           - text: Understand security issues using the Security tool
-            url: /microsoft-edge/devtools-guide-chromium/security/index
+            url: ../security/index
+
           - text: Troubleshooting common performance issues
-            url: /microsoft-edge/devtools-guide-chromium/rendering-tools/index
+            url: ../rendering-tools/index
 
 # =============================================================================
 # Card r2c3
@@ -162,18 +182,21 @@ landingContent:
       - linkListType: reference
         links:
           - text: Keyboard shortcuts
-            url: /microsoft-edge/devtools-guide-chromium/shortcuts/index
+            url: ../shortcuts/index
+
           - text: CSS features reference
-            url: /microsoft-edge/devtools-guide-chromium/css/reference
+            url: ../css/reference
+
           - text: Console features reference
-            url: /microsoft-edge/devtools-guide-chromium/console/reference
+            url: ../console/reference
+
           - text: Console object API Reference
-            url: /microsoft-edge/devtools-guide-chromium/console/api
+            url: ../console/api
       - linkListType: how-to-guide
         links:
           - text: Performance features reference
-            url: /microsoft-edge/devtools-guide-chromium/evaluate-performance/reference
+            url: ../evaluate-performance/reference
       - linkListType: sample
         links:
           - text: Sample code for DevTools
-            url: /microsoft-edge/devtools-guide-chromium/sample-code/sample-code
+            url: ../sample-code/sample-code

--- a/microsoft-edge/devtools-guide-chromium/landing/index.yml
+++ b/microsoft-edge/devtools-guide-chromium/landing/index.yml
@@ -42,23 +42,23 @@ landingContent:
       - linkListType: get-started
         links:
           - text: Overview of DevTools
-            url: ../overview
+            url: ../overview.md
 
           - text: Change DevTools placement (Undock, Dock to bottom, Dock to left)
-            url: ../customize/placement
+            url: ../customize/placement.md
 
           - text: Run commands in the Command Menu
-            url: ../command-menu/index
+            url: ../command-menu/index.md
 
           - text: Console overview
-            url: ../console/index
+            url: ../console/index.md
       - linkListType: whats-new
         links:
-          - text: What's New in Microsoft Edge DevTools 
-            url: ../whats-new/whats-new
+          - text: What's New in Microsoft Edge DevTools
+            url: ../whats-new/whats-new.md
 
           - text: Contact the Microsoft Edge DevTools team
-            url: ../contact
+            url: ../contact.md
 
 # =============================================================================
 # Card r1c2
@@ -67,21 +67,21 @@ landingContent:
       - linkListType: get-started
         links:
           - text: Customize DevTools
-            url: ../customize/index
+            url: ../customize/index.md
 
           - text: Apply a color theme to DevTools
-            url: ../customize/theme
+            url: ../customize/theme.md
       - linkListType: whats-new
         links:
           - text: Experimental features in Microsoft Edge DevTools
-            url: ../experimental-features/index
+            url: ../experimental-features/index.md
       - linkListType: how-to-guide
         links:
           - text: Change DevTools language settings
-            url: ../customize/localization
+            url: ../customize/localization.md
 
           - text: Customize keyboard shortcuts
-            url: ../customize/shortcuts
+            url: ../customize/shortcuts.md
 
 # =============================================================================
 # Card r1c3
@@ -90,30 +90,30 @@ landingContent:
       - linkListType: quickstart
         links:
           - text: Analyze pages using the Inspect tool
-            url: ../css/inspect
+            url: ../css/inspect.md
       - linkListType: tutorial
         links:
           - text: Get started viewing and changing CSS
-            url: ../css/index
+            url: ../css/index.md
 
           - text: Get started viewing and changing the DOM
-            url: ../dom/index
+            url: ../dom/index.md
       - linkListType: how-to-guide
         links:
           - text: Find and fix problems using the Issues tool
-            url: ../issues/index
+            url: ../issues/index.md
 
           - text: Navigate webpage layers, z-index, and DOM using the 3D View tool
-            url: ../3d-view/index
+            url: ../3d-view/index.md
 
           - text: Inspect animations
-            url: ../inspect-styles/animations
+            url: ../inspect-styles/animations.md
 
           - text: Debug Progressive Web Apps (PWAs)
-            url: ../progressive-web-apps/index
+            url: ../progressive-web-apps/index.md
 
           - text: Inspect network activity
-            url: ../network/index
+            url: ../network/index.md
 
 # =============================================================================
 # Card r2c1
@@ -122,25 +122,25 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Emulate mobile devices (Device Emulation)
-            url: ../device-mode/index
+            url: ../device-mode/index.md
 
           - text: Accessibility-testing features
-            url: ../accessibility/reference
+            url: ../accessibility/reference.md
 
           - text: Emulate dark or light schemes in the rendered page
-            url: ../accessibility/preferred-color-scheme-simulation
+            url: ../accessibility/preferred-color-scheme-simulation.md
 
           - text: Test keyboard support using the Source Order Viewer
-            url: ../accessibility/test-tab-key-source-order-viewer
+            url: ../accessibility/test-tab-key-source-order-viewer.md
 
           - text: Force print preview mode
-            url: ../css/print-preview
+            url: ../css/print-preview.md
 
           - text: Emulate vision deficiencies
-            url: ../accessibility/emulate-vision-deficiencies
+            url: ../accessibility/emulate-vision-deficiencies.md
 
           - text: Simulate reduced motion
-            url: ../accessibility/reduced-motion-simulation
+            url: ../accessibility/reduced-motion-simulation.md
 
 # =============================================================================
 # Card r2c2
@@ -149,31 +149,31 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Run JavaScript in the Console
-            url: ../console/console-javascript
+            url: ../console/console-javascript.md
 
           - text: Fix JavaScript errors that are reported in the Console
-            url: ../console/console-debug-javascript
+            url: ../console/console-debug-javascript.md
 
           - text: Sources tool overview
-            url: ../sources/index
+            url: ../sources/index.md
 
           - text: JavaScript debugging features
-            url: ../javascript/reference
+            url: ../javascript/reference.md
 
           - text: Find unused JavaScript and CSS code with the Coverage tool
-            url: ../coverage/index
+            url: ../coverage/index.md
 
           - text: Fix memory problems
-            url: ../memory-problems/index
+            url: ../memory-problems/index.md
 
           - text: Debug DOM memory leaks with the Detached Elements tool
-            url: ../memory-problems/dom-leaks
+            url: ../memory-problems/dom-leaks.md
 
           - text: Understand security issues using the Security tool
-            url: ../security/index
+            url: ../security/index.md
 
           - text: Troubleshooting common performance issues
-            url: ../rendering-tools/index
+            url: ../rendering-tools/index.md
 
 # =============================================================================
 # Card r2c3
@@ -182,21 +182,21 @@ landingContent:
       - linkListType: reference
         links:
           - text: Keyboard shortcuts
-            url: ../shortcuts/index
+            url: ../shortcuts/index.md
 
           - text: CSS features reference
-            url: ../css/reference
+            url: ../css/reference.md
 
           - text: Console features reference
-            url: ../console/reference
+            url: ../console/reference.md
 
           - text: Console object API Reference
-            url: ../console/api
+            url: ../console/api.md
       - linkListType: how-to-guide
         links:
           - text: Performance features reference
-            url: ../evaluate-performance/reference
+            url: ../evaluate-performance/reference.md
       - linkListType: sample
         links:
           - text: Sample code for DevTools
-            url: ../sample-code/sample-code
+            url: ../sample-code/sample-code.md

--- a/microsoft-edge/devtools-guide-chromium/landing/index.yml
+++ b/microsoft-edge/devtools-guide-chromium/landing/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Landing
-
+# landing page for DevTools portion of docset
 title: Microsoft Edge DevTools documentation
 summary: Development using Microsoft Edge DevTools.
 

--- a/microsoft-edge/devtools-protocol-chromium/index.md
+++ b/microsoft-edge/devtools-protocol-chromium/index.md
@@ -189,7 +189,7 @@ None.
         "devtoolsFrontendUrl": "https://devtools.azureedge.net/serve_file/@d6d5aea402510697e05382293a4c6d3da0183736/inspector.html?wss=172.17.75.195:50443/msedge/23416/devtools/page/2AE2506D9FDB1C541FB36DD908ED51DE",
         "faviconUrl": "https://learn.microsoft.com/favicon.ico",
         "id": "2AE2506D9FDB1C541FB36DD908ED51DE",
-        "title": "Remotely debug Windows devices - Microsoft Edge Development | Microsoft Learn",
+        "title": "Remotely debug Windows devices - Microsoft Edge Developer documentation | Microsoft Learn",
         "type": "page",
         "url": "https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/remote-debugging/windows",
         "webSocketDebuggerUrl": "wss://172.17.75.195:50443/msedge/23416/devtools/page/2AE2506D9FDB1C541FB36DD908ED51DE"
@@ -226,7 +226,7 @@ None.
     "devtoolsFrontendUrl": "/msedge/23416/devtools/inspector.html?wss=localhost:50443/msedge/23416/devtools/page/2AE2506D9FDB1C541FB36DD908ED51DE",
     "faviconUrl": "https://learn.microsoft.com/favicon.ico",
     "id": "2AE2506D9FDB1C541FB36DD908ED51DE",
-    "title": "Remotely debug Windows devices - Microsoft Edge Development | Microsoft Learn",
+    "title": "Remotely debug Windows devices - Microsoft Edge Developer documentation | Microsoft Learn",
     "type": "page",
     "url": "https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/remote-debugging/windows",
     "webSocketDebuggerUrl": "wss://localhost:50443/msedge/23416/devtools/page/2AE2506D9FDB1C541FB36DD908ED51DE"

--- a/microsoft-edge/extensions-chromium/publish/extensions-analytics.md
+++ b/microsoft-edge/extensions-chromium/publish/extensions-analytics.md
@@ -109,6 +109,6 @@ The following screenshot shows Installs per Language over a six month period.
 > ![Language distribution for your extension](./extensions-analytics-images/extension-analytics-installs-filter-language-6-months.png)
 
 The Analytics Dashboard helps you better understand and engage with your extension users. For information about other 
-features launched on Partner Center, see [Released features for Microsoft Edge Add-ons - Microsoft Edge Development | Microsoft Docs](/microsoft-edge/extensions-chromium/whats-new/released-features).
+features launched on Partner Center, see [Released features for Microsoft Edge Add-ons - Microsoft Edge Developer documentation | Microsoft Docs](/microsoft-edge/extensions-chromium/whats-new/released-features).
 
 Share your feedback, questions, and comments with the team on Twitter [@MSEdgeDev](https://twitter.com/msedgedev/) or via the [Microsoft Edge Insider forums on TechCommunity](https://techcommunity.microsoft.com/t5/articles/manifest-v3-changes-are-now-available-in-microsoft-edge/m-p/1780254).

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -41,7 +41,7 @@ highlightedContent:
     # Card
     - title: "Get support"
       itemType: reference
-      url: ./index.md#help-and-support
+      url: ../index.yml#help-and-support
     # Card
     - title: "How to use Microsoft Edge"
       itemType: learn
@@ -53,7 +53,7 @@ highlightedContent:
     # Card
     - title: "Discover web developer features"
       itemType: learn
-      url: ./index.md#microsoft-edge-for-developers
+      url: ./index.yml#microsoft-edge-for-developers
 
 # =============================================================================
 # conceptualContent section (optional)
@@ -340,7 +340,7 @@ conceptualContent:
               itemType: how-to-guide
 
             - text: Detect Microsoft Edge from your website
-              url: ./web-platform/user-agent-guidance/index.md
+              url: ./web-platform/user-agent-guidance.md
               itemType: how-to-guide
 
             - text: Detect Windows 11 using User-Agent Client Hints
@@ -387,8 +387,8 @@ additionalContent:
         # Card
         - title: Reference
           links:
-            - text: How to detect Microsoft Edge in your website
-              url: ./web-platform/user-agent-guidance
+            - text: Detecting Microsoft Edge from your website
+              url: ./web-platform/user-agent-guidance.md
 
             - text: Visual Studio Code
               url: ./visual-studio-code/index.md

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -41,7 +41,7 @@ highlightedContent:
     # Card
     - title: "Get support"
       itemType: reference
-      url: ./index.yml#help-and-support
+      url: ./index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support  # orig path works: /microsoft-edge/index#help-and-support
     # Card
     - title: "How to use Microsoft Edge"
       itemType: learn
@@ -53,7 +53,7 @@ highlightedContent:
     # Card
     - title: "Discover web developer features"
       itemType: learn
-      url: ./index.yml#microsoft-edge-for-developers
+      url: ./index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers  # orig path works: /microsoft-edge/index#microsoft-edge-for-developers
 
 # =============================================================================
 # conceptualContent section (optional)

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -41,7 +41,7 @@ highlightedContent:
     # Card
     - title: "Get support"
       itemType: reference
-      url: ./index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support  # orig path works: /microsoft-edge/index#help-and-support
+      url: /microsoft-edge/index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support
     # Card
     - title: "How to use Microsoft Edge"
       itemType: learn
@@ -53,7 +53,7 @@ highlightedContent:
     # Card
     - title: "Discover web developer features"
       itemType: learn
-      url: ./index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers  # orig path works: /microsoft-edge/index#microsoft-edge-for-developers
+      url: /microsoft-edge/index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers
 
 # =============================================================================
 # conceptualContent section (optional)

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Hub
-
+# hub page for Enterprise docset & Edge Dev docset
 title: Microsoft Edge documentation
 summary: Learn to use Microsoft Edge by browsing documentation, tutorials, and samples.  Includes information for users, developers, and administrators.
 brand: m365
@@ -41,7 +41,7 @@ highlightedContent:
     # Card
     - title: "Get support"
       itemType: reference
-      url: ./index#help-and-support
+      url: ./index.md#help-and-support
     # Card
     - title: "How to use Microsoft Edge"
       itemType: learn
@@ -53,8 +53,7 @@ highlightedContent:
     # Card
     - title: "Discover web developer features"
       itemType: learn
-      url: ./index#microsoft-edge-for-developers
-      # url: ./index#microsoft-edge-for-developers #alt-link
+      url: ./index.md#microsoft-edge-for-developers
 
 # =============================================================================
 # conceptualContent section (optional)
@@ -73,6 +72,7 @@ conceptualContent:
             - url: /deployedge/microsoft-edge-channels
               itemType: overview
               text: Microsoft Edge channel overview
+
             - url: /deployedge/edge-ie-mode
               itemType: reference
               text: Use enterprise features
@@ -82,9 +82,11 @@ conceptualContent:
             - itemType: reference
               text: Video - Deploy Microsoft Edge
               url: /deployedge/microsoft-edge-video-deploy
+
             - itemType: reference
               text: Deploy to Windows
               url: /configmgr/apps/deploy-use/deploy-edge
+
             - itemType: reference
               text: Deploy to macOS
               url: /intune/apps/apps-edge-macos
@@ -94,9 +96,11 @@ conceptualContent:
             - itemType: reference
               text: Configure Microsoft Edge on Windows and macOS
               url: /deployedge/configure-microsoft-edge
+
             - itemType: reference
               text: Set Microsoft Edge as the default browser
               url: /deployedge/edge-default-browser
+
             - itemType: reference
               text: Manage Microsoft Edge on iOS and Android with Intune
               url: /mem/intune/apps/manage-microsoft-edge
@@ -106,6 +110,7 @@ conceptualContent:
             - itemType: reference
               text: Security
               url: /deployedge/ms-edge-security-for-business
+
             - itemType: reference
               text: Privacy
               url: /deployedge/microsoft-edge-enterprise-privacy-settings
@@ -115,6 +120,7 @@ conceptualContent:
             - itemType: reference
               text: Browser policy reference
               url: /deployedge/microsoft-edge-policies
+
             - itemType: reference
               text: Update policy reference
               url: /deployedge/microsoft-edge-update-policies
@@ -133,12 +139,14 @@ conceptualContent:
             - itemType: overview
               text: Manage Microsoft Edge extensions in the enterprise
               url: /deployedge/microsoft-edge-manage-extensions
+
             - itemType: reference
               text: Defining match patterns to access file URLs
-              url: ./extensions-chromium/enterprise/match-patterns
+              url: ./extensions-chromium/enterprise/match-patterns.md
+
             - itemType: reference
               text: Extension hosting
-              url: ./extensions-chromium/enterprise/hosting-and-updating
+              url: ./extensions-chromium/enterprise/hosting-and-updating.md
 # =============================================================================
     - title: Microsoft Edge for Developers # < 60 chars (optional)
     # summary:  # < 160 chars (optional)
@@ -175,7 +183,7 @@ conceptualContent:
               itemType: how-to-guide
 
             - text: Keyboard shortcuts
-              url: ./devtools-guide-chromium/shortcuts.md
+              url: ./devtools-guide-chromium/shortcuts/index.md
               itemType: reference
         # Card
         - title: Microsoft Edge IDE integration
@@ -241,7 +249,7 @@ conceptualContent:
               itemType: overview
 
             - text: Debug Progressive Web Apps
-              url: ./devtools-guide-chromium/progressive-web-apps.md
+              url: ./devtools-guide-chromium/progressive-web-apps/index.md
               itemType: overview
 
             - text: What's New in Progressive Web Apps
@@ -298,7 +306,7 @@ conceptualContent:
               itemType: overview
 
             - text: DevTools Protocol
-              url: ./devtools-protocol-chromium.md
+              url: ./test-and-automation/devtools-protocol.md
               itemType: how-to-guide
 
             - text: Origin Trials
@@ -310,11 +318,11 @@ conceptualContent:
               itemType: overview
 
             - text: Puppeteer
-              url: ./puppeteer.md
+              url: ./puppeteer/index.md
               itemType: how-to-guide
 
             - text: WebDriver
-              url: ./webdriver-chromium.md
+              url: ./webdriver-chromium/index.md
               itemType: how-to-guide
 
             - text: webhint extension for Visual Studio Code
@@ -332,7 +340,7 @@ conceptualContent:
               itemType: how-to-guide
 
             - text: Detect Microsoft Edge from your website
-              url: ./web-platform/user-agent-guidance.md
+              url: ./web-platform/user-agent-guidance/index.md
               itemType: how-to-guide
 
             - text: Detect Windows 11 using User-Agent Client Hints
@@ -383,10 +391,10 @@ additionalContent:
               url: ./web-platform/user-agent-guidance
 
             - text: Visual Studio Code
-              url: ./visual-studio-code/index
+              url: ./visual-studio-code/index.md
 
             - text: Privacy Whitepaper
-              url: ./privacy-whitepaper
+              url: ./privacy-whitepaper/index.md
         # Card
         - title: Microsoft Edge Legacy documentation
           links:

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -41,7 +41,7 @@ highlightedContent:
     # Card
     - title: "Get support"
       itemType: reference
-      url: /microsoft-edge/index#help-and-support
+      url: ./index#help-and-support
     # Card
     - title: "How to use Microsoft Edge"
       itemType: learn
@@ -53,8 +53,8 @@ highlightedContent:
     # Card
     - title: "Discover web developer features"
       itemType: learn
-      url: /microsoft-edge/index#microsoft-edge-for-developers
-      # url: /microsoft-edge/index#microsoft-edge-for-developers #alt-link
+      url: ./index#microsoft-edge-for-developers
+      # url: ./index#microsoft-edge-for-developers #alt-link
 
 # =============================================================================
 # conceptualContent section (optional)
@@ -135,10 +135,10 @@ conceptualContent:
               url: /deployedge/microsoft-edge-manage-extensions
             - itemType: reference
               text: Defining match patterns to access file URLs
-              url: /microsoft-edge/extensions-chromium/enterprise/match-patterns
+              url: ./extensions-chromium/enterprise/match-patterns
             - itemType: reference
               text: Extension hosting
-              url: /microsoft-edge/extensions-chromium/enterprise/hosting-and-updating
+              url: ./extensions-chromium/enterprise/hosting-and-updating
 # =============================================================================
     - title: Microsoft Edge for Developers # < 60 chars (optional)
     # summary:  # < 160 chars (optional)
@@ -171,173 +171,187 @@ conceptualContent:
               itemType: how-to-guide
 
             - text: View and change CSS
-              url: /microsoft-edge/devtools-guide-chromium/css/index
+              url: ./devtools-guide-chromium/css/index.md
               itemType: how-to-guide
 
             - text: Keyboard shortcuts
-              url: /microsoft-edge/devtools-guide-chromium/shortcuts
+              url: ./devtools-guide-chromium/shortcuts.md
               itemType: reference
         # Card
         - title: Microsoft Edge IDE integration
           links:
-            - url: /microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension
+            - text: DevTools extension for Visual Studio Code
+              url: ./visual-studio-code/microsoft-edge-devtools-extension.md
               itemType: how-to-guide
-              text: DevTools extension for Visual Studio Code
 
             - text: Microsoft Edge IDE integration
-              url: /microsoft-edge/visual-studio-code/ide-integration
+              url: ./visual-studio-code/ide-integration.md
               itemType: overview
 
             - text: Open source files in Visual Studio Code
-              url: /microsoft-edge/devtools-guide-chromium/sources/opening-sources-in-vscode
+              url: ./devtools-guide-chromium/sources/opening-sources-in-vscode.md
               itemType: how-to-guide
 
             - text: Debug Microsoft Edge in Visual Studio Code
-              url: /microsoft-edge/visual-studio-code/debugger-for-edge
+              url: ./visual-studio-code/debugger-for-edge.md
               itemType: overview
 
             - text: Visual Studio for web development
-              url: /microsoft-edge/visual-studio/
+              url: ./visual-studio-code/index.md
               itemType: how-to-guide
         # Card
         - title: Microsoft Edge extensions
           links:
-            - url: /microsoft-edge/extensions-chromium/index
+            - text: Extensions overview
+              url: ./extensions-chromium/index.md
               itemType: overview
-              text: Extensions overview
-            - url: /microsoft-edge/extensions-chromium/getting-started/index
+
+            - text: Getting started tutorial
+              url: ./extensions-chromium/getting-started/index.md
               itemType: overview
-              text: Getting started tutorial
-            - url: /microsoft-edge/extensions-chromium/developer-guide/port-chrome-extension
+
+            - text: Port a Chromium extension to Microsoft Edge
+              url: ./extensions-chromium/developer-guide/port-chrome-extension.md
               itemType: overview
-              text: Port a Chromium extension to Microsoft Edge
-            - url: /microsoft-edge/extensions-chromium/developer-guide/alternate-distribution-options
+
+            - text: Alternate methods of distributing extensions
+              url: ./extensions-chromium/developer-guide/alternate-distribution-options.md
               itemType: how-to-guide
-              text: Alternate methods of distributing extensions
-            - url: /microsoft-edge/extensions-chromium/publish/publish-extension
+
+            - text: Step-wise publishing process
+              url: ./extensions-chromium/publish/publish-extension.md
               itemType: how-to-guide
-              text: Step-wise publishing process
-            - url: /microsoft-edge/extensions-chromium/publish/create-dev-account
+
+            - text: Register as a Microsoft Edge extension developer
+              url: ./extensions-chromium/publish/create-dev-account.md
               itemType: how-to-guide
-              text: Register as a Microsoft Edge extension developer
-            - url: /microsoft-edge/extensions-chromium/getting-started/part1-simple-extension
+
+            - text: Create a simple extension
+              url: ./extensions-chromium/getting-started/part1-simple-extension.md
               itemType: how-to-guide
-              text: Create a simple extension
         # Card
         - title: Progressive Web Apps
           links:
-            - url: /microsoft-edge/progressive-web-apps-chromium/index
+            - text: Progressive Web Apps overview
+              url: ./progressive-web-apps-chromium/index.md
               itemType: overview
-              text: Progressive Web Apps overview
 
-            - url: /microsoft-edge/progressive-web-apps-chromium/how-to/index
+            - text: Get started with Progressive Web Apps
+              url: ./progressive-web-apps-chromium/how-to/index.md
               itemType: overview
-              text: Get started with Progressive Web Apps
 
-            - url: /microsoft-edge/devtools-guide-chromium/progressive-web-apps
+            - text: Debug Progressive Web Apps
+              url: ./devtools-guide-chromium/progressive-web-apps.md
               itemType: overview
-              text: Debug Progressive Web Apps
 
-            - url: /microsoft-edge/progressive-web-apps-chromium/whats-new/pwa
+            - text: What's New in Progressive Web Apps
+              url: ./progressive-web-apps-chromium/whats-new/pwa.md
               itemType: whats-new
-              text: What's New in Progressive Web Apps
 
-            - url: /microsoft-edge/progressive-web-apps-chromium/how-to/offline
+            - text: Offline scenarios
+              url: ./progressive-web-apps-chromium/how-to/offline.md
               itemType: concept
-              text: Offline scenarios
 
-            - url: /microsoft-edge/progressive-web-apps-chromium/how-to/service-workers
+            - text: Service Workers
+              url: ./progressive-web-apps-chromium/how-to/service-workers.md
               itemType: concept
-              text: Service Workers
 
-            - url: /microsoft-edge/progressive-web-apps-chromium/how-to/web-app-manifests
+            - text: Web App Manifests
+              url: ./progressive-web-apps-chromium/how-to/web-app-manifests.md
               itemType: concept
-              text: Web App Manifests
 
         # Card
         - title: WebView2
           links:
             - text: Introduction to Microsoft Edge WebView2
-              url: /microsoft-edge/webview2/index
+              url: ./webview2/index.md
               itemType: overview
 
             - text: Differences between Microsoft Edge and WebView2
-              url: /microsoft-edge/webview2/concepts/browser-features
+              url: ./webview2/concepts/browser-features.md
               itemType: concept
 
             - text: Development best practices
-              url: /microsoft-edge/webview2/concepts/developer-guide
+              url: ./webview2/concepts/developer-guide.md
               itemType: concept
 
             - text: Get started with WebView2
-              url: /microsoft-edge/webview2/get-started/get-started
+              url: ./webview2/get-started/get-started.md
               itemType: get-started
 
             - text: Sample Code
-              url: /microsoft-edge/webview2/code-samples-links
+              url: ./webview2/code-samples-links.md
               itemType: download
 
             - text: Release Notes for the WebView2 SDK
-              url: /microsoft-edge/webview2/release-notes
+              url: ./webview2/release-notes.md
               itemType: whats-new
 
             - text: WebView2 API Reference
-              url: /microsoft-edge/webview2/webview2-api-reference
+              url: ./webview2/webview2-api-reference.md
               itemType: reference
         # Card
         - title: Test and automation
           links:
-            - url: /microsoft-edge/test-and-automation/test-and-automation
+            - text: Test and automation in Microsoft Edge  # new firstchild article
+              url: ./test-and-automation/test-and-automation.md
               itemType: overview
-              text: Test and automation in Microsoft Edge  # new firstchild article
-            - url: /microsoft-edge/devtools-protocol-chromium
+
+            - text: DevTools Protocol
+              url: ./devtools-protocol-chromium.md
               itemType: how-to-guide
-              text: DevTools Protocol
-            - url: /microsoft-edge/origin-trials/index
+
+            - text: Origin Trials
+              url: ./origin-trials/index.md
               itemType: overview
-              text: Origin Trials
-            - url: /microsoft-edge/playwright/index
+
+            - text: Playwright
+              url: ./playwright/index.md
               itemType: overview
-              text: Playwright
-            - url: /microsoft-edge/puppeteer
+
+            - text: Puppeteer
+              url: ./puppeteer.md
               itemType: how-to-guide
-              text: Puppeteer
-            - url: /microsoft-edge/webdriver-chromium
+
+            - text: WebDriver
+              url: ./webdriver-chromium.md
               itemType: how-to-guide
-              text: WebDriver
-            - url: /microsoft-edge/visual-studio-code/webhint
+
+            - text: webhint extension for Visual Studio Code
+              url: ./visual-studio-code/webhint.md
               itemType: how-to-guide
-              text: webhint extension for Visual Studio Code
         # Card
         - title: Development tips for Microsoft Edge
           links:
             - text: Development tips for Microsoft Edge
-              url: /microsoft-edge/web-platform/web-platform  # new firstchild article
+              url: ./web-platform/web-platform.md
               itemType: overview
 
             - text: Site compatibility-impacting changes
-              url: /microsoft-edge/web-platform/site-impacting-changes
+              url: ./web-platform/site-impacting-changes.md
               itemType: how-to-guide
 
             - text: Detect Microsoft Edge from your website
-              url: /microsoft-edge/web-platform/user-agent-guidance
+              url: ./web-platform/user-agent-guidance.md
               itemType: how-to-guide
 
             - text: Detect Windows 11 using User-Agent Client Hints
-              url: /microsoft-edge/web-platform/how-to-detect-win11
+              url: ./web-platform/how-to-detect-win11.md
               itemType: how-to-guide
         # Card
         - title: Accessibility in Microsoft Edge
           links:
-            - url: /microsoft-edge/devtools-guide-chromium/accessibility/reference
+            - text: Accessibility-testing features
+              url: ./devtools-guide-chromium/accessibility/reference.md
               itemType: overview
-              text: Accessibility-testing features
-            - url: /microsoft-edge/accessibility/
+
+            - text: Accessibility overview
+              url: ./accessibility/index.md
               itemType: overview
-              text: Accessibility overview
-            - url: /microsoft-edge/accessibility/test
+
+            - text: Accessibility testing
+              url: ./accessibility/test.md
               itemType: how-to-guide
-              text: Accessibility testing
 # =============================================================================
 # additionalContent section (optional)
 # Card with summary style
@@ -366,11 +380,13 @@ additionalContent:
         - title: Reference
           links:
             - text: How to detect Microsoft Edge in your website
-              url: /microsoft-edge/web-platform/user-agent-guidance
+              url: ./web-platform/user-agent-guidance
+
             - text: Visual Studio Code
-              url: /microsoft-edge/visual-studio-code/index
+              url: ./visual-studio-code/index
+
             - text: Privacy Whitepaper
-              url: /microsoft-edge/privacy-whitepaper
+              url: ./privacy-whitepaper
         # Card
         - title: Microsoft Edge Legacy documentation
           links:

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -41,7 +41,7 @@ highlightedContent:
     # Card
     - title: "Get support"
       itemType: reference
-      url: ../index.yml#help-and-support
+      url: ./index.yml#help-and-support
     # Card
     - title: "How to use Microsoft Edge"
       itemType: learn

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -9,7 +9,7 @@ metadata:
   ms.topic: hub-page
   author: MSEdgeTeam
   ms.author: msedgedevrel
-  ms.date: 09/09/2021
+  ms.date: 03/06/2024
   ms.localizationpriority: high
   ms.service: microsoft-edge
 
@@ -147,27 +147,27 @@ conceptualContent:
         - title: Microsoft Edge DevTools
           links:
             - text: Microsoft Edge Developer documentation  # Edge landing page
-              url: /microsoft-edge/developer/index
+              url: ./developer/index.yml
               itemType: overview
 
             - text: Develop for the web with Microsoft Edge  # topmost article
-              url: /microsoft-edge/develop-web-microsoft-edge
+              url: ./develop-web-microsoft-edge.md
               itemType: overview
 
             - text: Microsoft Edge DevTools documentation  # DevTools landing page
-              url: /microsoft-edge/devtools-guide-chromium/landing/index
+              url: ./devtools-guide-chromium/landing/index.yml
               itemType: overview
 
             - text: Overview of DevTools  # renamed from index.md
-              url: /microsoft-edge/devtools-guide-chromium/overview
+              url: ./devtools-guide-chromium/overview.md
               itemType: overview
 
             - text: What's New in Microsoft Edge DevTools
-              url: /microsoft-edge/devtools-guide-chromium/whats-new/whats-new
+              url: ./devtools-guide-chromium/whats-new/whats-new.md
               itemType: whats-new
 
             - text: Command Menu
-              url: /microsoft-edge/devtools-guide-chromium/command-menu/index
+              url: ./devtools-guide-chromium/command-menu/index.md
               itemType: how-to-guide
 
             - text: View and change CSS


### PR DESCRIPTION
Rendered pages for review:
* Hub page
   * https://review.learn.microsoft.com/microsoft-edge/?branch=pr-en-us-3089
* Landing page & breadcrumb path
   * https://review.learn.microsoft.com/microsoft-edge/developer/?branch=pr-en-us-3089

This PR fixes 119 Suggestions of type relative-link-expected ("The link [link] is written as a site-relative link but the file is in the same docset. Use relative path link instead.") eg [full build report webpage](https://buildapi.docs.microsoft.com/Output/Commit/db9f4228-bcf7-7df9-527f-b7c9a032ef40/202403070145117558-userLw==mikehoffmsLw==prerelease-testing-self-hosting/BuildReport?accessString=b633b6663df575d96d3f413a47a24f98573cb3098fe87eb2b03d8b44965922ed)

And per **Learn Platform Manual** > **How to create or update a hub page** article > **Guidelines** section:
https://review.learn.microsoft.com/help/platform/navigation-how-create-hub-page?branch=main#guidelines - "Use relative paths for links whenever possible."

AB#49330889