### PR TITLE
Remove dup line of code in "Working with local content in WebView2 apps"

### DIFF
--- a/microsoft-edge/webview2/concepts/working-with-local-content.md
+++ b/microsoft-edge/webview2/concepts/working-with-local-content.md
@@ -743,7 +743,6 @@ HRESULT AppWindow::WebResourceRequestedEventHandler(
     CHECK_FAILURE(request->get_Uri(&uri));
     std::wstring assetsFilePath = L"C:\\Demo";
     assetsFilePath += (uri.get() + ARRAYSIZE(L"https://demo"));
-    wil::com_ptr<IStream> stream;
     SHCreateStreamOnFileEx(
         assetsFilePath.c_str(), STGM_READ, FILE_ATTRIBUTE_NORMAL, FALSE,
         nullptr, &stream);


### PR DESCRIPTION
Rendered article section for review: 
* **Working with local content in WebView2 apps** > **Example of handling the WebResourceRequested event** - removes dup line `wil::com_ptr<IStream> stream;`
   * https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/working-with-local-content?branch=pr-en-us-3208&tabs=win32cpp#example-of-handling-the-webresourcerequested-event
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/concepts/working-with-local-content?tabs=win32cpp#example-of-handling-the-webresourcerequested-event)

AB#51968489