### PR TITLE
Extensions landing page

### DIFF
--- a/microsoft-edge/extensions-chromium/index.md
+++ b/microsoft-edge/extensions-chromium/index.md
@@ -22,6 +22,8 @@ An extension should include at least the following features:
 
 To work directly with a specific part of the browser, such as a window or tab, you must send API requests, and must often reference the browser by name.
 
+<!-- todo: equivalent of landing page cards -->
+
 ![A Microsoft Edge extension](./index-images/example-extension-screenshot.png)
 
 See also:

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -35,6 +35,9 @@ metadata:
 # =============================================================================
 landingContent:
 
+# todo: convert PR2899 toc to cards
+# https://github.com/MicrosoftDocs/edge-developer/pull/2899/files#diff-ee2ce4f25251cfbee0656b0e57a5e2400000a29db0a53f90a9584f61985b583e
+
 # =============================================================================
 # Card r1c1
   - title: Getting started with DevTools

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -73,7 +73,7 @@ landingContent:
     linkLists:
       - linkListType: how-to-guide
         links:
-         - text: Overview and timelines for migrating to Manifest V3
+          - text: Overview and timelines for migrating to Manifest V3
             url: ../developer-guide/manifest-v3.md
 
           - text: Migrate an extension from Manifest V2 to V3

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -67,6 +67,9 @@ landingContent:
           - text: Roadmap for Microsoft Edge Add-ons
             url: ../whats-new/roadmap.md
 
+          - text: Contact the Microsoft Edge extensions team
+            url: extensions-chromium/publish/contact-extensions-team.md
+
 # =============================================================================
 # Card r1c2
   - title: Manifests and JavaScript APIs

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -69,14 +69,11 @@ landingContent:
 
 # =============================================================================
 # Card r1c2
-  - title: Develop an extension
+  - title: Manifests and JavaScript APIs
     linkLists:
       - linkListType: how-to-guide
         links:
-          - text: Port a Chrome extension to Microsoft Edge
-            url: ../developer-guide/port-chrome-extension.md
-
-          - text: Overview and timelines for migrating to Manifest V3
+         - text: Overview and timelines for migrating to Manifest V3
             url: ../developer-guide/manifest-v3.md
 
           - text: Migrate an extension from Manifest V2 to V3
@@ -96,6 +93,15 @@ landingContent:
           - text: Using Content Security Policy (CSP) to control which resources can be run
             url: ../developer-guide/csp.md
 
+# =============================================================================
+# Card r1c3
+  - title: Develop an extension
+    linkLists:
+      - linkListType: how-to-guide
+        links:
+          - text: Port a Chrome extension to Microsoft Edge
+            url: ../developer-guide/port-chrome-extension.md
+ 
       - linkListType: concept
         links:
           - text: Create an extension that customizes the DevTools UI
@@ -119,7 +125,7 @@ landingContent:
             url: /legal/microsoft-edge/extensions/developer-policies
 
 # =============================================================================
-# Card r1c3
+# Card r2c1
   - title: Register
     linkLists:
       - linkListType: how-to-guide
@@ -137,7 +143,7 @@ landingContent:
             url: ../publish/github.md
 
 # =============================================================================
-# Card r2c1
+# Card r2c2
   - title: Publish an extension
     linkLists:
       - linkListType: deploy
@@ -163,7 +169,7 @@ landingContent:
             url: ../publish/add-ons-store-curation.md
 
 # =============================================================================
-# Card r2c2
+# Card r2c3
   - title: Update an extension
     linkLists:
       - linkListType: how-to-guide
@@ -183,7 +189,7 @@ landingContent:
             url: ../publish/api/addons-api-reference.md
 
 # =============================================================================
-# Card r2c3
+# Card r3c1
   - title: Analytics and reviews
     linkLists:
       - linkListType: how-to-guide
@@ -195,7 +201,7 @@ landingContent:
             url: ../publish/reply-user-reviews.md
 
 # =============================================================================
-# Card r3c1
+# Card r3c2
   - title: Best practices and samples
     linkLists:
       - linkListType: overview

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -12,7 +12,7 @@ metadata:
   # ms.collection: collection # Optional; Remove if no collection is used.
   author: MSEdgeTeam
   ms.author: msedgedevrel
-  ms.date: 02/15/2024
+  ms.date: 09/17/2024
 
 # =============================================================================
 # Valid article types (sections of a card)
@@ -34,9 +34,6 @@ metadata:
 
 # =============================================================================
 landingContent:
-
-# todo: convert PR2899 toc to cards
-# https://github.com/MicrosoftDocs/edge-developer/pull/2899/files#diff-ee2ce4f25251cfbee0656b0e57a5e2400000a29db0a53f90a9584f61985b583e
 
 # =============================================================================
 # Card r1c1
@@ -180,7 +177,7 @@ landingContent:
           - text: Update a Microsoft Edge extension
             url: ../publish/update-extension.md
 
-          - text: Automatically update an extension in Microsoft Edge
+          - text: Set an extension to automatically update
             url: ../publish/auto-update.md
 
           - text: Using the Microsoft Edge Add-ons REST API

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -45,27 +45,27 @@ landingContent:
       - linkListType: get-started
         links:
           - text: Overview of Microsoft Edge extensions
-            url: ./extensions-chromium/index.md
+            url: ../index.md
 
           - text: Extension concepts and architecture
-            url: ./extensions-chromium/getting-started/index.md
+            url: ../getting-started/index.md
 
           - text: Create an extension tutorial, part 1
-            url: ./extensions-chromium/getting-started/part1-simple-extension.md
+            url: ../getting-started/part1-simple-extension.md
 
           - text: Create an extension tutorial, part 2
-            url: ./extensions-chromium/getting-started/part2-content-scripts.md
+            url: ../getting-started/part2-content-scripts.md
 
           - text: Sideload an extension
-            url: ./extensions-chromium/getting-started/extension-sideloading.md
+            url: ../getting-started/extension-sideloading.md
 
       - linkListType: whats-new
         links:
           - text: Released features for Microsoft Edge Add-ons
-            url: ./extensions-chromium/whats-new/released-features.md
+            url: ../whats-new/released-features.md
 
           - text: Roadmap for Microsoft Edge Add-ons
-            url: ./extensions-chromium/whats-new/roadmap.md
+            url: ../whats-new/roadmap.md
 
 # =============================================================================
 # Card r1c2
@@ -74,41 +74,41 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Port a Chrome extension to Microsoft Edge
-            url: ./extensions-chromium/developer-guide/port-chrome-extension.md
+            url: ../developer-guide/port-chrome-extension.md
 
           - text: Overview and timelines for migrating to Manifest V3
-            url: ./extensions-chromium/developer-guide/manifest-v3.md
+            url: ../developer-guide/manifest-v3.md
 
           - text: Migrate an extension from Manifest V2 to V3
-            url: ./extensions-chromium/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
+            url: ../developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
 
           - text: Supported APIs for Microsoft Edge extensions
