### PR TITLE
Improve the Edge old versions detector and remove a couple of outdated versions

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/memory-problems/heap-snapshots.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/heap-snapshots.md
@@ -224,7 +224,7 @@ To hide internal nodes from the **Retainers** section, in the **Filter edges** d
 
 By default, the **Shallow Size** column in the **Memory** tool only includes the size of the object itself. The _shallow size_ is the size of the JavaScript heap that's _directly_ held by an object. The shallow size of an object is usually small, because a JavaScript object often only stores its description of the object, not the values, in the object's directly held memory. Most JavaScript objects store their values in a _backing store_ that's elsewhere in the JavaScript heap, and only expose a small wrapper object on the portion of the JavaScript heap that's directly owned by the object. For example, JavaScript `Array` instances store the contents of the array in a backing store, which is a separate memory location that's not included in the array's shallow size.
 
-Starting with Microsoft Edge 123, you can configure the **Shallow Size** column to report the entire size of objects, including the size of the object's backing store.
+You can configure the **Shallow Size** column to report the entire size of objects, including the size of the object's backing store.
 
 To include the entire size of objects in the **Shallow Size** column:
 

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/memory-101.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/memory-101.md
@@ -105,7 +105,7 @@ The _distance_ of an object in the JavaScript heap is the number of nodes on the
 
 The _shallow size_ is the size of the JavaScript heap that's _directly_ held by an object. The shallow size of an object is usually small, because a JavaScript object often only stores its description of the object, not the values, in the object's directly held memory. Most JavaScript objects store their values in a _backing store_ that's elsewhere in the JavaScript heap, and only expose a small wrapper object on the portion of the JavaScript heap that's directly owned by the object.
 
-Starting with Microsoft Edge 123, the **Memory** tool can be configured to report the total memory size of objects instead of only the memory size they directly hold. To learn more, see [Configure the Shallow Size column to include an entire object's size](./heap-snapshots.md#configure-the-shallow-size-column-to-include-an-entire-objects-size) in _Record heap snapshots using the Memory tool_.
+The **Memory** tool can be configured to report the total memory size of objects instead of only the memory size they directly hold. To learn more, see [Configure the Shallow Size column to include an entire object's size](./heap-snapshots.md#configure-the-shallow-size-column-to-include-an-entire-objects-size) in _Record heap snapshots using the Memory tool_.
 
 Nevertheless, even a small object can hold a large amount of memory _indirectly_, by preventing other objects from being disposed of by the garbage collection process.
 

--- a/scripts/report-references-to-old-versions.js
+++ b/scripts/report-references-to-old-versions.js
@@ -7,7 +7,8 @@ const FILES_TO_INCLUDE = '../microsoft-edge/**/*.md';
 const FILES_TO_IGNORE = [
     // What's new/release notes articles are bound to always have version numbers in them. That's ok.
     '../microsoft-edge/devtools-guide-chromium/whats-new/**/*.md',
-    '../microsoft-edge/webview2/release-notes.md',
+    '../microsoft-edge/webview2/release-notes/index.md',
+    '../microsoft-edge/webview2/release-notes/archive.md',
     '../microsoft-edge/progressive-web-apps-chromium/whats-new/*.md',
     // Experimental features also often have version numbers in them. Let's ignore them too.
     '../microsoft-edge/devtools-guide-chromium/experimental-features/index.md'


### PR DESCRIPTION
Fixes #3142.

The WebView2 release note files have changed, so I needed to change the script that detects old versions of Edge a little bit.
In this PR, I'm also removing a couple of Edge 123 occurrences, since these have now been in Stable for a while.

AB#50579994