### PR TITLE
Change the search scope to narrow down to edge developer

### DIFF
--- a/microsoft-edge/docfx.json
+++ b/microsoft-edge/docfx.json
@@ -35,7 +35,7 @@
       "breadcrumb_path": "/microsoft-edge/breadcrumbs/toc.json",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/edge-developer",
-      "searchScope": ["Microsoft Edge Developer"],
+      "searchScope": ["Microsoft Edge Developer", "Microsoft Edge"],
       "titleSuffix": "Microsoft Edge Developer documentation",
       "uhfHeaderId": "MSDocsHeader-MSEdge"
     },

--- a/microsoft-edge/docfx.json
+++ b/microsoft-edge/docfx.json
@@ -35,7 +35,7 @@
       "breadcrumb_path": "/microsoft-edge/breadcrumbs/toc.json",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/edge-developer",
-      "searchScope": ["Microsoft Edge"],
+      "searchScope": ["Microsoft Edge Developer"],
       "titleSuffix": "Microsoft Edge Developer documentation",
       "uhfHeaderId": "MSDocsHeader-MSEdge"
     },


### PR DESCRIPTION
Rendered docs for review: 
* https://review.learn.microsoft.com/microsoft-edge/developer/?branch=pr-en-us-3090

Changing the search scope to **Microsoft Edge Developer** would better match our docset, and return fewer, but more useful, results when using the search tool.

This would make the **Filter by title** box show a more relevant last option:

![image](https://github.com/MicrosoftDocs/edge-developer/assets/1152698/58f26ac8-2eb5-4a6a-9b04-6a6df1a01a0d)

And would hopefully narrow down the results to our docset only. Currently, the results are for Microsoft Edge, and include a lot 
of non-developer documentation.

My only uncertainty is whether **Microsoft Edge Developer** is actually a scope that can be used on Learn. Currently, it returns nothing:

![image](https://github.com/MicrosoftDocs/edge-developer/assets/1152698/5da91670-2547-4793-a2e7-702632d29c76)

AB#49334958