### PR TITLE
WebView2 source map handling

### DIFF
--- a/microsoft-edge/webview2/concepts/working-with-local-content.md
+++ b/microsoft-edge/webview2/concepts/working-with-local-content.md
@@ -353,7 +353,7 @@ When loading local content via a virtual host name mapping, you are mapping a vi
 <!-- ---------- -->
 ###### Additional web resources
 
-Local content that's loaded via virtual host name mapping has an HTTP or HTTPS URL which supports relative URL resolution. This means that the loaded document can have references to additional web resources such as CSS, script, or image files which are also served via virtual host name mapping.
+Local content that's loaded via virtual host name mapping has an HTTP or HTTPS URL which supports relative URL resolution. This means that the loaded document can have references to additional web resources such as CSS, script, or image files which are also served via virtual host name mapping, except [source maps](#source-maps-with-virtual-host-name-mapping).
 
 
 <!-- ---------- -->
@@ -361,6 +361,14 @@ Local content that's loaded via virtual host name mapping has an HTTP or HTTPS U
 
 Virtual host name URLs are resolved in WebView2 processes. This is a faster option than `WebResourceRequested`, which resolves in the host app process UI thread.
 
+<!-- ---------- -->
+###### Source maps with virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. TypeScript, minified JavaScript) or CSS (e.g. SASS, SCSS). WebView2 does not load source maps referenced by content which was loaded using virtual host name mapping. Consider the following example. WebView2 loads JavaScript file `main.js` via virtual host name mapping. If `main.js` references `main.js.map` as its source map, then `main.js.map` will neither be loaded automatically nor any `WebResourceRequested` event handler will be called to load it.
+
+To use source maps along with virtual host name mapping, choose one of the following approaches:
+- Generate inline source maps during compilation of your content. Inline source maps are embedded to the corresponding compiled file.
+- Use `WebResourceRequested` event instead, and inline separate source maps to the content at runtime in your `WebResourceRequested` event handler. Use this approach only if your content build system does not support inlining source maps.
 
 <!-- ------------------------------ -->
 #### APIs for loading local content by using virtual host name mapping
@@ -462,7 +470,7 @@ When loading local content via `WebResourceRequested`, you specify the local con
 <!-- ---------- -->
 ###### Additional web resources
 
-`WebResourceRequested` modifies the content that's loaded via HTTP or HTTPS URLs, which support relative URL resolution. This means that the resulting document can have references to additional web resources such as CSS, script, or image files that are also served via `WebResourceRequested`.
+`WebResourceRequested` modifies the content that's loaded via HTTP or HTTPS URLs, which support relative URL resolution. This means that the resulting document can have references to additional web resources such as CSS, script, or image files that are also served via `WebResourceRequested`, except [source maps](#source-maps- with-webresourcerequested-event).
 
 
 <!-- ---------- -->
@@ -476,6 +484,14 @@ When loading content via a file URL or a virtual host name mapping, the resoluti
 
 This can take some time. Make sure to limit calls to `AddWebResourceRequestedFilter` to only the web resources that must raise the `WebResourceRequested` event.
 
+<!-- ---------- -->
+###### Source maps with WebResourceRequested event
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. TypeScript, minified JavaScript) or CSS (e.g. SASS, SCSS). WebView2 does not load source maps referenced by content which was loaded using `WebResourceRequested` event. Consider the following example. You load JavaScript file `main.js` in your `WebResourceRequested` event handler by setting `WebResourceRequestedArgs.Response`. If `main.js` references `main.js.map` as its source map, then `main.js.map` will neither be loaded automatically nor your `WebResourceRequested` event handler will be called again to load it.
+
+To use source maps along with virtual host name mapping, choose one of the following approaches:
+- Generate inline source maps during compilation of your content. Inline source maps are embedded to the corresponding compiled file.
+- Inline separate source maps to the content at runtime in your `WebResourceRequested` event handler. Use this approach only if your content build system does not support inlining source maps.
 
 <!-- ------------------------------ -->
 #### APIs for loading local content by handling the WebResourceRequested event

--- a/microsoft-edge/webview2/how-to/debug-devtools.md
+++ b/microsoft-edge/webview2/how-to/debug-devtools.md
@@ -38,6 +38,10 @@ An app can also use the `OpenDevToolsWindow` API to programmatically open a DevT
 
 If none of the above approaches are available, you can add `--auto-open-devtools-for-tabs` to the browser arguments via an environment variable or registry key.  This approach will open a DevTools window when a WebView2 is created.
 
