### PR TITLE
Update the LAF support link to the correct URL

### DIFF
--- a/microsoft-edge/dualengine/concepts/adapter-dll.md
+++ b/microsoft-edge/dualengine/concepts/adapter-dll.md
@@ -19,7 +19,7 @@ To have Internet Explorer successfully load your DLL, do the following.
 <!-- ====================================================================== -->
 ## Unlock the Limited Access Feature
 
-The DualEngine API is a Limited Access Feature (LAF); that is, a feature that needs to be unlocked before it can be used. For more information about implementation, see [LimitedAccessFeatures Class](/uwp/api/windows.applicationmodel.limitedaccessfeatures). To request an unlock token, contact [Microsoft Support](https://aka.ms/LAFAccessRequests).
+The DualEngine API is a Limited Access Feature (LAF); that is, a feature that needs to be unlocked before it can be used. For more information about implementation, see [LimitedAccessFeatures Class](/uwp/api/windows.applicationmodel.limitedaccessfeatures). To request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
 
 The DualEngine API is not a typical LAF, in that `Windows.ApplicationModel.TryUnlockFeature` is not used to unlock the feature.  This is because LAF typically uses the application identity of the calling process to grant access, and as a plugin DLL, this will always be Internet Explorer.  Therefore, to unlock the API, you need to call [DualEngineSessionFactory::TryUnlockFeature](../reference/dualenginesessionfactory.md#tryunlockfeature).
 

--- a/microsoft-edge/dualengine/get-started.md
+++ b/microsoft-edge/dualengine/get-started.md
@@ -17,7 +17,7 @@ This article walks you through the steps to start using the DualEngine API.
 <!-- ====================================================================== -->
 ## Step 1: Get access to the DualEngine Limited Access Feature
 
-The DualEngine API is part of a Limited Access Feature. For more information or to request an unlock token, contact [Microsoft Support](https://aka.ms/LAFAccessRequests).
+The DualEngine API is part of a Limited Access Feature. For more information or to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
 
 The DualEngine LAF is handled somewhat atypically; for details, see [Unlock the Limited Access Feature](concepts/adapter-dll.md#unlock-the-limited-access-feature) in _Creating a DualEngine adapter plugin DLL_.
 


### PR DESCRIPTION
The Limited Access Support support link changed. This PR updates it in the docs.

* **Creating a DualEngine adapter plugin DLL**: [Preview](https://review.learn.microsoft.com/en-us/microsoft-edge/dualengine/concepts/adapter-dll?branch=pr-en-us-3162) / [Before](https://learn.microsoft.com/en-us/microsoft-edge/dualengine/concepts/adapter-dll).
* **Getting started with the DualEngine API**: [Preview](https://review.learn.microsoft.com/en-us/microsoft-edge/dualengine/get-started?branch=pr-en-us-3162) / [Before](https://learn.microsoft.com/en-us/microsoft-edge/dualengine/get-started).

AB#50930590