### PR TITLE
Comment out 404 link browserstack.com/test-on-microsoft-edge-browser

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
+++ b/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers.md
@@ -121,7 +121,7 @@ When you are done, learn how to work with the simulator through [Apple Developer
 <!-- ------------------------------ -->
 #### Microsoft Edge (EdgeHTML)
 
-If you need to test your website or app with Microsoft browsers and don't have the necessary versions of Windows to do so, you can use BrowserStack, which supports testing of many combinations of Microsoft browsers and operating systems both past and present.  For example, you can test all versions of Microsoft Edge (Chromium) from version 80 onwards, and Microsoft Edge (EdgeHTML) versions 15 through 18.  Testing of Microsoft Edge is free on BrowserStack.  For more information, see [Microsoft Edge Browser Testing](https://www.browserstack.com/test-on-microsoft-edge-browser) at BrowserStack.
+If you need to test your website or app with Microsoft browsers and don't have the necessary versions of Windows to do so, you can use BrowserStack, which supports testing of many combinations of Microsoft browsers and operating systems both past and present.  For example, you can test all versions of Microsoft Edge (Chromium) from version 80 onwards, and Microsoft Edge (EdgeHTML) versions 15 through 18.  Testing of Microsoft Edge is free on BrowserStack. <!-- For more information, see [Microsoft Edge Browser Testing](https://www.browserstack.com/test-on-microsoft-edge-browser) at BrowserStack.  todo: update 404 link, article title not found at site -->
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
Rendered article section for review:
https://review.learn.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers?branch=pr-en-us-3220#microsoft-edge-edgehtml - commented-out final sentence, that contains 404 link.
[Before/Live](https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/device-mode/testing-other-browsers#microsoft-edge-edgehtml)

The objective of this PR is to immediately remove the 404 warning from PR build reports for PRs in this repo.  Rewriting or removing the section or sentence is out of scope for this PR; covered by an earlier PR.

AB#52409791