### PR TITLE
Reverse the order in `searchScope` to prioritize developer docs in search results

### DIFF
--- a/microsoft-edge/docfx.json
+++ b/microsoft-edge/docfx.json
@@ -35,7 +35,7 @@
       "breadcrumb_path": "/microsoft-edge/breadcrumbs/toc.json",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/edge-developer",
-      "searchScope": ["Microsoft Edge Developer", "Microsoft Edge"],
+      "searchScope": ["Microsoft Edge", "Microsoft Edge Developer"],
       "titleSuffix": "Microsoft Edge Developer documentation",
       "uhfHeaderId": "MSDocsHeader-MSEdge"
     },


### PR DESCRIPTION
Now that the new **Microsoft Edge Developer** search scope has been introduced and returns results (see [this search query](https://learn.microsoft.com/en-us/search/?scope=Microsoft%20Edge%20Developer&terms=capture%20screenshot)), it's time to reverse the order of the `searchScope` array in docfx.json. 

Making **Microsoft Edge Developer** be last in the array means that results that belong to our docset will be returned first.