### PR TITLE
Add flag "edge-webview-disable-interactive-dragging"

### DIFF
--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -84,7 +84,8 @@ The following are some of the flags we've seen used.
 | `edge-webview-foreground-boost-opt-in` | Opts-in to foreground boost. |
 | `edge-webview-foreground-boost-opt-out` | Opts-out of foreground boost. |
 | `edge-webview-force-personal-context` | Forces Edge WebView browser processes to run in WIP personal context. |
-| `edge-webview-interactive-dragging` | Enables pointer events and focus events to occur on elements that have the `--app-region: drag` attribute.  If this flag isn't set, drag elements are non-interactive. |
+| `edge-webview-interactive-dragging` | Enables pointer events and focus events to occur on elements that have the `--app-region: drag` attribute. Drag elements are interactive by default. |
+| `edge-webview-disable-interactive-dragging` | Disables pointer events and focus events from occuring on elements that have the `--app-region: drag` attribute. If this flag isn't set, drag elements are interactive by default. |
 | `edge-webview-is-background` | Indicates that WebView is being launched in the background. |
 | `edge-webview-no-dpi-workaround` | Disables the "DPI awareness app compatibility shim" workaround, which launches Edge WebView browser process via a shell, so that the process doesn't inherit the "app compat" shim. |
 | `edge-webview-run-with-package-id` | Runs WebView processes with a package identity (package ID) for a bridged Desktop app. |


### PR DESCRIPTION
Rendered article section for review: 
* **WebView2 browser flags** > **Available WebView2 browser flags**
   * https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags?branch=pr-en-us-3251#available-webview2-browser-flags
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags#available-webview2-browser-flags)

# What
This PR is intended to update the documentation for the interactive dragging feature flags. 

# Why
The feature behavior has changed, it is now enabled by default and can be disabled with an opt-out flag `edge-webview-disable-interactive-dragging`. The previous opt-in flag `edge-webview-interactive-dragging` is now a no-op.

AB#53385943