### PR TITLE
Add scavenger GC & SSO flags in "WebView2 browser flags"

### DIFF
--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -153,7 +153,7 @@ The following shortcuts are always turned off in WebView2, or are effectively tu
 | Browser Task Manager `*` | **Shift+Escape** |
 | Edge Feedback `*` | **Shift+Alt+I** |
 | Mute Tab `*` | **Ctrl+M** |
-| New Incognito Window | **Ctrl+Shift+N** |
+| New Incognito<!-- todo: InPrivate? --> Window | **Ctrl+Shift+N** |
 | New Tab | **Ctrl+T** |
 | New Window | **Ctrl+N** |
 | Restore Last Closed Tab | **Ctrl+Shift+T** |

--- a/microsoft-edge/webview2/concepts/browser-features.md
+++ b/microsoft-edge/webview2/concepts/browser-features.md
@@ -153,7 +153,7 @@ The following shortcuts are always turned off in WebView2, or are effectively tu
 | Browser Task Manager `*` | **Shift+Escape** |
 | Edge Feedback `*` | **Shift+Alt+I** |
 | Mute Tab `*` | **Ctrl+M** |
-| New Incognito<!-- todo: InPrivate? --> Window | **Ctrl+Shift+N** |
+| New InPrivate (Incognito) Window | **Ctrl+Shift+N** |
 | New Tab | **Ctrl+T** |
 | New Window | **Ctrl+N** |
 | Restore Last Closed Tab | **Ctrl+Shift+T** |

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -123,7 +123,7 @@ The following are some of the flags we've seen used.
 | `msFloatyShouldHonorIndiaHoldout` | If `true`, honors the India holdout group.  Use this flag, set to `false`, to disable the Floaty feature that's enabled if the user is part of the India holdout group, because WebView doesn't support browser retention experiments. |
 | `msOverlayScrollbarWinStyle` | Whether the users can change between overlay and non-overlay modes for Fluent scrollbars. |
 | `msPdfEnableAsPreview` | This features enables the PDF viewer to launch with a minimal toolbar and in read-only preview mode. |
-| `msSingleSignOnForInPrivateWebView2` | This flag enables the single sign-on (SSO) flow for an InPrivate (Incognito) session of WebView2.  Browser-based SSO should<!-- todo: style guide: avoid "should" https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/s/should-vs-must --> seamlessly work in InPrivate (Incognito) mode after enabling this flag. |
+| `msSingleSignOnForInPrivateWebView2` | This flag enables the single sign-on (SSO) flow for InPrivate (Incognito) sessions of WebView2.  Enables browser-based SSO in InPrivate (Incognito) mode. |
 | `msSingleSignOnOSForPrimaryAccountIsShared` | If enabled, allows implicit sign-in to Microsoft webpages using any account, by using the information from the primary OS account. |
 | `msSmartScreenProtection` | If enabled, SmartScreen protection will be available. |
 | `msUseSpellCheckCorrectionsCard` | If enabled, a new corrections card UI is shown when the user clicks a misspelled word. |

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -101,7 +101,7 @@ The following are some of the flags we've seen used.
 | `HardwareMediaKeyHandling` | Enables handling of hardware media keys for controlling media. |
 | `ignore-certificate-errors` | Ignores certificate-related errors. |
 | `ignore-gpu-blocklist` | Whether to ignore the GPU blocklist. |
-| `incognito` | Forces Incognito mode even if user data directory is specified by using the `--user-data-dir` flag. |
+| `incognito` | Forces InPrivate (Incognito) mode even if the user data directory is specified by using the `--user-data-dir` flag. |
 | `isolate-origins` | Require dedicated processes for a set of origins, specified as a comma-separated list. For example: --isolate-origins=https://www.foo.com,https://www.bar.com. |
 | `js-flags` | Specifies the flags passed to JS engine. |
 | `--js-flags=--scavenger_max_new_space_capacity_mb=8` | This flag specifies the maximum limit (in MB) for scavenger (minor garbage collector) in V8.  <br/>A higher scavenger memory limit reduces the frequency of minor garbage collectors, but increases memory usage.  <br/>A lower limit reduces memory footprint, but increases garbage collectors frequency, which may impact performance. |
