### PR TITLE
WebView2: VS Code debug config corrections, and source map loading description

### DIFF
--- a/microsoft-edge/webview2/concepts/working-with-local-content.md
+++ b/microsoft-edge/webview2/concepts/working-with-local-content.md
@@ -353,7 +353,7 @@ When loading local content via a virtual host name mapping, you are mapping a vi
 <!-- ---------- -->
 ###### Additional web resources
 
-Local content that's loaded via virtual host name mapping has an HTTP or HTTPS URL which supports relative URL resolution. This means that the loaded document can have references to additional web resources such as CSS, script, or image files which are also served via virtual host name mapping.
+Local content that's loaded via virtual host name mapping has an HTTP or HTTPS URL which supports relative URL resolution. This means that the loaded document can have references to additional web resources such as CSS, script, or image files which are also served via virtual host name mapping, except [source maps](#source-maps-with-virtual-host-name-mapping).
 
 
 <!-- ---------- -->
@@ -361,6 +361,14 @@ Local content that's loaded via virtual host name mapping has an HTTP or HTTPS U
 
 Virtual host name URLs are resolved in WebView2 processes. This is a faster option than `WebResourceRequested`, which resolves in the host app process UI thread.
 
+<!-- ---------- -->
+###### Source maps with virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. from TypeScript) or CSS (e.g. from SASS or SCSS). WebView2 does not load source maps referenced by content which was loaded using virtual host name mapping. Consider the following example. WebView2 loads JavaScript file `main.js` via virtual host name mapping. If `main.js` references `main.js.map` as its source map, then `main.js.map` will neither be loaded automatically nor any `WebResourceRequested` event handler will be called to load it.
+
+To use source maps along with virtual host name mapping, choose one of the following approaches:
+- Generate inline source maps during compilation of your content. Inline source maps are embedded to the corresponding compiled file.
+- Use `WebResourceRequested` event instead, and inline separate source maps to the content at runtime in your `WebResourceRequested` event handler. Use this approach only if your content build system does not support inlining source maps.
 
 <!-- ------------------------------ -->
 #### APIs for loading local content by using virtual host name mapping
@@ -462,7 +470,7 @@ When loading local content via `WebResourceRequested`, you specify the local con
 <!-- ---------- -->
 ###### Additional web resources
 
-`WebResourceRequested` modifies the content that's loaded via HTTP or HTTPS URLs, which support relative URL resolution. This means that the resulting document can have references to additional web resources such as CSS, script, or image files that are also served via `WebResourceRequested`.
+`WebResourceRequested` modifies the content that's loaded via HTTP or HTTPS URLs, which support relative URL resolution. This means that the resulting document can have references to additional web resources such as CSS, script, or image files that are also served via `WebResourceRequested`, except [source maps](#source-maps- with-webresourcerequested-event).
 
 
 <!-- ---------- -->
@@ -476,6 +484,14 @@ When loading content via a file URL or a virtual host name mapping, the resoluti
 
 This can take some time. Make sure to limit calls to `AddWebResourceRequestedFilter` to only the web resources that must raise the `WebResourceRequested` event.
 
+<!-- ---------- -->
+###### Source maps with WebResourceRequested event
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. from TypeScript) or CSS (e.g. from SASS, SCSS). WebView2 does not load source maps referenced by content which was loaded using `WebResourceRequested` event. Consider the following example. You load JavaScript file `main.js` in your `WebResourceRequested` event handler by setting `WebResourceRequestedArgs.Response`. If `main.js` references `main.js.map` as its source map, then `main.js.map` will neither be loaded automatically nor your `WebResourceRequested` event handler will be called again to load it.
+
+To use source maps along with virtual host name mapping, choose one of the following approaches:
+- Generate inline source maps during compilation of your content. Inline source maps are embedded to the corresponding compiled file.
+- Inline separate source maps to the content at runtime in your `WebResourceRequested` event handler. Use this approach only if your content build system does not support inlining source maps.
 
 <!-- ------------------------------ -->
 #### APIs for loading local content by handling the WebResourceRequested event

--- a/microsoft-edge/webview2/how-to/debug-devtools.md
+++ b/microsoft-edge/webview2/how-to/debug-devtools.md
@@ -38,6 +38,12 @@ An app can also use the `OpenDevToolsWindow` API to programmatically open a DevT
 
 If none of the above approaches are available, you can add `--auto-open-devtools-for-tabs` to the browser arguments via an environment variable or registry key.  This approach will open a DevTools window when a WebView2 is created.
 
