### PR TITLE
Add note describing discontinuing Hololens support

### DIFF
--- a/microsoft-edge/webview2/get-started/hololens2.md
+++ b/microsoft-edge/webview2/get-started/hololens2.md
@@ -14,7 +14,10 @@ This tutorial is for developers using WebView2 in immersive HoloLens 2 Unity app
 
 WebView2 on HoloLens 2 and the WebView plugin for Unity are both in Preview and are subject to change before general availability.  
 
-WebView2 is only supported on HoloLens 2 devices running the Windows 11 update. For more information, see [Update HoloLens 2](/hololens/hololens-update-hololens).
+WebView2 only works on HoloLens 2 devices running the Windows 11 update. For more information, see [Update HoloLens 2](/hololens/hololens-update-hololens).
+
+[!IMPORTANT]
+WebView2 on Hololens 2 continues to be available. However, support for WebView2 on Hololens 2 is discontinued (no bug fixes, content updates or technical support), and we can therefore make no guarantees that applications will continue to work for any extended period of time.
 
 For WebView2-enabled 2D applications on HoloLens 2, see [Get started with WebView2 in WinUI 2 (UWP) apps](./winui2.md).
 


### PR DESCRIPTION
Hololens 2 is slowly being discontinued/deprecated, which means no more updates or technical support for the platform. Add a note to our support page indicating this, and that there is a risk that the applications may break in the future.