### PR TITLE
Deprecate "Detached Elements" tool

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -6,22 +6,24 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.subservice: devtools
-ms.date: 09/16/2023
+ms.date: 09/18/2023
 ---
 # Debug DOM memory leaks with the Detached Elements tool
 
 > [!IMPORTANT]
-> The **Detached Elements** tool is being deprecated and eventually removed.  The same functionality is now available in the **Memory** tool instead.  Deprecation period:
->   * Microsoft Edge 130: The **Detached Elements** tool is still available, but the **Memory** tool is recommended instead.
->   * Microsoft Edge 133: The **Detached Elements** tool is removed.
->
-> The downstream-only CDP function `EdgeDOMMemory.getDetachedNodesIds` is deprecated; for the moment, it still works, but use `DOM.getDetachedDomNodes` instead.
+> The **Detached Elements** tool is being deprecated.  In Microsoft Edge 130, the **Detached Elements** tool has been removed; use the **Memory** tool instead, which contains the same functionality.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
+> 
+> In Microsoft Edge 133, the **Detached Elements** tool will be removed; use the **Memory** tool instead.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
+> 
+> Status of Microsoft Edge channels as of September 18, 2024:
+> Edge Stable 128 - **Memory** tool lacks **Detached Elements** functionality.
+> Edge Canary 130 - **Memory** tool has **Detached Elements** functionality.
 
-todo:
-* When the **Detached Elements** tool is removed, delete the present article, redirect to a new page: 
-* Add a new page, under the Memory tool TOC bucket, which describes how to debug detached DOM element memory leaks with the Memory tool.  eg h1:
-   * Debug detached DOM element memory leaks with the Memory tool
-
+<!-- todo:  
+When the **Detached Elements** tool is removed, delete the present article, redirect to new url:
+Add new article in Memory tool toc bucket: "Debug detached DOM element memory leaks with the Memory tool"
+or possibly reuse present .md file / url; change title & content
+-->
 
 Use the **Detached Elements** tool to find detached elements that the browser cannot garbage-collect, and locate the JavaScript object that is still referencing the detached element.  By changing your JavaScript to release the element, you reduce the number of detached elements on your page.
 

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -16,8 +16,8 @@ ms.date: 09/18/2023
 > In Microsoft Edge 133, the **Detached Elements** tool will be removed; use the **Memory** tool instead.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
 > 
 > Status of Microsoft Edge channels as of September 18, 2024:
-> Edge Stable 128 - **Memory** tool lacks **Detached Elements** functionality.
-> Edge Canary 130 - **Memory** tool has **Detached Elements** functionality.
+> * Edge Stable 128 - **Memory** tool lacks **Detached Elements** functionality.
+> * Edge Canary 130 - **Memory** tool has **Detached Elements** functionality.
 
 <!-- todo:  
 When the **Detached Elements** tool is removed, delete the present article, redirect to new url:

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -11,13 +11,13 @@ ms.date: 09/18/2023
 # Debug DOM memory leaks with the Detached Elements tool
 
 > [!IMPORTANT]
-> The **Detached Elements** tool is being deprecated.  In Microsoft Edge 130, the **Detached Elements** tool has been removed; use the **Memory** tool instead, which contains the same functionality.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
+> The **Detached Elements** tool is being deprecated.  Starting with Microsoft Edge 130, the **Detached Elements** tool has a deprecation message.  Instead, use the **Detached Elements** profiling type in the **Memory** tool.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
 > 
-> In Microsoft Edge 133, the **Detached Elements** tool will be removed; use the **Memory** tool instead.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
+> In Microsoft Edge 133, the **Detached Elements** tool will be removed; instead, use the **Detached Elements** profiling type in the **Memory** tool.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
 > 
 > Status of Microsoft Edge channels as of September 18, 2024:
-> * Edge Stable 128 - **Memory** tool lacks **Detached Elements** functionality.
-> * Edge Canary 130 - **Memory** tool has **Detached Elements** functionality.
+> * Edge Stable 128 - The **Detached Elements** tool is present, without a deprecation message.  The **Memory** tool lacks **Detached Elements** functionality.
+> * Edge Canary 130 - The **Detached Elements** tool is present, with a deprecation message.  The **Memory** tool has **Detached Elements** functionality (the **Detached Elements** profiling type).
 
 <!-- todo:  
 When the **Detached Elements** tool is removed, delete the present article, redirect to new url:

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -11,7 +11,7 @@ ms.date: 09/18/2023
 # Debug DOM memory leaks with the Detached Elements tool
 
 > [!IMPORTANT]
