### PR TITLE
Link to Entra info in "Types of accounts to publish extensions"

### DIFF
--- a/microsoft-edge/extensions-chromium/publish/create-dev-account.md
+++ b/microsoft-edge/extensions-chromium/publish/create-dev-account.md
@@ -26,7 +26,7 @@ To add and manage users in the Microsoft Edge program to manage extensions, you 
 | _GitHub account_ | A user account at GitHub.com.  You can use your personal GitHub account to sign in to Partner Center—a Microsoft account (MSA) will be created for you. |
 | _Partner Center account_, _Partner Center developer account_ | A _Partner Center account_ is an account on partner.microsoft.com.  To submit Microsoft Edge extensions, you need a _Partner Center developer account_, which is a Partner Center account that has a Microsoft account (MSA) as the Primary Owner. |
 | _Microsoft Edge Program account_ | Enables multiple users to work with Microsoft Edge extensions at Partner Center. |
-| _Microsoft Entra ID_ | A [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) account. |
+| _Microsoft Entra ID_ | A Microsoft Entra ID account; see [What is Microsoft Entra ID?](/entra/fundamentals/whatis) |
 | _Microsoft Entra tenant_ | A _tenant_ represents an organization.  A tenant is a dedicated instance of Microsoft Entra ID that an organization or app developer receives at the beginning of a relationship with Microsoft. |
 
 

--- a/microsoft-edge/extensions-chromium/publish/create-dev-account.md
+++ b/microsoft-edge/extensions-chromium/publish/create-dev-account.md
@@ -26,7 +26,7 @@ To add and manage users in the Microsoft Edge program to manage extensions, you 
 | _GitHub account_ | A user account at GitHub.com.  You can use your personal GitHub account to sign in to Partner Center—a Microsoft account (MSA) will be created for you. |
 | _Partner Center account_, _Partner Center developer account_ | A _Partner Center account_ is an account on partner.microsoft.com.  To submit Microsoft Edge extensions, you need a _Partner Center developer account_, which is a Partner Center account that has a Microsoft account (MSA) as the Primary Owner. |
 | _Microsoft Edge Program account_ | Enables multiple users to work with Microsoft Edge extensions at Partner Center. |
-| _Microsoft Entra ID_ | A Microsoft Entra ID account. |
+| _Microsoft Entra ID_ | A [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) account. |
 | _Microsoft Entra tenant_ | A _tenant_ represents an organization.  A tenant is a dedicated instance of Microsoft Entra ID that an organization or app developer receives at the beginning of a relationship with Microsoft. |
 
 

--- a/microsoft-edge/extensions-chromium/publish/create-dev-account.md
+++ b/microsoft-edge/extensions-chromium/publish/create-dev-account.md
@@ -27,7 +27,7 @@ To add and manage users in the Microsoft Edge program to manage extensions, you 
 | _Partner Center account_, _Partner Center developer account_ | A _Partner Center account_ is an account on partner.microsoft.com.  To submit Microsoft Edge extensions, you need a _Partner Center developer account_, which is a Partner Center account that has a Microsoft account (MSA) as the Primary Owner. |
 | _Microsoft Edge Program account_ | Enables multiple users to work with Microsoft Edge extensions at Partner Center. |
 | _Microsoft Entra ID_ | A Microsoft Entra ID account; see [What is Microsoft Entra ID?](/entra/fundamentals/whatis) |
-| _Microsoft Entra tenant_ | A _tenant_ represents an organization.  A tenant is a dedicated instance of Microsoft Entra ID that an organization or app developer receives at the beginning of a relationship with Microsoft. |
+| _Microsoft Entra tenant_ | A _tenant_ represents an organization.  A tenant is a dedicated instance of Microsoft Entra ID that an organization or app developer receives at the beginning of a relationship with Microsoft.  See [Quickstart: Set up a Microsoft Entra tenant](/azure/active-directory/develop/quickstart-create-new-tenant).<!-- dest titles --> |
 
 
 <!-- ====================================================================== -->
@@ -43,7 +43,7 @@ If you don't have a Partner Center account, or you have a Partner Center account
 
 To create a Microsoft account (MSA):
 
-1. Decide if you want to use your existing GitHub account to create a Microsoft account (MSA).  See [Register and sign in to Partner Center using a GitHub account](github.md).
+1. Decide if you want to use your existing GitHub account to create a Microsoft account (MSA).  See [Register and sign in to Partner Center using a GitHub account](./github.md).
 
 1. If you aren't using your GitHub account to create the Microsoft account (MSA), see [account.microsoft.com](https://account.microsoft.com/account).
 
