### PR TITLE
Change "filename" to "file name" globally

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/accessibility/navigation.md
+++ b/microsoft-edge/devtools-guide-chromium/accessibility/navigation.md
@@ -249,7 +249,7 @@ With focus on the **Computed** tab, press **Tab** to move focus inside and explo
 
 #### Explore all computed styles
 
-Press **Tab** until you reach the collection of computed styles.  Computed styles are presented as an [ARIA tree](https://www.w3.org/TR/wai-aria-1.1/#tree).  Expanding a listbox reveals which CSS selectors are applying the computed style.  These selectors are organized by specificity.  A screen reader announces the computed value, which CSS selector is currently matching, the filename of the stylesheet that contains the selector, and the line number for the selector.
+Press **Tab** until you reach the collection of computed styles.  Computed styles are presented as an [ARIA tree](https://www.w3.org/TR/wai-aria-1.1/#tree).  Expanding a listbox reveals which CSS selectors are applying the computed style.  These selectors are organized by specificity.  A screen reader announces the computed value, which CSS selector is currently matching, the file name of the stylesheet that contains the selector, and the line number for the selector.
 
 **Known issues**
 

--- a/microsoft-edge/devtools-guide-chromium/command-menu/index.md
+++ b/microsoft-edge/devtools-guide-chromium/command-menu/index.md
@@ -62,7 +62,7 @@ Available actions include:
 * **Go to Line**
 * **Run Snippet**
 
-The actions other than **Run Command** require input, such as a filename or line number.
+The actions other than **Run Command** require input, such as a file name or line number.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/devtools-guide-chromium/device-mode/index.md
+++ b/microsoft-edge/devtools-guide-chromium/device-mode/index.md
@@ -412,7 +412,7 @@ To set the user agent string:
    Or, to enter your own user agent string, enter the string in the **Enter a custom user agent** text box:
 
    ![Setting a custom user agent string](./index-images/device-toolbar-network-conditions-macos.png)
-<!-- todo: remove "macos" from filename, or show such a user agent string -->
+<!-- todo: remove "macos" from file name, or show such a user agent string -->
 
 See also:
 * [Override the user agent string](override-user-agent.md)

--- a/microsoft-edge/devtools-guide-chromium/evaluate-performance/unminify.md
+++ b/microsoft-edge/devtools-guide-chromium/evaluate-performance/unminify.md
@@ -65,9 +65,9 @@ For details, see [Map the processed code to your original source code, for debug
 
    ![The Unminify button in the Performance tool](./unminify-images/perf-profile-unminify-button.png)
 
-   In DevTools, a popup briefly appears, reading: **Status: creating unminfied file**.  Then the **Save As** dialog opens.  The default filename is a pattern starting with date and time like `yymmddThhmmss`, such as: `Profile-20220307T164948-unminified.json`.  The default directory is the **Downloads** directory.
+   In DevTools, a popup briefly appears, reading: **Status: creating unminfied file**.  Then the **Save As** dialog opens.  The default file name is a pattern starting with date and time like `yymmddThhmmss`, such as: `Profile-20220307T164948-unminified.json`.  The default directory is the **Downloads** directory.
 
-1. Select a filename and directory and then click the **Save** button.
+1. Select a file name and directory and then click the **Save** button.
 
    The **Performance** tool creates a new version of the recorded performance profile, with some function names from the flame chart replaced by more meaningful function names by using your source maps.  Some of the minified production names might still appear, because source maps don't always provide the necessary information for the **Performance** tool to map all function names.
 

--- a/microsoft-edge/devtools-guide-chromium/network/index.md
+++ b/microsoft-edge/devtools-guide-chromium/network/index.md
@@ -254,7 +254,7 @@ The **Filter** text box supports many different types of filtering.
 
 1. Type `png` into the **Filter** text box.  Only the files that contain the text `png` are shown.  In this case the only files that match the filter are the PNG images.
 
-1. Type `/.*\.[cj]s+$/`, which is a JavaScript regular expression.  DevTools filters out any resource with a filename that doesn't end with a `j` or a `c` followed by 1 or more `s` characters.
+1. Type `/.*\.[cj]s+$/`, which is a JavaScript regular expression.  DevTools filters out any resource with a file name that doesn't end with a `j` or a `c` followed by 1 or more `s` characters.
 
 1. Type `-main.css`.  DevTools filters out `main.css`.  If any file matches that pattern, it's also filtered out.
 

--- a/microsoft-edge/devtools-guide-chromium/network/reference.md
+++ b/microsoft-edge/devtools-guide-chromium/network/reference.md
@@ -417,7 +417,7 @@ Use the **Requests** table to display a log of all requests made while DevTools 
 
 The Requests table displays the following columns by default:
 
-- **Name**. The filename of, or an identifier for, the resource.
+- **Name**. The file name of the resource, or an identifier for the resource.
 - **Status**. The HTTP status code.
 - **Type**. The MIME type of the requested resource.
 - **Initiator**. The following objects or processes can initiate requests:

--- a/microsoft-edge/devtools-guide-chromium/resources/index.md
+++ b/microsoft-edge/devtools-guide-chromium/resources/index.md
@@ -54,9 +54,9 @@ When you know the name of a webpage's resource file that you want to inspect, th
 
 1. If there's a greater-than (>) prompt, press **Backspace** to get to the **Open File** prompt.
 
-1. Start typing the filename, and then press **Enter** when the correct file is highlighted in the autocomplete box, or select the file from the dropdown list:
+1. Start typing the file name, and then press **Enter** when the correct file is highlighted in the autocomplete box, or select the file from the dropdown list:
 
-   ![Typing part of a filename in the Open File list of the Command Menu](./index-images/command-menu-file-search.png)
+   ![Typing part of a file name in the Open File list of the Command Menu](./index-images/command-menu-file-search.png)
 
 
 <!-- ====================================================================== -->
@@ -160,7 +160,7 @@ You can use the **Sources** tool to view the webpage's resource files organized 
 
 
 <!-- ====================================================================== -->
-## Browse resource files sorted by filename in the Page tab of the Sources tool
+## Browse resource files sorted by file name in the Page tab of the Sources tool
 
 By default, the **Page** tab in the **Sources** tool groups resource files by folder.  To instead display all the resource files for each domain grouped together in a single alphabetized list:
 

--- a/microsoft-edge/devtools-guide-chromium/sample-code/sample-code.md
+++ b/microsoft-edge/devtools-guide-chromium/sample-code/sample-code.md
@@ -280,7 +280,7 @@ To open an `.html` file and edit it:
 
    If editing isn't enabled, click the **Allow** button to grant read/write access to the folder by doing the steps in [Opening a folder from the Filesystem (Workspace) tab in the Sources tool](#opening-a-folder-from-the-filesystem-workspace-tab-in-the-sources-tool) above.
 
-   The change is displayed in the **Changes** tool in the Drawer, and an asterisk is added to the filename in the **index.html** tab in the **Sources** tool:
+   The change is displayed in the **Changes** tool in the Drawer, and an asterisk is added to the file name in the **index.html** tab in the **Sources** tool:
 
    ![The modified demo-to-do page before saving changes](./sample-code-images/modified-demo-to-do-before-save.png)
 

--- a/microsoft-edge/devtools-guide-chromium/whats-new/2021/10/devtools.md
+++ b/microsoft-edge/devtools-guide-chromium/whats-new/2021/10/devtools.md
@@ -151,9 +151,9 @@ For the history of this feature, see Chromium issue: [1243976](https://crbug.com
 
 <!-- Chromium What's New entry: [Improved UI for DevTools command menu](https://developer.chrome.com/blog/new-in-devtools-95/#command-menu) at _What's New in DevTools (Chrome 95)_. -->
 
-The **Command Menu** has been enhanced to make it easier to search for a file.  When you press **Ctrl+P** in Windows and Linux or **Command+P** in macOS, the **Command Menu** now displays filenames in bold, along with an icon indicating the file type:
+The **Command Menu** has been enhanced to make it easier to search for a file.  When you press **Ctrl+P** in Windows and Linux or **Command+P** in macOS, the **Command Menu** now displays file names in bold, along with an icon indicating the file type:
 
-![Command Menu showing filenames in bold with an icon indicating the file type](./devtools-images/command-menu-filenames-bold-icons.png)
+![Command Menu showing file names in bold with an icon indicating the file type](./devtools-images/command-menu-filenames-bold-icons.png)
 
 See also:
 * [Command Menu](../../../command-menu/index.md)

--- a/microsoft-edge/progressive-web-apps-chromium/how-to/handle-urls.md
+++ b/microsoft-edge/progressive-web-apps-chromium/how-to/handle-urls.md
@@ -16,7 +16,7 @@ Progressive Web Apps (PWAs) can also handle links in a similar way.
 
 <!--
 link handling vs. url handling:
-Although the present filename is handle-urls.md, this file was repurposed to cover link handling rather than URL handlers.
+Although the present file name is handle-urls.md, this file was repurposed to cover link handling rather than URL handlers.
 The PWA URL handlers feature was removed from Chromium.
 See also [PWAs as URL Handlers](https://web.dev/pwa-url-handler/).
 -->

--- a/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/opening-source-files-from-elements-tool.md
+++ b/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/opening-source-files-from-elements-tool.md
@@ -15,7 +15,7 @@ In the **Elements** tool:
 
 *  The **Event Listeners** tab indicates which source file is used to define event handlers for the selected node in the DOM tree.
 
-The source file name and line number are shown as a clickable link.  Clicking a filename link opens that file in the Visual Studio Code editor:
+The source file name and line number are shown as a clickable link.  Clicking a file name link opens that file in the Visual Studio Code editor:
 
 ![Opening source files from Elements tool](./opening-source-files-from-elements-tool-images/elements-files.png)
 

--- a/microsoft-edge/webview2/concepts/basic-authentication.md
+++ b/microsoft-edge/webview2/concepts/basic-authentication.md
@@ -55,8 +55,8 @@ For more information, see [Navigation events for WebView2 apps](navigation-event
 The following diagram shows the flow of navigation events for basic authentication for WebView2 apps:
 
 ![Flow of navigation events for basic authentication for WebView2 apps](basic-authentication-images/basic-auth-page-nav-flow.png)
-<!-- initial Visio filename: https://microsoft-my.sharepoint.com/ ... "Basic Auth in Page Nav Flow.vsd"
-later, check:  Teams > Team > channel > Files > dir > filename -->
+<!-- initial Visio file name: https://microsoft-my.sharepoint.com/ ... "Basic Auth in Page Nav Flow.vsd"
+later, check:  Teams > Team > channel > Files > dir > file name -->
 
 <!-- diagram labels in comments: -->
 

--- a/microsoft-edge/webview2/concepts/user-data-folder.md
+++ b/microsoft-edge/webview2/concepts/user-data-folder.md
@@ -111,7 +111,7 @@ The default user data folder (UDF) location varies per platform.
 <!--
 **What is the default UDF location?**
 -->
-On this platform, the default UDF location is the directory that the app executable (`.exe`) is running in.  The default UDF is the executable (`exe`) path of your app + `.WebView2`.  The filename of the UDF is the executable (`exe`) path of your app + `.WebView2`.
+On this platform, the default UDF location is the directory that the app executable (`.exe`) is running in.  The default UDF is the executable (`exe`) path of your app + `.WebView2`.  The file name of the UDF is the executable (`exe`) path of your app + `.WebView2`.
 
 For example, if you ran `D:\WebView2App\WebView2.exe`, a UDF folder would be created: `D:\WebView2App\WebView2.exe.WebView2\`.  As another example: `WebView2APISample.exe.WebView2\`.
 
@@ -134,7 +134,7 @@ Win32 MSIX packaging is a standalone `.exe`.
 <!--
 **What is the default UDF location?**
 -->
-On this platform, the default UDF location is the directory that the app executable (`.exe`) is running in.  The default UDF is the executable (`exe`) path of your app + `.WebView2`.  The filename of the UDF is the executable (`exe`) path of your app + `.WebView2`.
+On this platform, the default UDF location is the directory that the app executable (`.exe`) is running in.  The default UDF is the executable (`exe`) path of your app + `.WebView2`.  The file name of the UDF is the executable (`exe`) path of your app + `.WebView2`.
 
 For example, if you ran `D:\WebView2App\WebView2.exe`, a UDF folder would be created: `D:\WebView2App\WebView2.exe.WebView2\`.  As another example: `WebView2APISample.exe.WebView2\`.
 

--- a/microsoft-edge/webview2/get-started/winforms.md
+++ b/microsoft-edge/webview2/get-started/winforms.md
@@ -168,7 +168,7 @@ The starter project has a `Form1.cs` form already, but we'll add another, as `Fo
 
    ![The 'Add New Item' window, expanded to 'Visual C# Items' > 'Windows Forms', selecting 'Form (Windows Forms)'](./winforms-images/add-new-item-form-windows-forms.png)
 
-   The project now has an additional form, with filename `Form2.cs`, shown in the Form Designer and in Solution Explorer:
+   The project now has an additional form, with file name `Form2.cs`, shown in the Form Designer and in Solution Explorer:
 
    ![The added form, Form2.cs, in the Form Designer and in Solution Explorer](./winforms-images/winforms-added-form2.png)
 

--- a/microsoft-edge/webview2/get-started/wpf.md
+++ b/microsoft-edge/webview2/get-started/wpf.md
@@ -92,7 +92,7 @@ If you are creating a .NET Core/5/6 project, do the following steps.  Otherwise,
    If you're using Visual Studio 2019, click a project template that has the title **WPF Application** and the description text **A project for creating a .NET Core WPF Application**:
 
    ![Selecting the template 'WPF Application: .NET Core WPF Application' in the 2019 'Create a new project' dialog](./wpf-images/wpf-getting-started-wpf-core.png)
-   <!--todo: after move png to article's dedicated images dir, change filename like for vs2022 above -->
+   <!--todo: after move png to article's dedicated images dir, change file name like for vs2022 above -->
 
    If the above project template isn't listed, see [Step 1 - Install Visual Studio with .NET support](#step-1---install-visual-studio-with-net-support) above, to install **.NET desktop development tools**.
 

--- a/microsoft-edge/webview2/how-to/chromium-devtools-protocol.md
+++ b/microsoft-edge/webview2/how-to/chromium-devtools-protocol.md
@@ -73,7 +73,7 @@ To create an `HTML file` to find your geolocation, complete following the action
    </html>
    ```
 
-1. Save the `.html` file with the filename `geolocation.html`.
+1. Save the `.html` file with the file name `geolocation.html`.
 
 1. Open Microsoft Edge.
 

--- a/microsoft-edge/webview2/how-to/set-preview-channel.md
+++ b/microsoft-edge/webview2/how-to/set-preview-channel.md
@@ -164,7 +164,7 @@ To make your application use a Microsoft Edge preview channel by using a registr
 
    `REG ADD HKLM\Software\Policies\Microsoft\Edge\WebView2\BrowserExecutableFolder /v WebView2APISample.exe /t REG_SZ /d "C:\Users\myname\AppData\Local\Microsoft\Edge SxS\Application\88.0.680.0"`
 
-   Replace `WebView2APISample.exe` with the filename of your own app executable or the Application User Model ID. Using a wildcard (*) as the value name will apply the override to _all_ WebView2 apps on the machine and can result in unexpected behavior.
+   Replace `WebView2APISample.exe` with the file name of your own app executable or the Application User Model ID. Using a wildcard (*) as the value name will apply the override to _all_ WebView2 apps on the machine and can result in unexpected behavior.
 
    Replace `C:\Users\myname\AppData\Local\Microsoft\Edge SxS\Application\88.0.680.0` by the path to the desired Microsoft Edge preview channel.
 
@@ -184,7 +184,7 @@ To make your application use a Microsoft Edge preview channel by using a registr
 
    `REG ADD HKLM\Software\Policies\Microsoft\Edge\WebView2\ReleaseChannelPreference /v WebView2APISample.exe /t REG_SZ /d "1"`
 
-   Replace `WebView2APISample.exe` with the filename of your own app executable or the Application User Model ID. Using a wildcard (*) as the value name will apply the override to _all_ WebView2 apps on the machine and can result in unexpected behavior.
+   Replace `WebView2APISample.exe` with the file name of your own app executable or the Application User Model ID. Using a wildcard (*) as the value name will apply the override to _all_ WebView2 apps on the machine and can result in unexpected behavior.
 
 #### Resuming using the default, WebView2 Evergreen Runtime
 
@@ -255,7 +255,7 @@ If you want to make your application use a Microsoft Edge preview channel by usi
 
 1. Select the **Show** button.
 
-1. Fill-in the **Show Contents** dialog.  In the **Value name** column, enter your app's `.exe` filename or Application User Model ID. Using a wildcard (*) as the value name will apply the override to _all_ WebView2 apps on the machine and can result in unexpected behavior.
+1. Fill-in the **Show Contents** dialog.  In the **Value name** column, enter your app's `.exe` file name or Application User Model ID. Using a wildcard (*) as the value name will apply the override to _all_ WebView2 apps on the machine and can result in unexpected behavior.
 
    ![The Show Contents dialog](./set-preview-channel-images/show-contents.png)
 

--- a/microsoft-edge/webview2/release-notes.md
+++ b/microsoft-edge/webview2/release-notes.md
@@ -4923,7 +4923,7 @@ The following APIs have been promoted from Experimental to Stable in this Prerel
 *  Allow the host app to set foreground on a different application in response to events including `NavigationStarting`, `AddHostObjectToScript` methods, `WebMessageReceived`, and `NewWindowRequested`. ([Issue #1092](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1092))
 *  Fix bug to trigger the `PermissionRequested` event for the microphone. This change is Runtime-specific.([Issue #1462](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1462))
 *  Fixed bug when `ExecuteScriptAsync` blocked after several successful runs. This change is Runtime-specific. ([Issue #1348](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1348))
-*  Fixed bug preventing non-ASCII filenames from being used in `ResultFilePath` in `DownloadStartingEventArgs`. ([Issue #1428](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1428))
+*  Fixed bug preventing non-ASCII file names from being used in `ResultFilePath` in `DownloadStartingEventArgs`. ([Issue #1428](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1428))
 *  Fixed bug where the title bar on the default pop-up wasn't displayed completely. This change is Runtime-specific. ([Issue #1016](https://github.com/MicrosoftEdge/WebViewFeedback/issues/1016))
 
 

--- a/microsoft-edge/webview2/samples/wv2deploymentvsinstallersample.md
+++ b/microsoft-edge/webview2/samples/wv2deploymentvsinstallersample.md
@@ -143,7 +143,7 @@ If you want to package the Evergreen WebView2 Runtime Standalone Installer with 
 
 1. Within the `<Commands Reboot="Defer">` and `</Commands>` section, make sure `PackageFile` points to `"MicrosoftEdgeWebView2RuntimeInstallerX64.exe"` so that the Visual Studio installer is using the Standalone Installer.
 
-1. If you're targeting non-X64 devices, edit the `MicrosoftEdgeWebView2RuntimeInstallerX64` filename to reflect the correct architecture.
+1. If you're targeting non-X64 devices, edit the `MicrosoftEdgeWebView2RuntimeInstallerX64` file name to reflect the correct architecture.
 
 1. Save the file.
 

--- a/microsoft-edge/webview2/samples/wv2deploymentwixcustomactionsample.md
+++ b/microsoft-edge/webview2/samples/wv2deploymentwixcustomactionsample.md
@@ -164,7 +164,7 @@ If you want to package the Evergreen WebView2 Runtime Standalone Installer with 
 
 1. Comment out other `<Binary>` and `<CustomAction>` elements under `Step 4`.
 
-1. If you're targeting non-X64 devices, you may also want to edit the `MicrosoftEdgeWebView2RuntimeInstallerX64` filename to reflect the correct architecture.
+1. If you're targeting non-X64 devices, you may also want to edit the `MicrosoftEdgeWebView2RuntimeInstallerX64` file name to reflect the correct architecture.
 
 1. Under `<!-- Step 5: Config execute sequence of custom action -->`, uncomment the `<Custom Action='InvokeStandalone' ...>` element below `<!-- [Package Standalone Installer] ...-->`.
 


### PR DESCRIPTION
This PR changes from "filename" (in sentences, not in code) to "file name", globally in this repo.

Per corp-level style guide:
https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/f/file-name - 
"**Two words** as an adjective or a noun when referring to the name of a file. 
Usually **one word** when referring to a programming term, such as the FileName property.
Example:
Set the **FileName** property before you set an initial **file name**."

AB#49442969