@@ -123,7 +123,7 @@ The following are some of the flags we've seen used.
 | `msFloatyShouldHonorIndiaHoldout` | If `true`, honors the India holdout group.  Use this flag, set to `false`, to disable the Floaty feature that's enabled if the user is part of the India holdout group, because WebView doesn't support browser retention experiments. |
 | `msOverlayScrollbarWinStyle` | Whether the users can change between overlay and non-overlay modes for Fluent scrollbars. |
 | `msPdfEnableAsPreview` | This features enables the PDF viewer to launch with a minimal toolbar and in read-only preview mode. |
-| `msSingleSignOnForInPrivateWebView2` | This flag enables the single sign-on (SSO) flow for incognito/private session<!-- todo: InPrivate? --> of WebView2.  Browser-based SSO should seamlessly work in incognito<!-- todo: InPrivate? --> mode after enabling this flag. |
+| `msSingleSignOnForInPrivateWebView2` | This flag enables the single sign-on (SSO) flow for InPrivate (Incognito) sessions of WebView2.  Browser-based SSO should<!-- todo: style guide: avoid "should" https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/s/should-vs-must --> seamlessly work in InPrivate (Incognito) mode after enabling this flag. |
 | `msSingleSignOnOSForPrimaryAccountIsShared` | If enabled, allows implicit sign-in to Microsoft webpages using any account, by using the information from the primary OS account. |
 | `msSmartScreenProtection` | If enabled, SmartScreen protection will be available. |
 | `msUseSpellCheckCorrectionsCard` | If enabled, a new corrections card UI is shown when the user clicks a misspelled word. |

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -103,14 +103,13 @@ The following are some of the flags we've seen used.
 | `ignore-gpu-blocklist` | Whether to ignore the GPU blocklist. |
 | `incognito` | Forces InPrivate (Incognito) mode even if the user data directory is specified by using the `--user-data-dir` flag. |
 | `isolate-origins` | Require dedicated processes for a set of origins, specified as a comma-separated list. For example: --isolate-origins=https://www.foo.com,https://www.bar.com. |
-| `js-flags` | Specifies the flags passed to JS engine. |
-| `--js-flags=--scavenger_max_new_space_capacity_mb=8` | Specifies the maximum limit (in MB) for scavenger (minor) garbage collectors in the V8 JavaScript engine.  <br/>A lower scavenger memory limit reduces memory usage, and increases the frequency of running minor garbage collectors.  <br/>A higher scavenger memory limit increases memory usage, and reduces the frequency of running minor garbage collectors. |
+| `js-flags` | Specifies the flags passed to the JS engine.  Available flags: `scavenger_max_new_space_capacity_mb`: Specifies the maximum limit (in MB) for scavenger (minor) garbage collectors in the V8 JavaScript engine.  <br/>A lower scavenger memory limit reduces memory usage, and increases the frequency of running minor garbage collectors.  <br/>A higher scavenger memory limit increases memory usage, and reduces the frequency of running minor garbage collectors. |
 | `lang` | The language file that WebView2 want to try to open. Of the form language[-country] where language is the 2-letter code from ISO-639. |
 | `log-net-log` | Enables saving net log events to a file.  If a value is given, that value is used as the directory path and file name.  If no value is given, the file is named `netlog.json`, and is placed in the user data directory. |
 | `msAbydos` | Enables the "handwriting-to-text" experience. |
 | `msAbydosGestureSupport` | Allows users to use gestures (such as the scratchout gesture) to delete text by using a pen.  Valid only if the `msAbydos` flag is enabled. |
 | `msAbydosHandwritingAttr` | Whether the "handwriting-to-text" experience is enabled for input elements at the DOM level.  Valid only if the `msAbydos` flag is enabled. |
