### PR TITLE
Add section "Limitations of the embedded DevTools browser"

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -915,7 +915,7 @@
                 - name: Inline and live issue analysis
                   href: visual-studio-code/microsoft-edge-devtools-extension/inline-live-issue-analysis.md
 
-                - name: Device and state emulation
+                - name: Device emulation
                   href: visual-studio-code/microsoft-edge-devtools-extension/device-state-emulation.md
 
                 - name: Update .css files from within the Styles tab (CSS mirror editing)

--- a/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/debugging-a-webpage.md
+++ b/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/debugging-a-webpage.md
@@ -72,6 +72,13 @@ JavaScript debugging is built in to Visual Studio Code; you can debug in Chrome,
 
 The DevTools extension gives additional functionality, such as the embedded DevTools browser which has a Device Emulation toolbar, and provides additional ways to enter Debug mode in Visual Studio Code.
 
+See also:
+* [Limitations of the embedded DevTools browser](./external-browser-window.md#limitations-of-the-embedded-devtools-browser) in _Using an external browser window_.
+
+
+<!-- ------------------------------ -->
+#### Start the debugger
+
 To start the Visual Studio Code debugger along with DevTools, by using the usual UI that's part of Visual Studio Code:
 
 1. Open a new Visual Studio Code window.  No folder (workspace) is open, and the **DevTools** tabs aren't open.

--- a/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/device-state-emulation.md
+++ b/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/device-state-emulation.md
@@ -15,6 +15,9 @@ In the **Edge DevTools: Browser** tab, the Device Emulation toolbar on the botto
 
 To reproduce the UI shown here, see [Opening DevTools by right-clicking an HTML file](./open-devtools-and-embedded-browser.md#opening-devtools-by-right-clicking-an-html-file) in _Opening DevTools and the DevTools browser_.
 
+See also:
+* [Limitations of the embedded DevTools browser](./external-browser-window.md#limitations-of-the-embedded-devtools-browser) in _Using an external browser window_.
+
 
 <!-- ====================================================================== -->
 ## Emulate Devices dropdown menu

--- a/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/external-browser-window.md
+++ b/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/external-browser-window.md
@@ -46,16 +46,13 @@ This tab is also called:
 <!-- ------------------------------ -->
 #### Limitations of the embedded DevTools browser
 
-The embedded Edge DevTools Browser in the Visual Studio Code DevTools extension provides a simple preview with many restrictions, and doesn't support all web browser features.  When you need a full-featured browser, use an external browser window instead of the embedded browser.  The embedded browser is based on a headless browser instance from which screen captures are being streamed.  Therefore, not all user interactions are implemented.
+The embedded Edge DevTools Browser in the Visual Studio Code DevTools extension provides a simple preview with many restrictions, and doesn't support all the features of a real web browser.  When you need a full-featured browser, use an external browser window instead of the embedded browser.  The embedded DevTools browser is a browser instance that runs without a user interface, and from which screen captures are being streamed.  Therefore, not all user interactions are implemented.
 
 The embedded DevTools browser has limitations including the following:
 
 * Drag-and-drop isn't supported.
-* [onPasteCapture onPaste events don't trigger](https://github.com/microsoft/vscode-edge-devtools/issues/2006).
-* [css cursor property isn't respected; it's always default](https://github.com/microsoft/vscode-edge-devtools/issues/1996).
-* [Cursor Pointer Issue](https://github.com/microsoft/vscode-edge-devtools/issues/1656).
-   * [Support for cursor: pointer](https://github.com/microsoft/vscode-edge-devtools/issues/2149).
-* [Missing CSS feature](https://github.com/microsoft/vscode-edge-devtools/issues/2084).
+* `onPasteCapture` and `onPaste` events don't trigger.
+* The CSS `cursor` property isn't respected.
 * There might be visual performance issues.
 
 

--- a/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/external-browser-window.md
+++ b/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/external-browser-window.md
@@ -43,6 +43,22 @@ This tab is also called:
 *  The _embedded DevTools browser_.
 
 
+<!-- ------------------------------ -->
+#### Limitations of the embedded DevTools browser
+
+The embedded Edge DevTools Browser in the Visual Studio Code DevTools extension provides a simple preview with many restrictions, and doesn't support all web browser features.  When you need a full-featured browser, use an external browser window instead of the embedded browser.  The embedded browser is based on a headless browser instance from which screen captures are being streamed.  Therefore, not all user interactions are implemented.
+
+The embedded DevTools browser has limitations including the following:
+
+* Drag-and-drop isn't supported.
+* [onPasteCapture onPaste events don't trigger](https://github.com/microsoft/vscode-edge-devtools/issues/2006).
+* [css cursor property isn't respected; it's always default](https://github.com/microsoft/vscode-edge-devtools/issues/1996).
+* [Cursor Pointer Issue](https://github.com/microsoft/vscode-edge-devtools/issues/1656).
+   * [Support for cursor: pointer](https://github.com/microsoft/vscode-edge-devtools/issues/2149).
+* [Missing CSS feature](https://github.com/microsoft/vscode-edge-devtools/issues/2084).
+* There might be visual performance issues.
+
+
 <!-- ====================================================================== -->
 ## Changing the setting
 

--- a/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/open-devtools-and-embedded-browser.md
+++ b/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/open-devtools-and-embedded-browser.md
@@ -312,3 +312,4 @@ Close instances of DevTools by using any of the following approaches:
 
 * [Get started using the DevTools extension for Visual Studio Code](./get-started.md)
 * [Microsoft Edge DevTools extension for Visual Studio Code](../microsoft-edge-devtools-extension.md)
+* [Limitations of the embedded DevTools browser](./external-browser-window.md#limitations-of-the-embedded-devtools-browser) in _Using an external browser window_.


### PR DESCRIPTION
Rendered article sections for review:
* **Using an external browser window** > **Limitations of the embedded DevTools browser** - new section.
   * https://review.learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/external-browser-window?branch=pr-en-us-3147#limitations-of-the-embedded-devtools-browser
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/external-browser-window#the-embedded-devtools-browser)
* **Integration with Visual Studio Code debugging** > **Opening the browser as part of a debugging session** - link to new section.
   * https://review.learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/debugging-a-webpage?branch=pr-en-us-3147#opening-the-browser-as-part-of-a-debugging-session
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/debugging-a-webpage#opening-the-browser-as-part-of-a-debugging-session)
* **Device emulation** > intro - link to new section.
   * https://review.learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/device-state-emulation?branch=pr-en-us-3147
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/device-state-emulation)
* **Opening DevTools and the DevTools browser** > **See also** - link to new section.
   * https://review.learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/open-devtools-and-embedded-browser?branch=pr-en-us-3147#see-also
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension/open-devtools-and-embedded-browser#see-also)

This PR fixes https://github.com/MicrosoftDocs/edge-developer/issues/3075

AB#50646343