-            url: ./extensions-chromium/developer-guide/api-support.md
+            url: ../developer-guide/api-support.md
 
           - text: Declare API permissions in the manifest
-            url: ./extensions-chromium/developer-guide/declare-permissions.md
+            url: ../developer-guide/declare-permissions.md
 
       - linkListType: reference
         links:
           - text: Manifest file format for extensions
-            url: ./extensions-chromium/getting-started/manifest-format.md
+            url: ../getting-started/manifest-format.md
 
           - text: Using Content Security Policy (CSP) to control which resources can be run
-            url: ./extensions-chromium/developer-guide/csp.md
+            url: ../developer-guide/csp.md
 
       - linkListType: concept
         links:
           - text: Create an extension that customizes the DevTools UI
-            url: ./extensions-chromium/developer-guide/devtools-extension.md
+            url: ../developer-guide/devtools-extension.md
 
           - text: Develop an extension for the Microsoft Edge sidebar
-            url: ./extensions-chromium/developer-guide/sidebar.md
+            url: ../developer-guide/sidebar.md
 
           - text: Native messaging
-            url: ./extensions-chromium/developer-guide/native-messaging.md
+            url: ../developer-guide/native-messaging.md
 
           - text: Defining match patterns for an extension to access file URLs
-            url: ./extensions-chromium/developer-guide/match-patterns.md
+            url: ../developer-guide/match-patterns.md
 
       - linkListType: deploy
         links:
@@ -125,16 +125,16 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Register as a Microsoft Edge extension developer
-            url: ./extensions-chromium/publish/create-dev-account.md
+            url: ../publish/create-dev-account.md
 
           - text: Verify your company account information  # enterprise
-            url: ./extensions-chromium/publish/verify-microsoft-edge-program.md
+            url: ../publish/verify-microsoft-edge-program.md
 
           - text: Add users to the Microsoft Edge program  # enterprise
-            url: ./extensions-chromium/publish/aad-account.md
+            url: ../publish/aad-account.md
 
           - text: Register and sign in to Partner Center using a GitHub account
-            url: ./extensions-chromium/publish/github.md
+            url: ../publish/github.md
 
 # =============================================================================
 # Card r2c1
@@ -143,24 +143,24 @@ landingContent:
       - linkListType: deploy
         links:
           - text: Publish a Microsoft Edge extension
-            url: ./extensions-chromium/publish/publish-extension.md
+            url: ../publish/publish-extension.md
 
           - text: Extension hosting
-            url: ./extensions-chromium/publish/hosting-and-updating.md
+            url: ../publish/hosting-and-updating.md
 
           - text: Submission states for extensions in the Microsoft Edge Add-ons website
-            url: ./extensions-chromium/publish/submission-states.md
+            url: ../publish/submission-states.md
 
           - text: Manage account settings
-            url: ./extensions-chromium/publish/manage-settings.md
+            url: ../publish/manage-settings.md
 
           - text: Alternative ways to distribute an extension
-            url: ./extensions-chromium/developer-guide/alternate-distribution-options.md
+            url: ../developer-guide/alternate-distribution-options.md
 
       - linkListType: concept
         links:
           - text: Curation and review process for the Edge Add-ons store
-            url: ./extensions-chromium/publish/add-ons-store-curation.md
+            url: ../publish/add-ons-store-curation.md
 
 # =============================================================================
 # Card r2c2
@@ -169,18 +169,18 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: Update a Microsoft Edge extension
-            url: ./extensions-chromium/publish/update-extension.md
+            url: ../publish/update-extension.md
 
           - text: Automatically update an extension in Microsoft Edge
-            url: ./extensions-chromium/publish/auto-update.md
+            url: ../publish/auto-update.md
 
       - linkListType: reference
         links:
           - text: Using the Microsoft Edge Add-ons REST API
-            url: ./extensions-chromium/publish/api/using-addons-api.md
+            url: ../publish/api/using-addons-api.md
 
           - text: REST API Reference for Microsoft Edge Add-ons
-            url: ./extensions-chromium/publish/api/addons-api-reference.md
+            url: ../publish/api/addons-api-reference.md
 
 # =============================================================================
 # Card r2c3
@@ -189,11 +189,10 @@ landingContent:
       - linkListType: how-to-guide
         links:
           - text: View Microsoft Edge extensions analytics dashboard
-            url: ./extensions-chromium/publish/extensions-analytics.md
+            url: ../publish/extensions-analytics.md
 
           - text: Reply to user reviews of an extension
-            url: ./extensions-chromium/publish/reply-user-reviews.md
-            displayName: Respond to user reviews
+            url: ../publish/reply-user-reviews.md
 
 # =============================================================================
 # Card r3c1
@@ -202,9 +201,9 @@ landingContent:
       - linkListType: overview
         links:
           - text: Best practices for extensions
-            url: ./extensions-chromium/developer-guide/best-practices.md
+            url: ../developer-guide/best-practices.md
 
       - linkListType: sample
         links:
           - text: Samples for Microsoft Edge extensions
-            url: ./extensions-chromium/samples.md
+            url: ../samples.md

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -183,11 +183,11 @@ landingContent:
           - text: Automatically update an extension in Microsoft Edge
             url: ../publish/auto-update.md
 
-      - linkListType: reference
-        links:
           - text: Using the Microsoft Edge Add-ons REST API
             url: ../publish/api/using-addons-api.md
 
+      - linkListType: reference
+        links:
           - text: REST API Reference for Microsoft Edge Add-ons
             url: ../publish/api/addons-api-reference.md
 

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -68,7 +68,7 @@ landingContent:
             url: ../whats-new/roadmap.md
 
           - text: Contact the Microsoft Edge extensions team
-            url: extensions-chromium/publish/contact-extensions-team.md
+            url: ../publish/contact-extensions-team.md
 
 # =============================================================================
 # Card r1c2

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -40,166 +40,171 @@ landingContent:
 
 # =============================================================================
 # Card r1c1
-  - title: Getting started with DevTools
+  - title: Get started
     linkLists:
       - linkListType: get-started
         links:
-          - text: Overview of DevTools
-            url: ../../devtools-guide-chromium/overview.md
+          - text: Overview of Microsoft Edge extensions
+            url: ./extensions-chromium/index.md
 
-          - text: Change DevTools placement (Undock, Dock to bottom, Dock to left)
-            url: ../../devtools-guide-chromium/customize/placement.md
+          - text: Extension concepts and architecture
+            url: ./extensions-chromium/getting-started/index.md
 
-          - text: Run commands in the Command Menu
-            url: ../../devtools-guide-chromium/command-menu/index.md
+          - text: Create an extension tutorial, part 1
+            url: ./extensions-chromium/getting-started/part1-simple-extension.md
 
