### PR TITLE
Remove unneeded request parameter from LAF support shortlink

### DIFF
--- a/microsoft-edge/dualengine/concepts/adapter-dll.md
+++ b/microsoft-edge/dualengine/concepts/adapter-dll.md
@@ -19,7 +19,7 @@ To have Internet Explorer successfully load your DLL, do the following.
 <!-- ====================================================================== -->
 ## Unlock the Limited Access Feature
 
-The DualEngine API is a Limited Access Feature (LAF); that is, a feature that needs to be unlocked before it can be used. For more information about implementation, see [LimitedAccessFeatures Class](/uwp/api/windows.applicationmodel.limitedaccessfeatures). To request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+The DualEngine API is a Limited Access Feature (LAF); that is, a feature that needs to be unlocked before it can be used. For more information about implementation, see [LimitedAccessFeatures Class](/uwp/api/windows.applicationmodel.limitedaccessfeatures). To request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 The DualEngine API is not a typical LAF, in that `Windows.ApplicationModel.TryUnlockFeature` is not used to unlock the feature.  This is because LAF typically uses the application identity of the calling process to grant access, and as a plugin DLL, this will always be Internet Explorer.  Therefore, to unlock the API, you need to call [DualEngineSessionFactory::TryUnlockFeature](../reference/dualenginesessionfactory.md#tryunlockfeature).
 

--- a/microsoft-edge/dualengine/get-started.md
+++ b/microsoft-edge/dualengine/get-started.md
@@ -17,7 +17,7 @@ This article walks you through the steps to start using the DualEngine API.
 <!-- ====================================================================== -->
 ## Step 1: Get access to the DualEngine Limited Access Feature
 
-The DualEngine API is part of a Limited Access Feature. For more information or to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+The DualEngine API is part of a Limited Access Feature. For more information or to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 The DualEngine LAF is handled somewhat atypically; for details, see [Unlock the Limited Access Feature](concepts/adapter-dll.md#unlock-the-limited-access-feature) in _Creating a DualEngine adapter plugin DLL_.
 

--- a/microsoft-edge/dualengine/reference/accelerator.md
+++ b/microsoft-edge/dualengine/reference/accelerator.md
@@ -25,7 +25,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 Represents a keyboard accelerator (keyboard shortcut).
 

--- a/microsoft-edge/dualengine/reference/cryptdatablob.md
+++ b/microsoft-edge/dualengine/reference/cryptdatablob.md
@@ -24,7 +24,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 Represents an SSL Certificate.
 

--- a/microsoft-edge/dualengine/reference/dualengine-idl.md
+++ b/microsoft-edge/dualengine/reference/dualengine-idl.md
@@ -23,7 +23,7 @@ api_loction:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 ## Summary
 

--- a/microsoft-edge/dualengine/reference/dualenginecookie.md
+++ b/microsoft-edge/dualengine/reference/dualenginecookie.md
@@ -30,7 +30,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 Represents the constituent parts of a cookie.
 

--- a/microsoft-edge/dualengine/reference/dualenginenewwindowoptions.md
+++ b/microsoft-edge/dualengine/reference/dualenginenewwindowoptions.md
@@ -35,7 +35,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 Represents the requested state of a new window.
 

--- a/microsoft-edge/dualengine/reference/dualenginesessionfactory.md
+++ b/microsoft-edge/dualengine/reference/dualenginesessionfactory.md
@@ -25,7 +25,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 Factory object for DualEngine interfaces.
 

--- a/microsoft-edge/dualengine/reference/idualengine20browser.md
+++ b/microsoft-edge/dualengine/reference/idualengine20browser.md
@@ -57,7 +57,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 ```cpp
 interface IDualEngine20Browser

--- a/microsoft-edge/dualengine/reference/idualengine20browserobserver.md
+++ b/microsoft-edge/dualengine/reference/idualengine20browserobserver.md
@@ -72,7 +72,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 ```cpp
 interface IDualEngine20BrowserObserver

--- a/microsoft-edge/dualengine/reference/idualengine20browsersession.md
+++ b/microsoft-edge/dualengine/reference/idualengine20browsersession.md
@@ -39,7 +39,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 ```cpp
 interface IDualEngine20BrowserSession

--- a/microsoft-edge/dualengine/reference/idualengine20browsersessionobserver.md
+++ b/microsoft-edge/dualengine/reference/idualengine20browsersessionobserver.md
@@ -25,7 +25,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 ```cpp
 interface IDualEngine20BrowserSessionObserver

--- a/microsoft-edge/dualengine/reference/index.md
+++ b/microsoft-edge/dualengine/reference/index.md
@@ -13,7 +13,7 @@ ms.date: 05/21/2024
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 The Microsoft DualEngine API enables you to host and control an Internet Explorer instance within your app.  For more information, see [Introduction to the Microsoft DualEngine API](../intro.md) and [Getting started with the DualEngine API](../get-started.md). 
 

--- a/microsoft-edge/dualengine/reference/tagsentinelentryinfo.md
+++ b/microsoft-edge/dualengine/reference/tagsentinelentryinfo.md
@@ -24,7 +24,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 Represents the position of the current region in the travel log.
 

--- a/microsoft-edge/dualengine/reference/visiblelistupdateentry.md
+++ b/microsoft-edge/dualengine/reference/visiblelistupdateentry.md
@@ -27,7 +27,7 @@ api_location:
 
 > [!IMPORTANT]
 > The DualEngine API is part of a Limited Access Feature (see [LimitedAccessFeatures class](/uwp/api/windows.applicationmodel.limitedaccessfeatures)). For more information or 
-> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232&clcid=0x409).
+> to request an unlock token, contact [Microsoft Support](https://go.microsoft.com/fwlink/?linkid=2271232).
 
 Represents a change to a travel log entry.
 


### PR DESCRIPTION
Turns out this second parameter is not needed. I'll file an internal issue to get the template used by the reference docs in this PR updated too.

AB#51192189