### PR TITLE
Add AOT support fix to September's prerelease and October's release notes

### DIFF
--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -213,7 +213,8 @@ Added a new `SaveFileSecurityCheckStarting` event.  Your app can register a hand
 ###### SDK-only
 
 * Using `CoreWebView2.AddWebResourceRequestedFilter` without a `CoreWebView2WebResourceRequestSourceKinds` parameter is now deprecated.  See the .NET [CoreWebView2.AddWebResourceRequestedFilter Method](https://go.microsoft.com/fwlink/?linkid=2286319).<!-- points to WebView2Announcements -->
-* Added the .NET 8 TargetFramework for C# WinRT, enabled AOT (ahead-of-time) compatibility and disabled runtime marshalling
+* Added the .NET 8 `TargetFramework` for C# WinRT, enabled AOT (ahead-of-time) compatibility, and disabled runtime marshalling.
+
 
 <!-- end of Oct 2024 Release SDK -->
 
@@ -492,7 +493,7 @@ No APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 * Fixed an SDK dependency for .NET projects.  ([Issue #4743](https://github.com/MicrosoftEdge/WebView2Feedback/issues/4743))
 * Fixed a compatibility issue when calling `GetAvailableBrowserVersionString()` with an older `WebView2Loader.dll`.  ([Issue #4395](https://github.com/MicrosoftEdge/WebView2Feedback/issues/4395))
 * Fixed issues when compiling wv2winrt-generated code with the `cpp20` and `/permissive-` options.
-* Added the .NET 8 TargetFramework for C# WinRT, enabled AOT (ahead-of-time) compatibility and disabled runtime marshalling
+* Added the .NET 8 `TargetFramework` for C# WinRT, enabled AOT (ahead-of-time) compatibility, and disabled runtime marshalling.
 
 
 <!-- end of Sep 2024 Prerelease SDK -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -213,7 +213,7 @@ Added a new `SaveFileSecurityCheckStarting` event.  Your app can register a hand
 ###### SDK-only
 
 * Using `CoreWebView2.AddWebResourceRequestedFilter` without a `CoreWebView2WebResourceRequestSourceKinds` parameter is now deprecated.  See the .NET [CoreWebView2.AddWebResourceRequestedFilter Method](https://go.microsoft.com/fwlink/?linkid=2286319).<!-- points to WebView2Announcements -->
-
+* Added the .NET 8 TargetFramework for C# WinRT, enabled AOT (ahead-of-time) compatibility and disabled runtime marshalling
 
 <!-- end of Oct 2024 Release SDK -->
 
@@ -492,6 +492,7 @@ No APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 * Fixed an SDK dependency for .NET projects.  ([Issue #4743](https://github.com/MicrosoftEdge/WebView2Feedback/issues/4743))
 * Fixed a compatibility issue when calling `GetAvailableBrowserVersionString()` with an older `WebView2Loader.dll`.  ([Issue #4395](https://github.com/MicrosoftEdge/WebView2Feedback/issues/4395))
 * Fixed issues when compiling wv2winrt-generated code with the `cpp20` and `/permissive-` options.
+* Added the .NET 8 TargetFramework for C# WinRT, enabled AOT (ahead-of-time) compatibility and disabled runtime marshalling
 
 
 <!-- end of Sep 2024 Prerelease SDK -->


### PR DESCRIPTION
Rendered article sections for review:
* **Release Notes for the WebView2 SDK** > **1.0.2849.39** (Oct)
   * https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/?branch=pr-en-us-3299#10284939
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#10284939)
   * changelist
* **Release Notes for the WebView2 SDK** > **1.0.2839-prerelease** (Sep)
   * https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/?branch=pr-en-us-3299#102839-prerelease
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#102839-prerelease)
   * changelist

AB#54857233