-> The **Detached Elements** tool is being deprecated.  Starting with Microsoft Edge 130, the **Detached Elements** tool has a message stating that the tool is deprecated; instead, in the **Memory** tool, in the initial **Select profiling type** screen, select the **Detached elements** option button.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
+> The **Detached Elements** tool is being deprecated.  Starting with Microsoft Edge 130, the **Detached Elements** tool has a message stating that the tool is deprecated; instead, in the **Memory** tool, in the initial **Select profiling type** screen, select the **Detached elements** option button.  The Edge-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
 > 
 > In Microsoft Edge 133, the **Detached Elements** tool will be removed; instead, in the **Memory** tool, in the initial **Select profiling type** screen, select the **Detached elements** option button.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
 

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -11,9 +11,9 @@ ms.date: 09/18/2023
 # Debug DOM memory leaks with the Detached Elements tool
 
 > [!IMPORTANT]
-> The **Detached Elements** tool is being deprecated.  Starting with Microsoft Edge 130, the **Detached Elements** tool has a message stating that the tool is deprecated; instead, use the **Detached Elements** profiling type in the **Memory** tool.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
+> The **Detached Elements** tool is being deprecated.  Starting with Microsoft Edge 130, the **Detached Elements** tool has a message stating that the tool is deprecated; instead, in the **Memory** tool, in the initial **Select profiling type** screen, select the **Detached elements** option button.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
 > 
-> In Microsoft Edge 133, the **Detached Elements** tool will be removed; instead, use the **Detached Elements** profiling type in the **Memory** tool.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
+> In Microsoft Edge 133, the **Detached Elements** tool will be removed; instead, in the **Memory** tool, in the initial **Select profiling type** screen, select the **Detached elements** option button.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
 
 <!-- todo:  
 When the **Detached Elements** tool is removed, delete the present article, redirect to new url:

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -6,9 +6,22 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.subservice: devtools
-ms.date: 07/05/2023
+ms.date: 09/16/2023
 ---
 # Debug DOM memory leaks with the Detached Elements tool
+
+> [!IMPORTANT]
+> The **Detached Elements** tool is being deprecated and eventually removed.  The same functionality is now available in the **Memory** tool instead.  Deprecation period:
+>   * Microsoft Edge 130: The **Detached Elements** tool is still available, but the **Memory** tool is recommended instead.
+>   * Microsoft Edge 133: The **Detached Elements** tool is removed.
+>
+> The downstream-only CDP function `EdgeDOMMemory.getDetachedNodesIds` is deprecated; for the moment, it still works, but use `DOM.getDetachedDomNodes` instead.
+
+todo:
+* When the **Detached Elements** tool is removed, delete the present article, redirect to a new page: 
+* Add a new page, under the Memory tool TOC bucket, which describes how to debug detached DOM element memory leaks with the Memory tool.  eg h1:
+   * Debug detached DOM element memory leaks with the Memory tool
+
 
 Use the **Detached Elements** tool to find detached elements that the browser cannot garbage-collect, and locate the JavaScript object that is still referencing the detached element.  By changing your JavaScript to release the element, you reduce the number of detached elements on your page.
 

--- a/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
+++ b/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks.md
@@ -11,13 +11,9 @@ ms.date: 09/18/2023
 # Debug DOM memory leaks with the Detached Elements tool
 
 > [!IMPORTANT]
-> The **Detached Elements** tool is being deprecated.  Starting with Microsoft Edge 130, the **Detached Elements** tool has a deprecation message.  Instead, use the **Detached Elements** profiling type in the **Memory** tool.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
+> The **Detached Elements** tool is being deprecated.  Starting with Microsoft Edge 130, the **Detached Elements** tool has a message stating that the tool is deprecated; instead, use the **Detached Elements** profiling type in the **Memory** tool.  The downstream-only Chrome DevTools Protocol (CDP) function `EdgeDOMMemory.getDetachedNodesIds` continues to work, but use `DOM.getDetachedDomNodes` instead.
 > 
 > In Microsoft Edge 133, the **Detached Elements** tool will be removed; instead, use the **Detached Elements** profiling type in the **Memory** tool.  The CDP function `EdgeDOMMemory.getDetachedNodesIds` will be removed; use `DOM.getDetachedDomNodes` instead.
-> 
-> Status of Microsoft Edge channels as of September 18, 2024:
-> * Edge Stable 128 - The **Detached Elements** tool is present, without a deprecation message.  The **Memory** tool lacks **Detached Elements** functionality.
-> * Edge Canary 130 - The **Detached Elements** tool is present, with a deprecation message.  The **Memory** tool has **Detached Elements** functionality (the **Detached Elements** profiling type).
 
 <!-- todo:  
 When the **Detached Elements** tool is removed, delete the present article, redirect to new url:


### PR DESCRIPTION
Rendered article for review: 
* **Debug DOM memory leaks with the Detached Elements tool**
   * https://review.learn.microsoft.com/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks?branch=pr-en-us-3267
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/memory-problems/dom-leaks)

AB#53967018