-| `msAllowAmbientAuthInPrivateWebView2` | This flag is to be used along with the `msSingleSignOnForInPrivateWebView2` browser browser flag, to enable SSO with default credential flow or ambient authentication flow. |
+| `msAllowAmbientAuthInPrivateWebView2` | This flag is to be used along with the `msSingleSignOnForInPrivateWebView2` browser flag, to enable single sign-on (SSO) with default credential flow or ambient authentication flow. |
 | `msEdgeDesignerUI` | Use this flag to disable the Designer Shoreline App. This feature is not supported in WebView2. |
 | `msEdgeHubAppDesigner ` | Use this flag to disable the Designer Shoreline App. This feature is not supported in WebView2. |
 | `msEdgeDesignerDriverFix ` |  Use this flag to disable getting content and automatically showing the Designer feature. This feature is not supported in WebView2. |

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 05/29/2024
+ms.date: 03/10/2025
 ---
 # WebView2 browser flags
 
@@ -104,11 +104,13 @@ The following are some of the flags we've seen used.
 | `incognito` | Forces Incognito mode even if user data directory is specified by using the `--user-data-dir` flag. |
 | `isolate-origins` | Require dedicated processes for a set of origins, specified as a comma-separated list. For example: --isolate-origins=https://www.foo.com,https://www.bar.com. |
 | `js-flags` | Specifies the flags passed to JS engine. |
+| `--js-flags=--scavenger_max_new_space_capacity_mb=8` | This flag specifies the maximum limit (in MB) for scavenger (minor garbage collector) in V8.  <br/>A higher scavenger memory limit reduces the frequency of minor garbage collectors, but increases memory usage.  <br/>A lower limit reduces memory footprint, but increases garbage collectors frequency, which may impact performance. |
 | `lang` | The language file that WebView2 want to try to open. Of the form language[-country] where language is the 2-letter code from ISO-639. |
 | `log-net-log` | Enables saving net log events to a file.  If a value is given, that value is used as the directory path and file name.  If no value is given, the file is named `netlog.json`, and is placed in the user data directory. |
 | `msAbydos` | Enables the "handwriting-to-text" experience. |
 | `msAbydosGestureSupport` | Allows users to use gestures (such as the scratchout gesture) to delete text by using a pen.  Valid only if the `msAbydos` flag is enabled. |
 | `msAbydosHandwritingAttr` | Whether the "handwriting-to-text" experience is enabled for input elements at the DOM level.  Valid only if the `msAbydos` flag is enabled. |
+| `msAllowAmbientAuthInPrivateWebView2` | This flag is to be used along with the `msSingleSignOnForInPrivateWebView2` browser browser flag, to enable SSO with default credential flow or ambient authentication flow. |
 | `msEdgeDesignerUI` | Use this flag to disable the Designer Shoreline App. This feature is not supported in WebView2. |
 | `msEdgeHubAppDesigner ` | Use this flag to disable the Designer Shoreline App. This feature is not supported in WebView2. |
 | `msEdgeDesignerDriverFix ` |  Use this flag to disable getting content and automatically showing the Designer feature. This feature is not supported in WebView2. |
@@ -121,6 +123,7 @@ The following are some of the flags we've seen used.
 | `msFloatyShouldHonorIndiaHoldout` | If `true`, honors the India holdout group.  Use this flag, set to `false`, to disable the Floaty feature that's enabled if the user is part of the India holdout group, because WebView doesn't support browser retention experiments. |
 | `msOverlayScrollbarWinStyle` | Whether the users can change between overlay and non-overlay modes for Fluent scrollbars. |
 | `msPdfEnableAsPreview` | This features enables the PDF viewer to launch with a minimal toolbar and in read-only preview mode. |
+| `msSingleSignOnForInPrivateWebView2` | This flag enables the single sign-on (SSO) flow for incognito/private session<!-- todo: InPrivate? --> of WebView2.  Browser-based SSO should seamlessly work in incognito<!-- todo: InPrivate? --> mode after enabling this flag. |
 | `msSingleSignOnOSForPrimaryAccountIsShared` | If enabled, allows implicit sign-in to Microsoft webpages using any account, by using the information from the primary OS account. |
 | `msSmartScreenProtection` | If enabled, SmartScreen protection will be available. |
 | `msUseSpellCheckCorrectionsCard` | If enabled, a new corrections card UI is shown when the user clicks a misspelled word. |

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -123,7 +123,7 @@ The following are some of the flags we've seen used.
 | `msFloatyShouldHonorIndiaHoldout` | If `true`, honors the India holdout group.  Use this flag, set to `false`, to disable the Floaty feature that's enabled if the user is part of the India holdout group, because WebView doesn't support browser retention experiments. |
 | `msOverlayScrollbarWinStyle` | Whether the users can change between overlay and non-overlay modes for Fluent scrollbars. |
 | `msPdfEnableAsPreview` | This features enables the PDF viewer to launch with a minimal toolbar and in read-only preview mode. |
