### PR TITLE
Expand "Contact the Microsoft Edge extensions team"

### DIFF
--- a/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
+++ b/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
@@ -60,6 +60,10 @@ To feature your extension in a collection on the Microsoft Edge Add-ons website,
 
 Participate in the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) forum in the MicrosoftEdge-Extensions repo to flag any issues, raise a feature request, be a part of discussions, and share your ideas regarding the Microsoft Edge Extensions Store.
 
+You can also create an issue on our Github page here(https://github.com/microsoft/MicrosoftEdge-Extensions/issues) for anything specific to extensions. 
+
+There is also a support email where you can reach out to us for further inquiries(ext_dev_support@microsoft.com)
+
 
 <!-- ====================================================================== -->
 ## Report copyright or trademark infringement

--- a/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
+++ b/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.subservice: extensions
-ms.date: 02/10/2025
+ms.date: 02/11/2025
 ---
 # Contact the Microsoft Edge extensions team
 
@@ -14,9 +14,26 @@ You can contact the Microsoft Edge extensions support team to request help, subm
 
 
 <!-- ====================================================================== -->
+## Inquire about an extension's review status or certification status
+
+For questions about a specific developer account, or questions about the review status or certification status of your extension after submitting the extension via Partner Center, email extensions developer support at [ext_dev_support@microsoft.com](mailto:ext_dev_support@microsoft.com).
+
+For questions about a specific developer account or the certification status of a specific extension, don't use the public **Issues** tab or the **Discussions** tab in the MicrosoftEdge-Extensions repo; use email instead.
+
+See also:
+* [Publish a Microsoft Edge extension](./publish-extension.md)
+
+
+<!-- ====================================================================== -->
+## Send email to extensions developer support
+
+To discuss issues about a specific developer account or extension, you can privately contact extensions developer support at [ext_dev_support@microsoft.com](mailto:ext_dev_support@microsoft.com).
+
+
+<!-- ====================================================================== -->
 ## Discussion forum in the MicrosoftEdge-Extensions repo
 
-Participate in the public [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) forum in the **MicrosoftEdge-Extensions** repo.  You can:
+Participate in the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) forum in the **MicrosoftEdge-Extensions** repo.  You can:
 * Discuss developing extensions.
    * Share best practices with other developers on building, managing or acquiring more users for their browser extension.
    * Connect with other extension developers about technical questions related to building Microsoft Edge add-ons.
