### PR TITLE
Cross-link sections about blocking network requests

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/network-request-blocking/network-request-blocking-tool.md
+++ b/microsoft-edge/devtools-guide-chromium/network-request-blocking/network-request-blocking-tool.md
@@ -56,6 +56,9 @@ To block a network request:
 
    ![The Network request blocking tool, blocking all JPEG images](./network-request-blocking-tool-images/blocked-images.png)
 
+See also:
+* [Block requests](../network/index.md#block-requests) in _Inspect network activity_.
+
 
 <!-- ====================================================================== -->
 ## Delete a blocked network request

--- a/microsoft-edge/devtools-guide-chromium/network/index.md
+++ b/microsoft-edge/devtools-guide-chromium/network/index.md
@@ -303,6 +303,9 @@ How does a page look and behave when some of the page resources aren't available
 
 1. Clear the **Enable network request blocking** checkbox.
 
+See also:
+* [Block a network request](../network-request-blocking/network-request-blocking-tool.md#block-a-network-request) in _Network request blocking tool_.
+
 
 <!-- ====================================================================== -->
 ## Conclusion


### PR DESCRIPTION
Rendered article sections for review:
* **Network request blocking tool** > **Block a network request** - opens the tool from the Activity Bar.  Added See Also link.
   * https://review.learn.microsoft.com/microsoft-edge/devtools-guide-chromium/network-request-blocking/network-request-blocking-tool?branch=pr-en-us-3146#block-a-network-request
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/network-request-blocking/network-request-blocking-tool#block-a-network-request)
* **Inspect network activity** > **Block requests** - opens the tool from the Command Menu.  Added See Also link.
   * https://review.learn.microsoft.com/microsoft-edge/devtools-guide-chromium/network/?branch=pr-en-us-3146#block-requests
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/network/#block-requests)

Docs to block a network request is documented in two different places, one under the Network tool and another under Network request blocking tool. One section uses the Command Menu to access the blocking tool.  The other section directly accesses the tool from the Activity bar. Rest of the content is the same.

This PR fixes Issue https://github.com/MicrosoftDocs/edge-developer/issues/2997.

AB#50645322