-| `msSingleSignOnForInPrivateWebView2` | This flag enables the single sign-on (SSO) flow for InPrivate (Incognito) sessions of WebView2.  Browser-based SSO should<!-- todo: style guide: avoid "should" https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/s/should-vs-must --> seamlessly work in InPrivate (Incognito) mode after enabling this flag. |
+| `msSingleSignOnForInPrivateWebView2` | This flag enables the single sign-on (SSO) flow for an InPrivate (Incognito) session of WebView2.  Browser-based SSO should<!-- todo: style guide: avoid "should" https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/s/should-vs-must --> seamlessly work in InPrivate (Incognito) mode after enabling this flag. |
 | `msSingleSignOnOSForPrimaryAccountIsShared` | If enabled, allows implicit sign-in to Microsoft webpages using any account, by using the information from the primary OS account. |
 | `msSmartScreenProtection` | If enabled, SmartScreen protection will be available. |
 | `msUseSpellCheckCorrectionsCard` | If enabled, a new corrections card UI is shown when the user clicks a misspelled word. |

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -104,7 +104,7 @@ The following are some of the flags we've seen used.
 | `incognito` | Forces InPrivate (Incognito) mode even if the user data directory is specified by using the `--user-data-dir` flag. |
 | `isolate-origins` | Require dedicated processes for a set of origins, specified as a comma-separated list. For example: --isolate-origins=https://www.foo.com,https://www.bar.com. |
 | `js-flags` | Specifies the flags passed to JS engine. |
-| `--js-flags=--scavenger_max_new_space_capacity_mb=8` | This flag specifies the maximum limit (in MB) for scavenger (minor garbage collector) in V8.  <br/>A higher scavenger memory limit reduces the frequency of minor garbage collectors, but increases memory usage.  <br/>A lower limit reduces memory footprint, but increases garbage collectors frequency, which may impact performance. |
+| `--js-flags=--scavenger_max_new_space_capacity_mb=8` | Specifies the maximum limit (in MB) for scavenger (minor) garbage collectors in the V8 JavaScript engine.  <br/>A lower scavenger memory limit reduces memory usage, and increases the frequency of running minor garbage collectors.  <br/>A higher scavenger memory limit increases memory usage, and reduces the frequency of running minor garbage collectors. |
 | `lang` | The language file that WebView2 want to try to open. Of the form language[-country] where language is the 2-letter code from ISO-639. |
 | `log-net-log` | Enables saving net log events to a file.  If a value is given, that value is used as the directory path and file name.  If no value is given, the file is named `netlog.json`, and is placed in the user data directory. |
 | `msAbydos` | Enables the "handwriting-to-text" experience. |


### PR DESCRIPTION
Rendered article sections for review:
* **WebView2 browser flags** > **Available WebView2 browser flags**
   * `/webview2/concepts/webview-features-flags.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags?branch=pr-en-us-3402#available-webview2-browser-flags
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/flags-sso/microsoft-edge/webview2/concepts/webview-features-flags.md#available-webview2-browser-flags
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags#available-webview2-browser-flags
   * Added rows:
      * `--js-flags=--scavenger_max_new_space_capacity_mb=8`
      * `msAllowAmbientAuthInPrivateWebView2`
      * `msSingleSignOnForInPrivateWebView2`
   * Changed `incognito` row to: Forces InPrivate (Incognito) mode ...

* **Differences between Microsoft Edge and WebView2** > **Shortcuts that are turned off**
   * `/webview2/concepts/browser-features.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/browser-features?branch=pr-en-us-3402#shortcuts-that-are-turned-off
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/flags-sso/microsoft-edge/webview2/concepts/browser-features.md#shortcuts-that-are-turned-off
   * Before/live: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/browser-features#shortcuts-that-are-turned-off
   * Worded keyboard shortcut as: "New InPrivate (Incognito) Window"

AB#56636621