@@ -25,6 +42,9 @@ Participate in the public [Discussions](https://github.com/microsoft/MicrosoftEd
    * Share inputs or suggestions to the Microsoft Edge add-ons engineering team.
    * Discuss how to improve extension publishing, management and listing processes or workflows.
    * Provide early feedback to the Microsoft Edge add-ons engineering team about new features for managing and publishing extensions.
+
+See also:
+* [README.md](https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md) of the **MicrosoftEdge-Extensions** repo.
 
 
 <!-- ====================================================================== -->
@@ -38,27 +58,9 @@ Use this **Issues** page for:
 
 
 <!-- ====================================================================== -->
-## Send email to extensions developer support
-
-To discuss issues about a specific developer account or extension, you can privately contact extensions developer support at [ext_dev_support@microsoft.com](mailto:ext_dev_support@microsoft.com).
-
-
-<!-- ====================================================================== -->
-## Inquire about an extension's review status or certification status
-
-After submitting your extension via Partner Center, if you have questions regarding your extension's review status or certification status, use the [MicrosoftEdge-Extensions](https://github.com/microsoft/MicrosoftEdge-Extensions/issues/new/choose) repo to enter a new Issue.
-
-
-<!-- ====================================================================== -->
 ## Report copyright or trademark infringement
 
 If you think an item in the Microsoft Edge Add-ons website violates a copyright or trademark, complete the [Reporting Infringement](https://www.microsoft.com/concern/dmca) form.  When filling in **Step 3: Where can the infringing material be found?**, in the **Product/Service/App** option, make sure to select **Microsoft Store on Windows**.  The Microsoft Edge extensions team will review your report and then take the necessary action.
-
-
-<!-- ====================================================================== -->
-## Learn about submitting an extension
-
-If you have any issues while you submit your extension to Partner Center, see [Publish your extension](publish-extension.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
+++ b/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
@@ -14,7 +14,7 @@ You can contact the Microsoft Edge extensions support team to request help, subm
 
 
 <!-- ====================================================================== -->
-## Discussion forum in MicrosoftEdge-Extensions repo
+## Discussion forum in the MicrosoftEdge-Extensions repo
 
 Participate in the public [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) forum in the **MicrosoftEdge-Extensions** repo.  You can:
 * Discuss developing extensions.
@@ -28,7 +28,7 @@ Participate in the public [Discussions](https://github.com/microsoft/MicrosoftEd
 
 
 <!-- ====================================================================== -->
-## Issues page in MicrosoftEdge-Extensions repo
+## Issues page in the MicrosoftEdge-Extensions repo
 
 To publicly report or discuss an issue about extensions, use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) page in the **MicrosoftEdge-Extensions** repo.
 
@@ -38,13 +38,13 @@ Use this **Issues** page for:
 
 
 <!-- ====================================================================== -->
-## Email extensions developer support
+## Send email to extensions developer support
 
 To discuss issues about a specific developer account or extension, you can privately contact extensions developer support at [ext_dev_support@microsoft.com](mailto:ext_dev_support@microsoft.com).
 
 
 <!-- ====================================================================== -->
-## Inquire about your extension's review status or certification status
+## Inquire about an extension's review status or certification status
 
 After submitting your extension via Partner Center, if you have questions regarding your extension's review status or certification status, use the [MicrosoftEdge-Extensions](https://github.com/microsoft/MicrosoftEdge-Extensions/issues/new/choose) repo to enter a new Issue.
 
@@ -68,7 +68,7 @@ To feature your extension in a collection on the Microsoft Edge Add-ons website,
 
 
 <!-- ====================================================================== -->
-## Microsoft Edge Insider Forum at Tech Community
+## Microsoft Edge Insider forum at Tech Community
 <!-- not specific to extensions -->
 
 For discussion about Microsoft Edge, including Beta, Dev, and Canary preview channels, use the [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) forum at Microsoft Tech Community.
@@ -79,15 +79,3 @@ For discussion about Microsoft Edge, including Beta, Dev, and Canary preview cha
 <!-- not specific to extensions -->
 
 For news and updates about developing for the web with Microsoft Edge, follow the [Microsoft Edge Dev (@MSEdgeDev)](https://twitter.com/msedgedev/) team on X (Twitter).
-
-
-<!-- ====================================================================== -->
-## Learn about correct use of APIs
-<!-- not about contact -->
-
-If your extension isn't working with Microsoft Edge as you expect, or you have a question about how to develop an extension, see [Supported APIs for Microsoft Edge extensions](../developer-guide/api-support.md) and [Port Chromium extensions to Microsoft Edge](../developer-guide/port-chrome-extension.md).
-
-
-<!-- ====================================================================== -->
-<!-- ## See also -->
-<!-- todo: all links in article -->

--- a/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
+++ b/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
@@ -10,13 +10,6 @@ ms.date: 02/10/2025
 ---
 # Contact the Microsoft Edge extensions team
 
-<!-- h2 sections per draft outline (July 3 2024):
-Request help or submit feedback
-Report copyright or trademark infringement
-Log your tickets via Partner Center
-Connect with Community
--->
-
 You can contact the Microsoft Edge extensions support team to request help, submit feedback, or report a copyright or trademark infringement.
 
 
@@ -24,15 +17,14 @@ You can contact the Microsoft Edge extensions support team to request help, subm
 ## Discussion forum in MicrosoftEdge-Extensions repo
 
 Participate in the public [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) forum in the **MicrosoftEdge-Extensions** repo.  You can:
-* Request a feature for extensions.
 * Discuss developing extensions.
-   * Share ideas about the Edge Add-ons website (the Edge extensions store).
    * Share best practices with other developers on building, managing or acquiring more users for their browser extension.
    * Connect with other extension developers about technical questions related to building Microsoft Edge add-ons.
-* Share inputs or suggestions to the Microsoft Edge add-ons engineering team.
-   * How to improve extension publishing, management and listing processes or workflows.
-   * Provide early feedback to the Microsoft Edge add-ons engineering team about any new features for extensions publishing, extensions management, or processes or workflows for extensions listings.
-<!-- todo: trim wordcount copied from https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md -->
+   * Share ideas about the Edge Add-ons website (the Edge extensions store).
+* Request a feature for extensions.
+   * Share inputs or suggestions to the Microsoft Edge add-ons engineering team.
+   * Discuss how to improve extension publishing, management and listing processes or workflows.
+   * Provide early feedback to the Microsoft Edge add-ons engineering team about new features for managing and publishing extensions.
 
 
 <!-- ====================================================================== -->
@@ -46,9 +38,9 @@ Use this **Issues** page for:
 
 
 <!-- ====================================================================== -->
-## Email extensions support
+## Email extensions developer support
 
-To discuss issues about a specific developer account or extension, you can privately contact extensions support at [ext_dev_support@microsoft.com](mailto:ext_dev_support@microsoft.com).
+To discuss issues about a specific developer account or extension, you can privately contact extensions developer support at [ext_dev_support@microsoft.com](mailto:ext_dev_support@microsoft.com).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
+++ b/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
@@ -6,22 +6,11 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.subservice: extensions
-ms.date: 06/26/2024
+ms.date: 02/10/2025
 ---
 # Contact the Microsoft Edge extensions team
 
-<!-- 
-existing h2 sections:
-
-Inquire about your extension's review status or certification status
-Learn about correct use of APIs
-Learn about submitting an extension
-Feature your extension in a collection
-Participate in the discussion forum
-Report copyright or trademark infringement
-
-h2 sections per draft outline (July 3 2024):
-
+<!-- h2 sections per draft outline (July 3 2024):
 Request help or submit feedback
 Report copyright or trademark infringement
 Log your tickets via Partner Center
@@ -32,37 +21,40 @@ You can contact the Microsoft Edge extensions support team to request help, subm
 
 
 <!-- ====================================================================== -->
+## Discussion forum in MicrosoftEdge-Extensions repo
+
+Participate in the public [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) forum in the **MicrosoftEdge-Extensions** repo.  You can:
+* Request a feature for extensions.
+* Discuss developing extensions.
+   * Share ideas about the Edge Add-ons website (the Edge extensions store).
+   * Share best practices with other developers on building, managing or acquiring more users for their browser extension.
+   * Connect with other extension developers about technical questions related to building Microsoft Edge add-ons.
+* Share inputs or suggestions to the Microsoft Edge add-ons engineering team.
+   * How to improve extension publishing, management and listing processes or workflows.
+   * Provide early feedback to the Microsoft Edge add-ons engineering team about any new features for extensions publishing, extensions management, or processes or workflows for extensions listings.
+<!-- todo: trim wordcount copied from https://github.com/microsoft/MicrosoftEdge-Extensions/blob/main/README.md -->
+
+
+<!-- ====================================================================== -->
+## Issues page in MicrosoftEdge-Extensions repo
+
+To publicly report or discuss an issue about extensions, use the [Issues](https://github.com/microsoft/MicrosoftEdge-Extensions/issues) page in the **MicrosoftEdge-Extensions** repo.
+
+Use this **Issues** page for: 
+* Aspects of Microsoft Partner Center that affect all extension developers.
+* Aspects of the Edge Add-ons website that affect all extension developers or all Microsoft Edge extension users.
+
+
+<!-- ====================================================================== -->
+## Email extensions support
+
+To discuss issues about a specific developer account or extension, you can privately contact extensions support at [ext_dev_support@microsoft.com](mailto:ext_dev_support@microsoft.com).
+
+
+<!-- ====================================================================== -->
 ## Inquire about your extension's review status or certification status
 
 After submitting your extension via Partner Center, if you have questions regarding your extension's review status or certification status, use the [MicrosoftEdge-Extensions](https://github.com/microsoft/MicrosoftEdge-Extensions/issues/new/choose) repo to enter a new Issue.
-
-
-<!-- ====================================================================== -->
-## Learn about correct use of APIs
-
-If your extension isn't working with Microsoft Edge as you expect, or you have a question about how to develop an extension, see [Supported APIs for Microsoft Edge extensions](../developer-guide/api-support.md) and [Port Chromium extensions to Microsoft Edge](../developer-guide/port-chrome-extension.md).
-
-
-<!-- ====================================================================== -->
-## Learn about submitting an extension
-
-If you have any issues while you submit your extension to Partner Center, see [Publish your extension](publish-extension.md).
-
-
-<!-- ====================================================================== -->
-## Feature your extension in a collection
-
-To feature your extension in a collection on the Microsoft Edge Add-ons website, see [Submit a request to add an extension to the collections on the Microsoft Edge Add-ons home page](https://forms.office.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbRw01UwyBfAxNna_1ZkP3X2VUN0lBSU1YMEU3VFY0VURRODEwSjgwU00yRy4u) and complete the form.
-
-
-<!-- ====================================================================== -->
-## MicrosoftEdge-Extensions discussion forum
-
-Participate in the [Discussions](https://github.com/microsoft/MicrosoftEdge-Extensions/discussions) forum in the MicrosoftEdge-Extensions repo to flag any issues, raise a feature request, be a part of discussions, and share your ideas regarding the Microsoft Edge Extensions Store.
-
-You can also create an issue on our Github page here(https://github.com/microsoft/MicrosoftEdge-Extensions/issues) for anything specific to extensions. 
-
-There is also a support email where you can reach out to us for further inquiries(ext_dev_support@microsoft.com)
 
 
 <!-- ====================================================================== -->
@@ -72,7 +64,38 @@ If you think an item in the Microsoft Edge Add-ons website violates a copyright 
 
 
 <!-- ====================================================================== -->
-## See also
+## Learn about submitting an extension
 
-* [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) - forum about Microsoft Edge at Microsoft Tech Community.
-* [@MSEdgeDev](https://twitter.com/msedgedev/) - Microsoft Edge team on X (Twitter).
+If you have any issues while you submit your extension to Partner Center, see [Publish your extension](publish-extension.md).
+
+
+<!-- ====================================================================== -->
+## Feature an extension in a collection
+
+To feature your extension in a collection on the Microsoft Edge Add-ons website, see [Submit a request to add an extension to the collections on the Microsoft Edge Add-ons home page](https://forms.office.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbRw01UwyBfAxNna_1ZkP3X2VUN0lBSU1YMEU3VFY0VURRODEwSjgwU00yRy4u) and complete the form.
+
+
+<!-- ====================================================================== -->
+## Microsoft Edge Insider Forum at Tech Community
+<!-- not specific to extensions -->
+
+For discussion about Microsoft Edge, including Beta, Dev, and Canary preview channels, use the [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) forum at Microsoft Tech Community.
+
+
+<!-- ====================================================================== -->
+## Microsoft Edge team on X (Twitter)
+<!-- not specific to extensions -->
+
+For news and updates about developing for the web with Microsoft Edge, follow the [Microsoft Edge Dev (@MSEdgeDev)](https://twitter.com/msedgedev/) team on X (Twitter).
+
+
+<!-- ====================================================================== -->
+## Learn about correct use of APIs
+<!-- not about contact -->
+
+If your extension isn't working with Microsoft Edge as you expect, or you have a question about how to develop an extension, see [Supported APIs for Microsoft Edge extensions](../developer-guide/api-support.md) and [Port Chromium extensions to Microsoft Edge](../developer-guide/port-chrome-extension.md).
+
+
+<!-- ====================================================================== -->
+<!-- ## See also -->
+<!-- todo: all links in article -->

--- a/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
+++ b/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
@@ -71,13 +71,18 @@ To feature your extension in a collection on the Microsoft Edge Add-ons website,
 
 <!-- ====================================================================== -->
 ## Microsoft Edge Insider forum at Tech Community
-<!-- not specific to extensions -->
 
-For discussion about Microsoft Edge, including Beta, Dev, and Canary preview channels, use the [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) forum at Microsoft Tech Community.
+You can stay tuned to recent updates and announcements via the [Microsoft Edge Insider](https://techcommunity.microsoft.com/category/MicrosoftEdgeInsider) product community at Tech Community, or search there for [Edge extensions](https://techcommunity.microsoft.com/search?q=edge+extensions&location=category%3AMicrosoftEdgeInsider) or [Edge add-on](https://techcommunity.microsoft.com/search?q=edge+add-on&location=category%3AMicrosoftEdgeInsider).
+
+
+<!-- ====================================================================== -->
+## #EdgeExtensions at X (Twitter)
+
+You can follow what's happening with Microsoft Edge add-ons via [#EdgeExtensions at Twitter](https://x.com/search?q=%23EdgeExtensions&src=typed_query&f=live).
 
 
 <!-- ====================================================================== -->
 ## Microsoft Edge team on X (Twitter)
 <!-- not specific to extensions -->
 
-For news and updates about developing for the web with Microsoft Edge, follow the [Microsoft Edge Dev (@MSEdgeDev)](https://twitter.com/msedgedev/) team on X (Twitter).
+For news and updates about developing for the web with Microsoft Edge, follow the [Microsoft Edge Dev (@MSEdgeDev)](https://x.com/msedgedev/) team on X (Twitter).


### PR DESCRIPTION
Rendered article section for review:
* **Contact the Microsoft Edge extensions team** > **MicrosoftEdge-Extensions discussion forum**
   * `/extensions-chromium/publish/contact-extensions-team.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team?branch=pr-en-us-3371
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/bhuvanapriyap-patch-3/microsoft-edge/extensions-chromium/publish/contact-extensions-team.md
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions-chromium/publish/contact-extensions-team
   * Broke up section "MicrosoftEdge-Extensions discussion forum" into sections:
      * "Discussion forum in the MicrosoftEdge-Extensions repo"
      * "Issues page in the MicrosoftEdge-Extensions repo"
      * "Email extensions developer support" - new content.
   * Deleted section "Learn about correct use of APIs".
   * To inquire about your account or extension status, use email, not Issues.
   * Reordered sections, to start with sections about contacting re: extensions.
   * Copied the ways of contact from Readme.md of repo.
      * Linked to Readme, so they're x-linked, to help Maint/sync/consistency.

AB#56183866 - PR 3371 tracking.
AB#56191476 - Broader page redesign.