### PR TITLE
Add "Show Downloads" shortcut to list that are turned off if AcceleratorEnabled is false

### DIFF
--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -203,6 +203,7 @@ If you set `AreBrowserAcceleratorKeysEnabled` to `FALSE`, the following addition
 | Open / Close DevTools | **Ctrl+Shift+I** |
 | Open DevTools Console | **Ctrl+Shift+J** |
 | Open DevTools Inspect | **Ctrl+Shift+C** |
+| Show Downloads | **Ctrl+J** |
 
 
 ### Customizing an individual key


### PR DESCRIPTION
Rendered article section for review:
* **Differences between Microsoft Edge and WebView2** > **Shortcuts turned off if AcceleratorEnabled is False**
   * https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/browser-features?branch=pr-en-us-3264#shortcuts-turned-off-if-acceleratorenabled-is-false
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/concepts/browser-features#shortcuts-turned-off-if-acceleratorenabled-is-false)

We recently removed "Show Downloads" shortcut, **Ctrl+J**, from the list of disabled shortcuts. However, we missed moving it to the list of supported shortcuts that get disabled if AcceleratorEnabled is turned off. Adding that in this PR.

AB#53715165