### PR TITLE
Fix TOC title for WebView2 landing page

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1242,8 +1242,8 @@
 # WebView2
     - name: WebView2
       items:
-        - name: Microsoft Edge extensions documentation
-          href: ./webview2/landing/index.yml  # landing page
+        - name: WebView2 documentation
+          href: ./webview2/landing/index.yml
           displayName: landing
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Rendered TOC for review:
* **WebView2 documentation**
   * https://review.learn.microsoft.com/microsoft-edge/webview2/landing/?branch=pr-en-us-3321
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/landing/)
   * Changed TOC title from "Microsoft Edge extensions documentation" to "WebView2 documentation".

AB#55248198