+<!-- ====================================================================== -->
+## Source maps with `WebResourceRequested` event or virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. from TypeScript) or CSS (e.g. from SASS or SCSS). When content is loaded to WebView2 using 
+[WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event)
+ or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping), special care is needed to also load the corresponding source maps. See details and solutions for [WebResourceRequested event here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping), and for [virtual host name mapping here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping)
 
 <!-- ====================================================================== -->
 ## See also

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -13,7 +13,6 @@ ms.date: 02/11/2022
 Use Microsoft Visual Studio Code to debug scripts that run in WebView2 controls.  <!-- Make sure you're using Visual Studio Code version [insert build here] or later. -->
 Visual Studio Code has a built-in debugger for browser debugging.  See [Browser debugging in VS Code](https://code.visualstudio.com/docs/nodejs/browser-debugging).
 
-
 <!-- ====================================================================== -->
 ## Create a launch.json file
 
@@ -28,6 +27,8 @@ The following code demonstrates launching the app from Visual Studio Code (rathe
 "request": "launch",
 "runtimeExecutable": "C:/path/to/your/webview2/app.exe",
 "env": {
+   // The port below shall match the value of "port" property above
+   "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS": "--remote-debugging-port=9222" 
    // Customize for your app location if needed
    "Path": "%path%;e:/path/to/your/app/location; "
 },
@@ -38,6 +39,7 @@ The following code demonstrates launching the app from Visual Studio Code (rathe
 "webRoot": "${workspaceFolder}/path/to/your/assets"
 ```
 
+> Instead of setting `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=9222` environment variable, you can add a new REGKEY `<myApp.exe> = --remote-debugging-port=9222` to registry under `Computer\HKEY_CURRENT_USER\Software\Policies\Microsoft\Edge\WebView2\AdditionalBrowserArguments`, so that the debugger can find the proper port. 
 
 <!-- ---------------------------------- -->
 #### Command-line URL parameter passed in
@@ -109,8 +111,7 @@ You might need to attach the debugger to running WebView2 processes.  To do that
 "runtimeExecutable": "C:/path/to/your/webview2/myApp.exe",
 "env": {
    "Path": "%path%;e:/path/to/your/build/location; "
-},
-"useWebView": true
+}
 ```
 
 Your WebView2 control must open the Chrome Developer Protocol (CDP) port to allow debugging of the WebView2 control.  Your code must be built to ensure that only one WebView2 control has a CDP port open, before starting the debugger.
@@ -143,6 +144,7 @@ You also need to add a new REGKEY `<myApp.exe> = --remote-debugging-port=9222` u
 
    ![The resulting registry key in the Registry Editor](./debug-visual-studio-code-images/set-debugging-port-registry-key.png)
 
+Instead of adding the above registry key, you can set `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=9222` environment variable. Make sure that your application was started after the environment variable had been set, and that your application inherits the variable.
 
 <!-- ====================================================================== -->
 ## Debug tracing options

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -220,6 +220,13 @@ If you're debugging Office Add-ins, open the add-in source code in a separate in
 
    ![Run and Debug](./debug-visual-studio-code-images/attach-uwp.png)
 
+<!-- ====================================================================== -->
+## Source maps with `WebResourceRequested` event or virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. from TypeScript) or CSS (e.g. from SASS or SCSS). When content is loaded to WebView2 using 
+[WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event)
+ or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping), special care is needed to also load the corresponding source maps. See details and solutions for [WebResourceRequested event here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping), and for [virtual host name mapping here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping)
+
 
 <!-- ====================================================================== -->
 ## Troubleshoot the debugger

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -227,7 +227,6 @@ Source maps are needed to debug the source code of compiled content like transpi
 [WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event)
  or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping), special care is needed to also load the corresponding source maps. See details and solutions for [WebResourceRequested event here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping), and for [virtual host name mapping here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping)
 
-
 <!-- ====================================================================== -->
 ## Troubleshoot the debugger
 

--- a/microsoft-edge/webview2/how-to/debug-visual-studio.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio.md
@@ -160,6 +160,12 @@ After doing the above setup, debug your WebView2 app, as follows.
 
    The app output shows "This is the very first line of code that executes", because of the line `console.log("This is the very first line of code that executes.");` in the file `WebView2Samples\SampleApps\WebView2APISample\assets\ScenarioJavaScriptDebugIndex.html`.
 
+<!-- ====================================================================== -->
+## Source maps with `WebResourceRequested` event or virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. from TypeScript) or CSS (e.g. from SASS or SCSS). When content is loaded to WebView2 using 
+[WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event)
+ or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping), special care is needed to also load the corresponding source maps. See details and solutions for [WebResourceRequested event here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping), and for [virtual host name mapping here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping)
 
 <!-- ====================================================================== -->
 ## Troubleshooting


### PR DESCRIPTION
**VS Code debugging:**
- `"useWebView": true` property is not allowed for `"request": "attach"` type configs. For attaching configs, `useWebView` is only needed for UWP apps, and accepts an object instead of boolean, where the debug pipe shall be specified.
- `--remote-debugging-port=9222` command line argument is also needed for  `"request": "launch"` type configs when custom `runtimeExecutable` is used. It can be supplied either via environment variable or via registry.

**Source map loading:**

WebView2 does not load source maps referenced by resources which were loaded using either `WebResourceRequested` event or virtual host name mapping.  This is a [known limitation](https://github.com/MicrosoftEdge/WebView2Feedback/issues/961?fbclid=IwZXh0bgNhZW0CMTEAAR2ipcsx9oeFkv51KZIKVgLvnIyk2x1SkoxQOdfl6UamLQOgfeMJVIME4SY_aem_jwSPdIAvI7ihPWuNph3SXA) which I also verified, and worth to be documented here along with its possible workarounds.