-          - text: Console overview
-            url: ../../devtools-guide-chromium/console/index.md
+          - text: Create an extension tutorial, part 2
+            url: ./extensions-chromium/getting-started/part2-content-scripts.md
+
+          - text: Sideload an extension
+            url: ./extensions-chromium/getting-started/extension-sideloading.md
+
       - linkListType: whats-new
         links:
-          - text: What's New in Microsoft Edge DevTools
-            url: ../../devtools-guide-chromium/whats-new/whats-new.md
+          - text: Released features for Microsoft Edge Add-ons
+            url: ./extensions-chromium/whats-new/released-features.md
 
-          - text: Contact the Microsoft Edge DevTools team
-            url: ../../devtools-guide-chromium/contact.md
+          - text: Roadmap for Microsoft Edge Add-ons
+            url: ./extensions-chromium/whats-new/roadmap.md
 
 # =============================================================================
 # Card r1c2
-  - title: Customizing DevTools
+  - title: Develop an extension
     linkLists:
-      - linkListType: get-started
-        links:
-          - text: Customize DevTools
-            url: ../../devtools-guide-chromium/customize/index.md
-
-          - text: Apply a color theme to DevTools
-            url: ../../devtools-guide-chromium/customize/theme.md
-      - linkListType: whats-new
-        links:
-          - text: Experimental features in Microsoft Edge DevTools
-            url: ../../devtools-guide-chromium/experimental-features/index.md
       - linkListType: how-to-guide
         links:
-          - text: Change DevTools language settings
-            url: ../../devtools-guide-chromium/customize/localization.md
+          - text: Port a Chrome extension to Microsoft Edge
+            url: ./extensions-chromium/developer-guide/port-chrome-extension.md
 
-          - text: Customize keyboard shortcuts
-            url: ../../devtools-guide-chromium/customize/shortcuts.md
+          - text: Overview and timelines for migrating to Manifest V3
+            url: ./extensions-chromium/developer-guide/manifest-v3.md
+
+          - text: Migrate an extension from Manifest V2 to V3
+            url: ./extensions-chromium/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
+
+          - text: Supported APIs for Microsoft Edge extensions
+            url: ./extensions-chromium/developer-guide/api-support.md
+
+          - text: Declare API permissions in the manifest
+            url: ./extensions-chromium/developer-guide/declare-permissions.md
+
+      - linkListType: reference
+        links:
+          - text: Manifest file format for extensions
+            url: ./extensions-chromium/getting-started/manifest-format.md
+
+          - text: Using Content Security Policy (CSP) to control which resources can be run
+            url: ./extensions-chromium/developer-guide/csp.md
+
+      - linkListType: concept
+        links:
+          - text: Create an extension that customizes the DevTools UI
+            url: ./extensions-chromium/developer-guide/devtools-extension.md
+
+          - text: Develop an extension for the Microsoft Edge sidebar
+            url: ./extensions-chromium/developer-guide/sidebar.md
+
+          - text: Native messaging
+            url: ./extensions-chromium/developer-guide/native-messaging.md
+
+          - text: Defining match patterns for an extension to access file URLs
+            url: ./extensions-chromium/developer-guide/match-patterns.md
+
+      - linkListType: deploy
+        links:
+          - text: App Developer Agreement Addendum for Microsoft Edge program users
+            url: /legal/microsoft-edge/extensions/ada-addendum
+
+          - text: Developer policies for the Microsoft Edge Add-ons store
+            url: /legal/microsoft-edge/extensions/developer-policies
 
 # =============================================================================
 # Card r1c3
-  - title: Debugging web projects
+  - title: Register
     linkLists:
-      - linkListType: quickstart
-        links:
-          - text: Analyze pages using the Inspect tool
-            url: ../../devtools-guide-chromium/css/inspect.md
-      - linkListType: tutorial
-        links:
-          - text: Get started viewing and changing CSS
-            url: ../../devtools-guide-chromium/css/index.md
-
-          - text: Get started viewing and changing the DOM
-            url: ../../devtools-guide-chromium/dom/index.md
       - linkListType: how-to-guide
         links:
-          - text: Find and fix problems using the Issues tool
-            url: ../../devtools-guide-chromium/issues/index.md
+          - text: Register as a Microsoft Edge extension developer
+            url: ./extensions-chromium/publish/create-dev-account.md
 
-          - text: Navigate webpage layers, z-index, and DOM using the 3D View tool
-            url: ../../devtools-guide-chromium/3d-view/index.md
+          - text: Verify your company account information  # enterprise
+            url: ./extensions-chromium/publish/verify-microsoft-edge-program.md
 
-          - text: Inspect animations
-            url: ../../devtools-guide-chromium/inspect-styles/animations.md
+          - text: Add users to the Microsoft Edge program  # enterprise
+            url: ./extensions-chromium/publish/aad-account.md
 
-          - text: Debug Progressive Web Apps (PWAs)
-            url: ../../devtools-guide-chromium/progressive-web-apps/index.md
-
-          - text: Inspect network activity
-            url: ../../devtools-guide-chromium/network/index.md
+          - text: Register and sign in to Partner Center using a GitHub account
+            url: ./extensions-chromium/publish/github.md
 
 # =============================================================================
 # Card r2c1
-  - title: Emulation and Testing
+  - title: Publish an extension
     linkLists:
-      - linkListType: how-to-guide
+      - linkListType: deploy
         links:
-          - text: Emulate mobile devices (Device Emulation)
-            url: ../../devtools-guide-chromium/device-mode/index.md
+          - text: Publish a Microsoft Edge extension
+            url: ./extensions-chromium/publish/publish-extension.md
 
-          - text: Accessibility-testing features
-            url: ../../devtools-guide-chromium/accessibility/reference.md
+          - text: Extension hosting
+            url: ./extensions-chromium/publish/hosting-and-updating.md
 
-          - text: Emulate dark or light schemes in the rendered page
-            url: ../../devtools-guide-chromium/accessibility/preferred-color-scheme-simulation.md
+          - text: Submission states for extensions in the Microsoft Edge Add-ons website
+            url: ./extensions-chromium/publish/submission-states.md
 
-          - text: Test keyboard support using the Source Order Viewer
-            url: ../../devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer.md
+          - text: Manage account settings
+            url: ./extensions-chromium/publish/manage-settings.md
 
-          - text: Force print preview mode
-            url: ../../devtools-guide-chromium/css/print-preview.md
+          - text: Alternative ways to distribute an extension
+            url: ./extensions-chromium/developer-guide/alternate-distribution-options.md
 
-          - text: Emulate vision deficiencies
-            url: ../../devtools-guide-chromium/accessibility/emulate-vision-deficiencies.md
-
-          - text: Simulate reduced motion
-            url: ../../devtools-guide-chromium/accessibility/reduced-motion-simulation.md
+      - linkListType: concept
+        links:
+          - text: Curation and review process for the Edge Add-ons store
+            url: ./extensions-chromium/publish/add-ons-store-curation.md
 
 # =============================================================================
 # Card r2c2
-  - title: JavaScript and performance
+  - title: Update an extension
     linkLists:
       - linkListType: how-to-guide
         links:
-          - text: Run JavaScript in the Console
-            url: ../../devtools-guide-chromium/console/console-javascript.md
+          - text: Update a Microsoft Edge extension
+            url: ./extensions-chromium/publish/update-extension.md
 
-          - text: Fix JavaScript errors that are reported in the Console
-            url: ../../devtools-guide-chromium/console/console-debug-javascript.md
+          - text: Automatically update an extension in Microsoft Edge
+            url: ./extensions-chromium/publish/auto-update.md
 
-          - text: Sources tool overview
-            url: ../../devtools-guide-chromium/sources/index.md
+      - linkListType: reference
+        links:
+          - text: Using the Microsoft Edge Add-ons REST API
+            url: ./extensions-chromium/publish/api/using-addons-api.md
 
-          - text: JavaScript debugging features
-            url: ../../devtools-guide-chromium/javascript/reference.md
-
-          - text: Find unused JavaScript and CSS code with the Coverage tool
-            url: ../../devtools-guide-chromium/coverage/index.md
-
-          - text: Fix memory problems
-            url: ../../devtools-guide-chromium/memory-problems/index.md
-
-          - text: Debug DOM memory leaks with the Detached Elements tool
-            url: ../../devtools-guide-chromium/memory-problems/dom-leaks.md
-
-          - text: Understand security issues using the Security tool
-            url: ../../devtools-guide-chromium/security/index.md
-
-          - text: Troubleshooting common performance issues
-            url: ../../devtools-guide-chromium/rendering-tools/index.md
+          - text: REST API Reference for Microsoft Edge Add-ons
+            url: ./extensions-chromium/publish/api/addons-api-reference.md
 
 # =============================================================================
 # Card r2c3
-  - title: Reference
+  - title: Analytics and reviews
     linkLists:
-      - linkListType: reference
-        links:
-          - text: Keyboard shortcuts
-            url: ../../devtools-guide-chromium/shortcuts/index.md
-
-          - text: CSS features reference
-            url: ../../devtools-guide-chromium/css/reference.md
-
-          - text: Console features reference
-            url: ../../devtools-guide-chromium/console/reference.md
-
-          - text: Console object API Reference
-            url: ../../devtools-guide-chromium/console/api.md
       - linkListType: how-to-guide
         links:
-          - text: Performance features reference
-            url: ../../devtools-guide-chromium/evaluate-performance/reference.md
+          - text: View Microsoft Edge extensions analytics dashboard
+            url: ./extensions-chromium/publish/extensions-analytics.md
+
+          - text: Reply to user reviews of an extension
+            url: ./extensions-chromium/publish/reply-user-reviews.md
+            displayName: Respond to user reviews
+
+# =============================================================================
+# Card r3c1
+  - title: Best practices and samples
+    linkLists:
+      - linkListType: overview
+        links:
+          - text: Best practices for extensions
+            url: ./extensions-chromium/developer-guide/best-practices.md
+
       - linkListType: sample
         links:
-          - text: Sample code for DevTools
-            url: ../../devtools-guide-chromium/sample-code/sample-code.md
+          - text: Samples for Microsoft Edge extensions
+            url: ./extensions-chromium/samples.md

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -1,0 +1,202 @@
+### YamlMime:Landing
+# landing page for Extensions portion of docset
+title: Microsoft Edge Extensions documentation
+summary: Develop an extension (add-on) for Microsoft Edge.
+
+metadata:
+  # title: default to root title above. # Required; page title displayed in search results. Include the brand. < 60 chars.
+  # description: default to root title above. # Required; article description that is displayed in search results. < 160 chars.
+  ms.service: microsoft-edge
+  ms.subservice: extensions
+  ms.topic: landing-page
+  # ms.collection: collection # Optional; Remove if no collection is used.
+  author: MSEdgeTeam
+  ms.author: msedgedevrel
+  ms.date: 02/15/2024
+
+# =============================================================================
+# Valid article types (sections of a card)
+
+      # - linkListType: architecture
+      # - linkListType: concept
+      # - linkListType: deploy
+      # - linkListType: download
+      # - linkListType: get-started
+      # - linkListType: how-to-guide
+      # - linkListType: learn
+      # - linkListType: overview
+      # - linkListType: quickstart
+      # - linkListType: reference
+      # - linkListType: sample
+      # - linkListType: tutorial
+      # - linkListType: video
+      # - linkListType: whats-new
+
+# =============================================================================
+landingContent:
+
+# =============================================================================
+# Card r1c1
+  - title: Getting started with DevTools
+    linkLists:
+      - linkListType: get-started
+        links:
+          - text: Overview of DevTools
+            url: ../../devtools-guide-chromium/overview.md
+
+          - text: Change DevTools placement (Undock, Dock to bottom, Dock to left)
+            url: ../../devtools-guide-chromium/customize/placement.md
+
+          - text: Run commands in the Command Menu
+            url: ../../devtools-guide-chromium/command-menu/index.md
+
+          - text: Console overview
+            url: ../../devtools-guide-chromium/console/index.md
+      - linkListType: whats-new
+        links:
+          - text: What's New in Microsoft Edge DevTools
+            url: ../../devtools-guide-chromium/whats-new/whats-new.md
+
+          - text: Contact the Microsoft Edge DevTools team
+            url: ../../devtools-guide-chromium/contact.md
+
+# =============================================================================
+# Card r1c2
+  - title: Customizing DevTools
+    linkLists:
+      - linkListType: get-started
+        links:
+          - text: Customize DevTools
+            url: ../../devtools-guide-chromium/customize/index.md
+
+          - text: Apply a color theme to DevTools
+            url: ../../devtools-guide-chromium/customize/theme.md
+      - linkListType: whats-new
+        links:
+          - text: Experimental features in Microsoft Edge DevTools
+            url: ../../devtools-guide-chromium/experimental-features/index.md
+      - linkListType: how-to-guide
+        links:
+          - text: Change DevTools language settings
+            url: ../../devtools-guide-chromium/customize/localization.md
+
+          - text: Customize keyboard shortcuts
+            url: ../../devtools-guide-chromium/customize/shortcuts.md
+
+# =============================================================================
+# Card r1c3
+  - title: Debugging web projects
+    linkLists:
+      - linkListType: quickstart
+        links:
+          - text: Analyze pages using the Inspect tool
+            url: ../../devtools-guide-chromium/css/inspect.md
+      - linkListType: tutorial
+        links:
+          - text: Get started viewing and changing CSS
+            url: ../../devtools-guide-chromium/css/index.md
+
+          - text: Get started viewing and changing the DOM
+            url: ../../devtools-guide-chromium/dom/index.md
+      - linkListType: how-to-guide
+        links:
+          - text: Find and fix problems using the Issues tool
+            url: ../../devtools-guide-chromium/issues/index.md
+
+          - text: Navigate webpage layers, z-index, and DOM using the 3D View tool
+            url: ../../devtools-guide-chromium/3d-view/index.md
+
+          - text: Inspect animations
+            url: ../../devtools-guide-chromium/inspect-styles/animations.md
+
+          - text: Debug Progressive Web Apps (PWAs)
+            url: ../../devtools-guide-chromium/progressive-web-apps/index.md
+
+          - text: Inspect network activity
+            url: ../../devtools-guide-chromium/network/index.md
+
+# =============================================================================
+# Card r2c1
+  - title: Emulation and Testing
+    linkLists:
+      - linkListType: how-to-guide
+        links:
+          - text: Emulate mobile devices (Device Emulation)
+            url: ../../devtools-guide-chromium/device-mode/index.md
+
+          - text: Accessibility-testing features
+            url: ../../devtools-guide-chromium/accessibility/reference.md
+
+          - text: Emulate dark or light schemes in the rendered page
+            url: ../../devtools-guide-chromium/accessibility/preferred-color-scheme-simulation.md
+
+          - text: Test keyboard support using the Source Order Viewer
+            url: ../../devtools-guide-chromium/accessibility/test-tab-key-source-order-viewer.md
+
+          - text: Force print preview mode
+            url: ../../devtools-guide-chromium/css/print-preview.md
+
+          - text: Emulate vision deficiencies
+            url: ../../devtools-guide-chromium/accessibility/emulate-vision-deficiencies.md
+
+          - text: Simulate reduced motion
+            url: ../../devtools-guide-chromium/accessibility/reduced-motion-simulation.md
+
+# =============================================================================
+# Card r2c2
+  - title: JavaScript and performance
+    linkLists:
+      - linkListType: how-to-guide
+        links:
+          - text: Run JavaScript in the Console
+            url: ../../devtools-guide-chromium/console/console-javascript.md
+
+          - text: Fix JavaScript errors that are reported in the Console
+            url: ../../devtools-guide-chromium/console/console-debug-javascript.md
+
+          - text: Sources tool overview
+            url: ../../devtools-guide-chromium/sources/index.md
+
+          - text: JavaScript debugging features
+            url: ../../devtools-guide-chromium/javascript/reference.md
+
+          - text: Find unused JavaScript and CSS code with the Coverage tool
+            url: ../../devtools-guide-chromium/coverage/index.md
+
+          - text: Fix memory problems
+            url: ../../devtools-guide-chromium/memory-problems/index.md
+
+          - text: Debug DOM memory leaks with the Detached Elements tool
+            url: ../../devtools-guide-chromium/memory-problems/dom-leaks.md
+
+          - text: Understand security issues using the Security tool
+            url: ../../devtools-guide-chromium/security/index.md
+
+          - text: Troubleshooting common performance issues
+            url: ../../devtools-guide-chromium/rendering-tools/index.md
+
+# =============================================================================
+# Card r2c3
+  - title: Reference
+    linkLists:
+      - linkListType: reference
+        links:
+          - text: Keyboard shortcuts
+            url: ../../devtools-guide-chromium/shortcuts/index.md
+
+          - text: CSS features reference
+            url: ../../devtools-guide-chromium/css/reference.md
+
+          - text: Console features reference
+            url: ../../devtools-guide-chromium/console/reference.md
+
+          - text: Console object API Reference
+            url: ../../devtools-guide-chromium/console/api.md
+      - linkListType: how-to-guide
+        links:
+          - text: Performance features reference
+            url: ../../devtools-guide-chromium/evaluate-performance/reference.md
+      - linkListType: sample
+        links:
+          - text: Sample code for DevTools
+            url: ../../devtools-guide-chromium/sample-code/sample-code.md