+<!-- ====================================================================== -->
+## Source maps with `WebResourceRequested` event or virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. TypeScript, minified JavaScript) or CSS (e.g. SASS, SCSS). WebView2 does not load source maps referenced by content which was loaded using either [WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event) or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping). See details and solutions for [WebResourceRequested event here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping), and for [virtual host name mapping here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping).
 
 <!-- ====================================================================== -->
 ## See also

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -28,7 +28,8 @@ The following code demonstrates launching the app from Visual Studio Code (rathe
 "request": "launch",
 "runtimeExecutable": "C:/path/to/your/webview2/app.exe",
 "env": {
-   // The port below shall match the value of "port" property above
+   // The following variable is needed when "runtimeExecutable" property is set.
+   // The port number below shall match the value of "port" property above.
    "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS": "--remote-debugging-port=9222" 
    // Customize for your app location if needed
    "Path": "%path%;e:/path/to/your/app/location; "

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -28,6 +28,8 @@ The following code demonstrates launching the app from Visual Studio Code (rathe
 "request": "launch",
 "runtimeExecutable": "C:/path/to/your/webview2/app.exe",
 "env": {
+   // The port below shall match the value of "port" property above
+   "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS": "--remote-debugging-port=9222" 
    // Customize for your app location if needed
    "Path": "%path%;e:/path/to/your/app/location; "
 },
@@ -38,6 +40,7 @@ The following code demonstrates launching the app from Visual Studio Code (rathe
 "webRoot": "${workspaceFolder}/path/to/your/assets"
 ```
 
+> Instead of setting `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=9222` environment variable, you can add a new REGKEY `<myApp.exe> = --remote-debugging-port=9222` to registry under `Computer\HKEY_CURRENT_USER\Software\Policies\Microsoft\Edge\WebView2\AdditionalBrowserArguments`, so that the debugger can find the proper port. 
 
 <!-- ---------------------------------- -->
 #### Command-line URL parameter passed in
@@ -109,8 +112,7 @@ You might need to attach the debugger to running WebView2 processes.  To do that
 "runtimeExecutable": "C:/path/to/your/webview2/myApp.exe",
 "env": {
    "Path": "%path%;e:/path/to/your/build/location; "
-},
-"useWebView": true
+}
 ```
 
 Your WebView2 control must open the Chrome Developer Protocol (CDP) port to allow debugging of the WebView2 control.  Your code must be built to ensure that only one WebView2 control has a CDP port open, before starting the debugger.
@@ -143,6 +145,7 @@ You also need to add a new REGKEY `<myApp.exe> = --remote-debugging-port=9222` u
 
    ![The resulting registry key in the Registry Editor](./debug-visual-studio-code-images/set-debugging-port-registry-key.png)
 
+> Instead of adding the above registry key, you can set `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=9222` environment variable. Make sure that your application was started after the environment variable had been set, and that your application inherits the variable.
 
 <!-- ====================================================================== -->
 ## Debug tracing options

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -222,6 +222,10 @@ If you're debugging Office Add-ins, open the add-in source code in a separate in
 
    ![Run and Debug](./debug-visual-studio-code-images/attach-uwp.png)
 
+<!-- ====================================================================== -->
+## Source maps with `WebResourceRequested` event or virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. TypeScript, minified JavaScript) or CSS (e.g. SASS, SCSS). WebView2 does not load source maps referenced by content which was loaded using either [WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event) or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping). See details and solutions for [WebResourceRequested event here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping), and for [virtual host name mapping here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping).
 
 <!-- ====================================================================== -->
 ## Troubleshoot the debugger

--- a/microsoft-edge/webview2/how-to/debug-visual-studio.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio.md
@@ -160,6 +160,10 @@ After doing the above setup, debug your WebView2 app, as follows.
 
    The app output shows "This is the very first line of code that executes", because of the line `console.log("This is the very first line of code that executes.");` in the file `WebView2Samples\SampleApps\WebView2APISample\assets\ScenarioJavaScriptDebugIndex.html`.
 
+<!-- ====================================================================== -->
+## Source maps with `WebResourceRequested` event or virtual host name mapping
+
+Source maps are needed to debug the source code of compiled content like transpiled JavaScript (e.g. TypeScript, minified JavaScript) or CSS (e.g. SASS, SCSS). WebView2 does not load source maps referenced by content which was loaded using either [WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event) or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping). See details and solutions for [WebResourceRequested event here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping), and for [virtual host name mapping here](../concepts/working-with-local-content.md#source-maps-with-virtual-host-name-mapping).
 
 <!-- ====================================================================== -->
 ## Troubleshooting


### PR DESCRIPTION
WebView2 does not load source maps referenced by content which was loaded using either [WebResourceRequested event](../concepts/working-with-local-content.md#loading-local-content-by-handling-the-webresourcerequested-event) or [virtual host name mapping](../concepts/working-with-local-content.md#loading-local-content-by-using-virtual-host-name-mapping). This is a [known limitation](https://github.com/MicrosoftEdge/WebView2Feedback/issues/961?fbclid=IwZXh0bgNhZW0CMTEAAR2JnU6XzGSllIlfzAhjYZFDvrInh6x0sZCeUlwtb9GYxrTBWG9koM6_nao_aem_nhQXggVJgv4je7r9onUSoA), which worth mentioning here to avoid confusion of developers using WebView2.

> VS Code provide several properties in its `launch.json` to configure locations of source maps  (`resolveSourceMapLocations`, `sourceMapPathOverrides`, `outFiles`), but in practice none of them worked for me with WebView2 and WebResourceRequested event. They work in other setups though. If you can configure VS Code to find source maps with WebResourceRequested event, you should describe that in VS Code Debugging chapter instead of my text.
