### PR TITLE
Remove "V8 runtime call stats" from "Experimental features in DevTools"

### DIFF
--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 no-loc: ["Enable webhint"]
-ms.date: 01/16/2025
+ms.date: 02/13/2025
 ---
 # Experimental features in Microsoft Edge DevTools
 
@@ -872,23 +872,6 @@ Status:
 <!-- checkbox has no "(?)" link pointing to this anchor wording -->
 
 Controls whether to show all events in the **Performance** tool.
-
-See also:
-* [Introduction to the Performance tool](../evaluate-performance/index.md)
-
-Status:
-* This checkbox is present in Microsoft Edge Canary 134.
-* This checkbox is present in Microsoft Edge Stable 132.
-
-
-<!-- ====================================================================== -->
-## Performance panel: V8 runtime call stats
-<!-- was:
-## Timeline: V8 Runtime Call Stats on Timeline
--->
-<!-- checkbox has no "(?)" link pointing to this anchor wording -->
-
-Controls whether to show V8 runtime call statistics in the **Performance** tool.  V8 is the JavaScript engine that's used by Microsoft Edge.
 
 See also:
 * [Introduction to the Performance tool](../evaluate-performance/index.md)

--- a/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
+++ b/microsoft-edge/devtools-guide-chromium/experimental-features/index.md
@@ -881,6 +881,12 @@ Status:
 * This checkbox is present in Microsoft Edge Stable 132.
 
 
+<!-- ====================================================================== --
+## Performance panel: V8 runtime call stats -->
+<!-- checkbox has no "(?)" link pointing to this anchor wording -->
+<!-- checkbox will be removed, has no effect; after that, remove this section -->
+
+
 <!-- ====================================================================== -->
 ## Performance panel: Enable collecting enhanced traces
 <!-- checkbox has no "(?)" link pointing to this anchor wording -->


### PR DESCRIPTION
Rendered article sections for review:
* **Experimental features in Microsoft Edge DevTools** > **Performance panel: V8 runtime call stats**
   * `/devtools-guide-chromium/experimental-features/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/devtools-guide-chromium/experimental-features/index?branch=pr-en-us-3377#performance-panel-v8-runtime-call-stats
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/v8-stats/microsoft-edge/devtools-guide-chromium/experimental-features/index.md#performance-panel-v8-runtime-call-stats
   * Before/live: https://learn.microsoft.com/microsoft-edge/devtools-guide-chromium/experimental-features/#performance-panel-v8-runtime-call-stats
   * Removed this h2 section.

AB#56235942