### PR TITLE
RelNotes: WebView2 Runtime no longer appears in Settings > Installed apps

### DIFF
--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -132,7 +132,7 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 <!-- ------------------------------ -->
 #### General changes
 
-* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps** because it is a persistent system component.
+* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**, because it is a persistent system component.
 
 
 <!-- ------------------------------ -->
@@ -227,13 +227,13 @@ Added a new `ScreenCaptureStarting` event.  This event is raised whenever the We
 <!-- ------------------------------ -->
 #### General changes
 
-* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**.
+* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**, because it is a persistent system component.
 
 
 <!-- ------------------------------ -->
 #### Other changes
 
-* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps** because it is a persistent system component.
+* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**, because it is a persistent system component.
 
 
 <!-- end of Nov 2024 Release SDK -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -130,9 +130,9 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
-<!-- #### General features -->
+#### General features
 
-<!-- * The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**. -->
+* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**.
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -130,7 +130,7 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
-#### General features
+#### General changes
 
 * The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**.
 
@@ -222,6 +222,12 @@ Added a new `ScreenCaptureStarting` event.  This event is raised whenever the We
 ###### Runtime-only
 
 * Allowed the **Download** dialog to receive initial focus on launch.
+
+
+<!-- ------------------------------ -->
+#### General changes
+
+* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**.
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -211,11 +211,14 @@ Added a new `ScreenCaptureStarting` event.  This event is raised whenever the We
 <!-- ------------------------------ -->
 #### Bug fixes
 
-
 <!-- ---------- -->
 ###### Runtime-only
 
 * Allowed the **Download** dialog to receive initial focus on launch.
+
+#### Other changes
+
+* Microsoft Edge WebView2 Runtime will no longer appear in the Installed Apps list in Windows Settings.
 
 <!-- end of Nov 2024 Release SDK -->
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -130,6 +130,12 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
+<!-- #### General features -->
+
+<!-- * The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**. -->
+
+
+<!-- ------------------------------ -->
 #### Promotions
 
 The following APIs have been promoted to Stable and are now included in this Release SDK.
@@ -211,14 +217,18 @@ Added a new `ScreenCaptureStarting` event.  This event is raised whenever the We
 <!-- ------------------------------ -->
 #### Bug fixes
 
+
 <!-- ---------- -->
 ###### Runtime-only
 
 * Allowed the **Download** dialog to receive initial focus on launch.
 
+
+<!-- ------------------------------ -->
 #### Other changes
 
-* Microsoft Edge WebView2 Runtime will no longer appear in the Installed Apps list in Windows Settings.
+* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**.
+
 
 <!-- end of Nov 2024 Release SDK -->
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -130,12 +130,6 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
-#### General changes
-
-* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**, because it is a persistent system component.
-
-
-<!-- ------------------------------ -->
 #### Promotions
 
 The following APIs have been promoted to Stable and are now included in this Release SDK.
@@ -226,12 +220,6 @@ Added a new `ScreenCaptureStarting` event.  This event is raised whenever the We
 
 <!-- ------------------------------ -->
 #### General changes
-
-* The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**, because it is a persistent system component.
-
-
-<!-- ------------------------------ -->
-#### Other changes
 
 * The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**, because it is a persistent system component.
 


### PR DESCRIPTION
Rendered article section for review:
* **Release Notes for the WebView2 SDK** > **1.0.2903.40** > **General features**
   * https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/?branch=pr-en-us-3326#general-features
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#general-features)
   * Added item: The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**.
* **Release Notes for the WebView2 SDK** > **1.0.2903.40** > **Other changes**
   * https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/?branch=pr-en-us-3326#other-changes
   * [Before/Live](https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#other-changes)
   * Added item: The Microsoft Edge WebView2 Runtime is no longer listed in Windows **Settings** > **Apps** > **Installed apps**.

AB#55329302