--- a/microsoft-edge/extensions-chromium/landing/index.yml
+++ b/microsoft-edge/extensions-chromium/landing/index.yml
@@ -129,7 +129,7 @@ landingContent:
 
 # =============================================================================
 # Card r2c1
-  - title: Register
+  - title: Register as a developer
     linkLists:
       - linkListType: how-to-guide
         links:

--- a/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
+++ b/microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md
@@ -12,7 +12,7 @@ ms.date: 09/05/2024
 
 This article is the REST endpoint reference for the Microsoft Edge Add-ons API.  This API automates publishing updates to add-ons that have been submitted to the Microsoft Edge Add-ons store.
 
-For an overview, see [Using the Microsoft Edge Add-ons REST API](using-addons-api.md).
+For an overview, see [Using the Microsoft Edge Add-ons REST API](./using-addons-api.md).
 
 
 <!-- ------------------------------ -->
@@ -86,12 +86,12 @@ This API has the following expected status codes.
 | HTTP status code | Description |
 |---|---|
 | 202 | The request is accepted for processing, but the processing isn't complete. |
-| 4XX | See [Error codes](#error-codes). |
-| 5XX | See [Error codes](#error-codes). |
+| 4XX | See [Error codes](#error-codes), below. |
+| 5XX | See [Error codes](#error-codes), below. |
 
 
 See also:
-* Introduction: [Uploading a package to update an existing submission](using-addons-api.md#uploading-a-package-to-update-an-existing-submission)
+* [Uploading a package to update an existing submission](./using-addons-api.md#uploading-a-package-to-update-an-existing-submission) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
@@ -207,12 +207,12 @@ This API has the following expected status codes.
 | HTTP status code | Description |
 |---|---|
 | 200 | The request is OK. |
-| 4XX | See [Error codes](#error-codes). |
-| 5XX | See [Error codes](#error-codes). |
+| 4XX | See [Error codes](#error-codes), below. |
+| 5XX | See [Error codes](#error-codes), below. |
 
 
 See also:
-* Introduction: [Checking the status of a package upload](using-addons-api.md#checking-the-status-of-a-package-upload)
+* [Checking the status of a package upload](./using-addons-api.md#checking-the-status-of-a-package-upload) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
@@ -278,12 +278,12 @@ This API has the following expected status codes.
 | HTTP status code | Description |
 |---|---|
 | 202 | The request is accepted for processing, but the processing isn't complete. |
-| 4XX | See [Error codes](#error-codes). |
-| 5XX | See [Error codes](#error-codes). |
+| 4XX | See [Error codes](#error-codes), below. |
+| 5XX | See [Error codes](#error-codes), below. |
 
 
 See also:
-* Introduction: [Publishing the submission](using-addons-api.md#publishing-the-submission)
+* [Publishing the submission](./using-addons-api.md#publishing-the-submission) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
@@ -493,12 +493,12 @@ This API has the following expected status codes.
 | HTTP status code | Description |
 |---|---|
 | 200 | The request is OK. |
-| 4XX | See [Error codes](#error-codes). |
-| 5XX | See [Error codes](#error-codes). |
+| 4XX | See [Error codes](#error-codes), below. |
+| 5XX | See [Error codes](#error-codes), below. |
 
 
 See also:
-* Introduction: [Checking the publishing status](using-addons-api.md#checking-the-publishing-status)
+* [Checking the publishing status](using-addons-api.md#checking-the-publishing-status) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
@@ -530,4 +530,7 @@ Here's a list of common error codes and possible reasons.  For a full list, see 
 <!-- ====================================================================== -->
 ## See also
 
-* [Using the Microsoft Edge Add-ons REST API](using-addons-api.md)
+<!-- all article-level links in article body: -->
+* [Using the Microsoft Edge Add-ons REST API](./using-addons-api.md)
+* [Partner Center REST error codes](/partner-center/develop/error-codes) in Partner Center docs.
+* [List of HTTP status codes](https://wikipedia.org/wiki/List_of_HTTP_status_codes) at Wikipedia.

--- a/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
+++ b/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
@@ -66,6 +66,8 @@ Type: POST
 Header Parameters: Content-Type: application/x-www-form-urlencoded
 ```
 
+
+<!-- ---------------------------------- -->
 #### Sample request
 
 ```console
@@ -80,6 +82,8 @@ Header Parameters: Content-Type: application/x-www-form-urlencoded
 https://login.microsoftonline.com/5c9eedce-81bc-42f3-8823-48ba6258b391/oauth2/v2.0/token
 ```
 
+
+<!-- ---------------------------------- -->
 #### Sample response
 
 ```json
@@ -90,7 +94,7 @@ https://login.microsoftonline.com/5c9eedce-81bc-42f3-8823-48ba6258b391/oauth2/v2
 }
 ```
 
-For more information, see [OAuth 2.0 client credentials flow on the Microsoft identity platform](/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#get-a-token).
+For more information, see [Get a token](/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow#get-a-token) in _Microsoft identity platform and the OAuth 2.0 client credentials flow_.
 
 
 <!-- ====================================================================== -->
@@ -130,6 +134,8 @@ Follow these steps to get the product ID:
  
 1. In the **Extension identity** section (or from the Address bar), select and copy the **Product ID**.
 
+
+<!-- ---------------------------------- -->
 #### Sample request
 
 ```console
@@ -146,7 +152,7 @@ If the request succeeds and the update process begins, you receive a `202 Accept
 
 
 See also:
-*  API Reference: [Upload a package to update an existing submission](addons-api-reference.md#upload-a-package-to-update-an-existing-submission)
+* [Upload a package to update an existing submission](./addons-api-reference.md#upload-a-package-to-update-an-existing-submission) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
@@ -160,6 +166,8 @@ Type: GET
 Header Parameters: Authorization: Bearer $TOKEN
 ```
 
+
+<!-- ---------------------------------- -->
 #### Sample request
 
 ```console
@@ -172,7 +180,7 @@ https://api.addons.microsoftedge.microsoft.com/v1/products/$productID/submission
 
 
 See also:
-*  API Reference: [Check the status of a package upload](addons-api-reference.md#check-the-status-of-a-package-upload)
+* [Check the status of a package upload](./addons-api-reference.md#check-the-status-of-a-package-upload) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
@@ -187,6 +195,8 @@ Header Parameters: Authorization: Bearer $TOKEN
 Body content: Notes for certification, in JSON format
 ```
 
+
+<!-- ---------------------------------- -->
 #### Sample request
 
 ```console
@@ -200,9 +210,8 @@ https://api.addons.microsoftedge.microsoft.com/v1/products/$productID/submission
 
 If the request succeeds and the publishing process begins, you'll receive a `202 Accepted` response status code with a `Location` header.  This location header contains the `operationID` that's required for checking the status of the publish operation.
 
-
 See also:
-*  API Reference: [Publish the product draft submission](addons-api-reference.md#publish-the-product-draft-submission)
+* [Publish the product draft submission](./addons-api-reference.md#publish-the-product-draft-submission) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
@@ -216,6 +225,8 @@ Type: GET
 Header Parameters: Authorization: Bearer $TOKEN
 ```
 
+
+<!-- ---------------------------------- -->
 #### Sample request
 
 ```console
@@ -226,12 +237,15 @@ Header Parameters: Authorization: Bearer $TOKEN
 https://api.addons.microsoftedge.microsoft.com/v1/products/$productID/submissions/operations/{operationID}
 ```
 
-
 See also:
-*  [Using the Microsoft Edge Add-ons REST API: Check the publishing status](addons-api-reference.md#check-the-publishing-status)
+* [Check the publishing status](./addons-api-reference.md#check-the-publishing-status) in _Using the Microsoft Edge Add-ons REST API_.
 
 
 <!-- ====================================================================== -->
 ## See also
 
+<!-- all article-level links in article body: -->
+* [Using the Microsoft Edge Add-ons REST API](./addons-api-reference.md)
+* [Issues](https://github.com/MicrosoftDocs/edge-developer/issues/) in `edge-developer` Docs repo.
+* [Microsoft identity platform and the OAuth 2.0 client credentials flow](/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow)
 * [Supported APIs for Microsoft Edge extensions](../../developer-guide/api-support.md) - JavaScript APIs for developing an extension.

--- a/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
+++ b/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
@@ -60,7 +60,7 @@ You can generate multiple client secrets for your client ID.  For example, you c
 
 After you've acquired the necessary authorization for your application, get access tokens for APIs.  To get a token using the client credentials grant, send a POST request to the Access token URL (the OAuth token).  The tenant information is available in the URL that you received in the **Before you begin** steps above.
 
-```rest
+```REST
 Endpoint: https://login.microsoftonline.com/5c9eedce-81bc-42f3-8823-48ba6258b391/oauth2/v2.0/token
 Type: POST
 Header Parameters: Content-Type: application/x-www-form-urlencoded
@@ -113,7 +113,7 @@ The API is available at the endpoint `https://api.addons.microsoftedge.microsoft
 
 Use this API to update the package for an add-on.  This API uploads a package to update an existing draft submission of an add-on product.
 
-```rest
+```REST
 Endpoint: /v1/products/$productID/submissions/draft/package
 Type: POST
 Header Parameters: Authorization: Bearer $TOKEN; Content-Type: application/zip
@@ -160,7 +160,7 @@ See also:
 
 Use this API to check the status of package upload.
 
-```rest
+```REST
 Endpoint: /v1/products/$productID/submissions/draft/package/operations/$operationID
 Type: GET
 Header Parameters: Authorization: Bearer $TOKEN
@@ -188,7 +188,7 @@ See also:
 
 Use this API to publish the current draft of the product to the Microsoft Edge Add-ons website.
 
-```rest
+```REST
 Endpoint: /v1/products/$productID/submissions
 Type: POST
 Header Parameters: Authorization: Bearer $TOKEN
@@ -219,7 +219,7 @@ See also:
 
 Use this API to check the status of the publish operation.
 
-```rest
+```REST
 Endpoint: /v1/products/$productID/submissions/operations/$operationID
 Type: GET
 Header Parameters: Authorization: Bearer $TOKEN

--- a/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
+++ b/microsoft-edge/extensions-chromium/publish/api/using-addons-api.md
@@ -152,7 +152,7 @@ If the request succeeds and the update process begins, you receive a `202 Accept
 
 
 See also:
-* [Upload a package to update an existing submission](./addons-api-reference.md#upload-a-package-to-update-an-existing-submission) in _Using the Microsoft Edge Add-ons REST API_.
+* [Upload a package to update an existing submission](./addons-api-reference.md#upload-a-package-to-update-an-existing-submission) in _REST API Reference for Microsoft Edge Add-ons_.
 
 
 <!-- ====================================================================== -->
@@ -180,7 +180,7 @@ https://api.addons.microsoftedge.microsoft.com/v1/products/$productID/submission
 
 
 See also:
-* [Check the status of a package upload](./addons-api-reference.md#check-the-status-of-a-package-upload) in _Using the Microsoft Edge Add-ons REST API_.
+* [Check the status of a package upload](./addons-api-reference.md#check-the-status-of-a-package-upload) in _REST API Reference for Microsoft Edge Add-ons_.
 
 
 <!-- ====================================================================== -->
@@ -211,7 +211,7 @@ https://api.addons.microsoftedge.microsoft.com/v1/products/$productID/submission
 If the request succeeds and the publishing process begins, you'll receive a `202 Accepted` response status code with a `Location` header.  This location header contains the `operationID` that's required for checking the status of the publish operation.
 
 See also:
-* [Publish the product draft submission](./addons-api-reference.md#publish-the-product-draft-submission) in _Using the Microsoft Edge Add-ons REST API_.
+* [Publish the product draft submission](./addons-api-reference.md#publish-the-product-draft-submission) in _REST API Reference for Microsoft Edge Add-ons_.
 
 
 <!-- ====================================================================== -->
@@ -238,14 +238,14 @@ https://api.addons.microsoftedge.microsoft.com/v1/products/$productID/submission
 ```
 
 See also:
-* [Check the publishing status](./addons-api-reference.md#check-the-publishing-status) in _Using the Microsoft Edge Add-ons REST API_.
+* [Check the publishing status](./addons-api-reference.md#check-the-publishing-status) in _REST API Reference for Microsoft Edge Add-ons_.
 
 
 <!-- ====================================================================== -->
 ## See also
 
 <!-- all article-level links in article body: -->
-* [Using the Microsoft Edge Add-ons REST API](./addons-api-reference.md)
+* [REST API Reference for Microsoft Edge Add-ons](./addons-api-reference.md)
 * [Issues](https://github.com/MicrosoftDocs/edge-developer/issues/) in `edge-developer` Docs repo.
 * [Microsoft identity platform and the OAuth 2.0 client credentials flow](/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow)
 * [Supported APIs for Microsoft Edge extensions](../../developer-guide/api-support.md) - JavaScript APIs for developing an extension.

--- a/microsoft-edge/extensions-chromium/publish/auto-update.md
+++ b/microsoft-edge/extensions-chromium/publish/auto-update.md
@@ -22,6 +22,19 @@ ms.date: 11/04/2022
    See the License for the specific language governing permissions and
    limitations under the License.  -->
 # Automatically update an extension in Microsoft Edge
+<!-- alts:
+# Autoupdate
+# Set an extension to automatically update
+# Automatically update an extension
+-->
+
+<!-- todo: reduce use of alerts; rewrite all Note alerts as standard headings & body text -->
+
+<!-- todo: rewrite Note content as standard positive intro:
+Use X to do Y.
+To do Z, see W.
+fix title & first paragraph's intro so that this off-topic content is not required.
+-->
 
 > [!NOTE]
 > This article doesn't apply to extensions that you publish using the [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd) dashboard.  You can use the dashboard to release updated versions to your users and to the Microsoft Edge Add-ons website.  For more information, see [Update a Microsoft Edge extension](../publish/update-extension.md).
@@ -33,11 +46,15 @@ When you set your extension to automatically update on users' machines, your ext
 *   Improve the user interface.
 
 Previously, non-store based extensions were supported.  Also, previously, you updated the native binaries and the extension at the same time.  Now, the Microsoft Edge Add-ons website hosts your extensions and you can update your extension using the same mechanism as Microsoft Edge.  You don't control the update mechanism. 
+
 > [!IMPORTANT]
 > Be careful when you update extensions that have a dependency on native binaries.
 
+
 <!-- ====================================================================== -->
 ## Overview
+
+<!-- todo: move to top of article per standard intro, w/o heading.  progressive disclosure -->
 
 Every few hours, Microsoft Edge checks whether each installed extension or app has an update URL.  To specify an update URL for your extension, use the `update_url` field in the manifest.  The `update_url` field in the manifest points to a location that can complete an update check.  For each `update_url`, this URL sends requests for updated manifest XML files.  If the update manifest XML file lists a newer extension or app version, Microsoft Edge downloads and installs the newer version.  The same process works for manual updates, where the new `.crx` file must be signed with the same private key as the currently installed version.
 

--- a/microsoft-edge/extensions-chromium/publish/auto-update.md
+++ b/microsoft-edge/extensions-chromium/publish/auto-update.md
@@ -1,6 +1,6 @@
 ---
-title: Automatically update an extension in Microsoft Edge
-description: Learn about automatic updates to extensions in Microsoft Edge.
+title: Set an extension to automatically update
+description: Set up a Microsoft Edge extension (add-on) to automatically update in users' instances of Microsoft Edge.
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
@@ -21,23 +21,13 @@ ms.date: 11/04/2022
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.  -->
-# Automatically update an extension in Microsoft Edge
-<!-- alts:
-# Autoupdate
 # Set an extension to automatically update
-# Automatically update an extension
--->
 
-<!-- todo: reduce use of alerts; rewrite all Note alerts as standard headings & body text -->
+<!-- todo: improve intro lead-in sequencing, after intro summary paragraph.  check latest https://developer.chrome.com/docs/apps/autoupdate & check description: yaml sentence -->
 
-<!-- todo: rewrite Note content as standard positive intro:
-Use X to do Y.
-To do Z, see W.
-fix title & first paragraph's intro so that this off-topic content is not required.
--->
+Every few hours, Microsoft Edge checks whether each installed extension or app has an update URL.  To specify an update URL for your extension, use the `update_url` field in the manifest.  The `update_url` field in the manifest points to a location that can complete an update check.  For each `update_url`, this URL sends requests for updated manifest XML files.  If the update manifest XML file lists a newer extension or app version, Microsoft Edge downloads and installs the newer version.  The same process works for manual updates, where the new `.crx` file must be signed with the same private key as the currently installed version.
 
-> [!NOTE]
-> This article doesn't apply to extensions that you publish using the [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd) dashboard.  You can use the dashboard to release updated versions to your users and to the Microsoft Edge Add-ons website.  For more information, see [Update a Microsoft Edge extension](../publish/update-extension.md).
+In order to maintain user privacy, Microsoft Edge doesn't send any `Cookie` headers with auto-update manifest requests, and ignores any `Set-Cookie` headers in the responses to those requests.
 
 When you set your extension to automatically update on users' machines, your extension shares the following benefits with Microsoft Edge: 
 
@@ -45,21 +35,14 @@ When you set your extension to automatically update on users' machines, your ext
 *   Add new features or performance enhancements.
 *   Improve the user interface.
 
-Previously, non-store based extensions were supported.  Also, previously, you updated the native binaries and the extension at the same time.  Now, the Microsoft Edge Add-ons website hosts your extensions and you can update your extension using the same mechanism as Microsoft Edge.  You don't control the update mechanism. 
+The Microsoft Edge Add-ons website hosts your extensions, and you can update your extension using the same mechanism as Microsoft Edge.  You don't control the update mechanism.
+
+(Previously, non-store-based extensions were supported.  Also, previously, you updated the native binaries and the extension at the same time.)
 
 > [!IMPORTANT]
 > Be careful when you update extensions that have a dependency on native binaries.
 
-
-<!-- ====================================================================== -->
-## Overview
-
-<!-- todo: move to top of article per standard intro, w/o heading.  progressive disclosure -->
-
-Every few hours, Microsoft Edge checks whether each installed extension or app has an update URL.  To specify an update URL for your extension, use the `update_url` field in the manifest.  The `update_url` field in the manifest points to a location that can complete an update check.  For each `update_url`, this URL sends requests for updated manifest XML files.  If the update manifest XML file lists a newer extension or app version, Microsoft Edge downloads and installs the newer version.  The same process works for manual updates, where the new `.crx` file must be signed with the same private key as the currently installed version.
-
-> [!NOTE]
-> In order to maintain user privacy, Microsoft Edge doesn't send any `Cookie` headers with auto-update manifest requests, and ignores any `Set-Cookie` headers in the responses to those requests.
+This article doesn't apply<!-- todo: true? clarify --> to extensions that you publish using the [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd) dashboard.  You can use the dashboard to release updated versions to your users and to the Microsoft Edge Add-ons website.  For more information, see [Update a Microsoft Edge extension](../publish/update-extension.md).
 
 
 <!-- ====================================================================== -->
@@ -160,8 +143,7 @@ http://contoso.com/extension_updates.php?x=id%3Daaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 If you send a single request and the number of installed extensions that use the same update URL is too long, the update check issues more `GET` requests.  A `GET` request URL is too long if it's approximately 2000 characters.
 
-> [!NOTE]
-> In the future, instead of issuing multiple `GET` requests, a single `POST` request might be issued, with the request parameters in the `POST` body.
+In a future release, instead of issuing multiple `GET` requests, a single `POST` request might be issued, with the request parameters in the `POST` body.<!-- todo: update - don't discuss planned design; doc only the present behavior.   check https://developer.chrome.com/docs/apps/autoupdate -->
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1118,7 +1118,7 @@
                 - name: REST API Reference for Microsoft Edge Add-ons
                   href: extensions-chromium/publish/api/addons-api-reference.md
 
-            - name: Automatically update an extension in Microsoft Edge
+            - name: Set an extension to automatically update
               href: extensions-chromium/publish/auto-update.md
 
 # -------------------------------------

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1067,12 +1067,10 @@
                   displayName: policy
 
 # -------------------------------------
-        - name: Publish an extension
+        - name: Register as an extension developer
           items:
-            - name: Register as an individual developer
-              items:
-                - name: Register as a Microsoft Edge extension developer
-                  href: extensions-chromium/publish/create-dev-account.md
+            - name: Register as a Microsoft Edge extension developer
+              href: extensions-chromium/publish/create-dev-account.md
 
             - name: Register as an enterprise developer
               items:
@@ -1085,6 +1083,12 @@
             - name: Register and sign in to Partner Center using a GitHub account
               href: extensions-chromium/publish/github.md
 
+            - name: Manage account settings
+              href: extensions-chromium/publish/manage-settings.md
+
+# -------------------------------------
+        - name: Publish an extension
+          items:
             - name: Publish a Microsoft Edge extension
               href: extensions-chromium/publish/publish-extension.md
 
@@ -1094,9 +1098,6 @@
             - name: Submission states for extensions in the Microsoft Edge Add-ons website
               href: extensions-chromium/publish/submission-states.md
 
-            - name: Manage account settings
-              href: extensions-chromium/publish/manage-settings.md
-
             - name: Alternative ways to distribute an extension
               href: extensions-chromium/developer-guide/alternate-distribution-options.md
 
@@ -1104,7 +1105,7 @@
               href: extensions-chromium/publish/add-ons-store-curation.md
 
 # -------------------------------------
-        - name: Manage and maintain an extension
+        - name: Update an extension
           items:
             - name: Update a Microsoft Edge extension
               href: extensions-chromium/publish/update-extension.md
@@ -1120,6 +1121,9 @@
             - name: Automatically update an extension in Microsoft Edge
               href: extensions-chromium/publish/auto-update.md
 
+# -------------------------------------
+        - name: Analytics and user reviews
+          items:
             - name: View Microsoft Edge extensions analytics dashboard
               href: extensions-chromium/publish/extensions-analytics.md
 

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -981,6 +981,11 @@
 # if top-of-page title is longer, add it to displayName comma-delimited list of lookup keywords
     - name: Microsoft Edge extensions
       items:
+# Card-based landing page -----------------------------------------------------
+        - name: Microsoft Edge extensions documentation
+          href: ./extensions-chromium/landing/index.yml
+          displayName: add-ons, landing
+
         - name: Overview of Microsoft Edge extensions
           href: extensions-chromium/index.md
 


### PR DESCRIPTION
Rendered landing page for review:
* https://review.learn.microsoft.com/microsoft-edge/extensions-chromium/landing/?branch=pr-en-us-3265
* [Planned live](https://learn.microsoft.com/microsoft-edge/extensions-chromium/landing/)
* [TOC before/live](https://learn.microsoft.com/microsoft-edge/extensions-chromium/)

To force-load the revised TOC:
F12 > right-click "Refresh" > "Empty cache and hard refresh" > F12
Open different branches in different windows.

This PR makes the following cdhanges:
* Added a landing page for Extensions, as a destination that's not a particular article; represents whole set of articles as a URL to give to users.
* Modified the TOC, so that bucket names use concrete keywords that match article title keywords:
   * Broke out the "Publish an extension" toc bucket into "Register as an extension developer" and "Publish an extension".
      * Helps group Publish articles, and supports structuring the relation (future toc design) of those articles.
   * Broke out the "Manage and maintain an extension" toc bucket into "Update an extension" and "Analytics and user reviews"
      * To surface the key words of the contained articles' titles, instead of abstract synonyms.
      * Matches scope of landing page cards of uniform length / article-count.
* Changed title from:
   Automatically update an extension in Microsoft Edge
   to:
   Set an extension to automatically update
   * Partly improves lead-in summary flow in that article.

AB#53967047