### PR TITLE
Remove "Show Downloads" from list of shortcuts that are turned off

### DIFF
--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -163,7 +163,6 @@ The following shortcuts are always turned off in WebView2, or are effectively tu
 | Home | **Alt+Home**, **Browser Home Key** |
 | Show App Menu | **Alt+E**, **Alt+F** |
 | Show Favorites | **Ctrl+Shift+O** |
-| Show Downloads | **Ctrl+J** |
 | Show History | **Ctrl+H** |
 | Show Reading Mode Bar `*` | **Shift+Alt+R** |
 | Show Collections `*` | **Ctrl+Shift+Y** |


### PR DESCRIPTION
Rendered article section for review:
* **Differences between Microsoft Edge and WebView2** > **Shortcuts that are turned off**
   * https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/browser-features?branch=pr-en-us-3261#shortcuts-that-are-turned-off
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/concepts/browser-features#shortcuts-that-are-turned-off)

The "Show Downloads" shortcut, Ctrl+J, does actually work properly, so we are removing it from this list of disabled shortcuts.

AB#53646594