### PR TITLE
Add js-flags/scavenger example in "WebView2 browser flags"

### DIFF
--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -102,8 +102,8 @@ The following are some of the flags we've seen used.
 | `ignore-certificate-errors` | Ignores certificate-related errors. |
 | `ignore-gpu-blocklist` | Whether to ignore the GPU blocklist. |
 | `incognito` | Forces InPrivate (Incognito) mode even if the user data directory is specified by using the `--user-data-dir` flag. |
-| `isolate-origins` | Require dedicated processes for a set of origins, specified as a comma-separated list. For example: --isolate-origins=https://www.foo.com,https://www.bar.com. |
-| `js-flags` | Specifies the flags passed to the JS engine.  Available flags: `scavenger_max_new_space_capacity_mb`: Specifies the maximum limit (in MB) for scavenger (minor) garbage collectors in the V8 JavaScript engine.  <br/>A lower scavenger memory limit reduces memory usage, and increases the frequency of running minor garbage collectors.  <br/>A higher scavenger memory limit increases memory usage, and reduces the frequency of running minor garbage collectors. |
+| `isolate-origins` | Require dedicated processes for a set of origins, specified as a comma-separated list. For example: `--isolate-origins=https://www.foo.com,https://www.bar.com`. |
+| `js-flags` | Specifies the flags passed to the JS engine.  Available flags: `scavenger_max_new_space_capacity_mb`: Specifies the maximum limit (in MB) for scavenger (minor) garbage collectors in the V8 JavaScript engine.  <br/>A lower scavenger memory limit reduces memory usage, and increases the frequency of running minor garbage collectors.  <br/>A higher scavenger memory limit increases memory usage, and reduces the frequency of running minor garbage collectors.  For example: `--js-flags=--scavenger_max_new_space_capacity_mb=8`.  |
 | `lang` | The language file that WebView2 want to try to open. Of the form language[-country] where language is the 2-letter code from ISO-639. |
 | `log-net-log` | Enables saving net log events to a file.  If a value is given, that value is used as the directory path and file name.  If no value is given, the file is named `netlog.json`, and is placed in the user data directory. |
 | `msAbydos` | Enables the "handwriting-to-text" experience. |


### PR DESCRIPTION
Rendered article sections for review:
* **WebView2 browser flags** > **Available WebView2 browser flags**
   * `/webview2/concepts/webview-features-flags.md`
   * Internal preview: 
   * External preview: 
   * Before/live: 
   * In `isolate-origins` row, added backticks on example. 
   * In `js-flags` row, added `scavenger_max_new_space_capacity_mb` example.

AB# pending