@@ -59,19 +59,19 @@ If you have a Partner Center account for which the Primary Owner is a Microsoft 
 <!-- ====================================================================== -->
 ## Enroll in the Microsoft Edge program on Partner Center
 
-<!-- 1.  Navigate to the [webpage about Partner Center](https://partner.microsoft.com).  You might see a "Join the Microsoft Partner Network" page with a **Become a partner** button, or a "Welcome back" page with a **Visit Partner Center** button.  Select the **Become a partner** button or the **Visit Partner Center** button. -->
+<!-- 1. Go to the [webpage about Partner Center](https://partner.microsoft.com).  You might see a "Join the Microsoft Partner Network" page with a **Become a partner** button, or a "Welcome back" page with a **Visit Partner Center** button.  Select the **Become a partner** button or the **Visit Partner Center** button. -->
 
-1.  Navigate to the [Partner Center developer login page](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd), and then select **Partner Center**.
+1. Go to [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd) and then select **Partner Center**.
 
-1.  If you have a Microsoft account (MSA), use it to sign into Partner Center.  A Microsoft account (MSA) is an Outlook.com, Live.com, or Hotmail.com account.  Then fill in the Microsoft Edge program registration form, using the registration form in the next section.
+1. If you have a Microsoft account (MSA), use it to sign into Partner Center.  A Microsoft account (MSA) is an Outlook.com, Live.com, or Hotmail.com account.  Then fill in the Microsoft Edge program registration form, using the registration form in the next section.
 
-1.  If you don't have a Microsoft account (MSA), either create a new Microsoft account (MSA) directly, or sign in to Partner Center by using your GitHub account using the next step.  The Partner Center account must have a Primary Owner that's a Microsoft account (MSA).  If you want to sign in to Partner Center using your existing personal GitHub account, open [Register and sign in to Partner Center using a GitHub account](github.md) in a new tab or window, and follow the steps in the article.  Your GitHub account will be linked to an automatically created Microsoft account (MSA) whose credentials you can use to register for the Microsoft Edge program.
+1. If you don't have a Microsoft account (MSA), either create a new Microsoft account (MSA) directly, or sign in to Partner Center by using your GitHub account using the next step.  The Partner Center account must have a Primary Owner that's a Microsoft account (MSA).  If you want to sign in to Partner Center using your existing personal GitHub account, open [Register and sign in to Partner Center using a GitHub account](./github.md) in a new tab or window, and follow the steps in the article.  Your GitHub account will be linked to an automatically created Microsoft account (MSA) whose credentials you can use to register for the Microsoft Edge program.
 
-1.  After you sign in, a registration form is displayed, to enroll in the Microsoft Edge program.  To help you fill in the registration form, see the next section.
+1. After you sign in, a registration form is displayed, to enroll in the Microsoft Edge program.  To help you fill in the registration form, see the next section.
 
-1.  Before submitting your registration form, read and accept the terms and conditions of the [Microsoft Store App Developer Agreement](https://go.microsoft.com/fwlink/?linkid=528905).
+1. Before submitting your registration form, read and accept the terms and conditions of the [Microsoft Store App Developer Agreement](https://go.microsoft.com/fwlink/?linkid=528905).
 
-1.  To complete your enrollment, select **Finish**.
+1. To complete your enrollment, select **Finish**.
 
 
 <!-- ====================================================================== -->
@@ -79,6 +79,8 @@ If you have a Partner Center account for which the Primary Owner is a Microsoft 
 
 Fill in the fields of the registration form as follows.
 
+
+<!-- ------------------------------ -->
 #### Account country/region
 
 This field is either where you live, or where your business is located.
@@ -86,6 +88,8 @@ This field is either where you live, or where your business is located.
 > [!IMPORTANT]
 > After enrollment, the value of this field is read-only.
 
+
+<!-- ------------------------------ -->
 #### Account types
 
 The Microsoft Edge program in [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd) offers both individual and company accounts.  The accounts are described in detail in the following sections.  Both account types enable you to publish extensions to the Microsoft Edge Add-ons website.
@@ -105,18 +109,24 @@ An individual account is appropriate for a developer not associated with a compa
 
 A company account is associated with an organization or business.  The account verification process is longer and involves confirmation that you're authorized to create the account for your company.  The duration of the process can range from a few days to a few weeks.  Your company might receive phone calls from Microsoft verification partners.
 
-For a company account, it's crucial to verify your Microsoft Edge program information when you enroll into a new Partner Center program.  This verification is needed to publish extensions to the Microsoft Edge Add-ons store.  See [Verify your company account information](verify-microsoft-edge-program.md).
+For a company account, it's crucial to verify your Microsoft Edge program information when you enroll into a new Partner Center program.  This verification is needed to publish extensions to the Microsoft Edge Add-ons store.  See [Verify your company account information](./verify-microsoft-edge-program.md).
 
+
+<!-- ------------------------------ -->
 #### Publisher display name
 
 This field contains the name that's displayed in the Microsoft Edge Add-ons website.  To use a particular name, that name must be available, and you must have the rights to use it.  Company accounts must use the registered business name of your organization.
 
 The maximum length for this field is fifty (50) characters.
 
+
+<!-- ------------------------------ -->
 #### Contact details
 
 This field contains any contact information that Microsoft uses to contact you about any account issues.  After registration is complete, you receive an email confirmation.  For a company account, you must use the registered email address associated with your organization.
 
+
+<!-- ------------------------------ -->
 #### Company approver
 
 For a company account, you must provide the contact information of your company approver.  The contact information includes name, email address, and phone number.  As a part of the verification process, Microsoft contacts the specified company approver, to make sure that your extension belongs to your organization.
@@ -127,14 +137,29 @@ For a company account, you must provide the contact information of your company 
 
 To display your verification status, go to [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd) and then select **Account settings**.  Continue to build, test, and prepare your submissions while you wait for the verification process to complete.
 
-*  [Publish an extension](publish-extension.md)
+* [Publish a Microsoft Edge extension](./publish-extension.md)
 
-*  [Extension concepts and architecture](../getting-started/index.md)
+* [Extension concepts and architecture](../getting-started/index.md)
 
-*  [Add users to the Microsoft Edge program](aad-account.md) - Add more users to your Microsoft Edge program and your Partner Center developer account.  To enable adding users, you associate your organization's Microsoft Entra ID account with your Microsoft account (MSA) on Partner Center.
+* [Add users to the Microsoft Edge program](./aad-account.md) - Add more users to your Microsoft Edge program and your Partner Center developer account.  To enable adding users, you associate your organization's Microsoft Entra ID account with your Microsoft account (MSA) on Partner Center.
 
 
 <!-- ====================================================================== -->
 ## See also
+<!-- all links in article -->
 
-*  [Quickstart: Set up a tenant](/azure/active-directory/develop/quickstart-create-new-tenant) - General information about Microsoft Entra tenants, in the Microsoft Entra documentation.
+* [Register and sign in to Partner Center using a GitHub account](./github.md)
+* [Verify your company account information](./verify-microsoft-edge-program.md)
+* [Add users to the Microsoft Edge program](./aad-account.md)
+* [Publish a Microsoft Edge extension](./publish-extension.md)
+* [Extension concepts and architecture](../getting-started/index.md)
+
+Entra:
+* [What is Microsoft Entra ID?](/entra/fundamentals/whatis)
+* [Quickstart: Set up a Microsoft Entra tenant](/azure/active-directory/develop/quickstart-create-new-tenant)<!-- dest titles -->
+
+Other sites:
+* [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd)
+* [account.microsoft.com](https://account.microsoft.com/account)
+* [Microsoft Store App Developer Agreement](https://go.microsoft.com/fwlink/?linkid=528905)
+* [Microsoft Edge Add-ons website](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home)


### PR DESCRIPTION
Rendered article section for review:
* **Register as a Microsoft Edge extension developer** > **Types of accounts related to publishing Microsoft Edge extensions**
   * `/extensions-chromium/publish/create-dev-account.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions-chromium/publish/create-dev-account?branch=pr-en-us-3370#types-of-accounts-related-to-publishing-microsoft-edge-extensions
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/bhuvanapriyap-patch-2/microsoft-edge/extensions-chromium/publish/create-dev-account.md#types-of-accounts-related-to-publishing-microsoft-edge-extensions
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/create-dev-account#types-of-accounts-related-to-publishing-microsoft-edge-extensions
   * In two table rows about Entra, linked to Entra info.
   * Cleaned up article's links & See Also section.

AB#56151647
