### PR TITLE
Remove fetchLater() from "Edge 134 web platform release notes (Mar. 2025)"

### DIFF
--- a/microsoft-edge/web-platform/release-notes/134.md
+++ b/microsoft-edge/web-platform/release-notes/134.md
@@ -32,7 +32,6 @@ To stay up-to-date and get the latest web platform features, download an Insider
     * [Private Aggregation API: per-context contribution limits for Shared Storage callers](#private-aggregation-api-per-context-contribution-limits-for-shared-storage-callers)
     * [Support `imageSmoothingQuality` in CSS Painting API](#support-imagesmoothingquality-in-css-painting-api)
     * [WebGPU Subgroups](#webgpu-subgroups)
-    * [`fetchLater()`](#fetchlater)
     * [Support Web Locks API in Shared Storage](#support-web-locks-api-in-shared-storage)
 * [Origin trials](#origin-trials)
   * [Microsoft Edge-only origin trials](#microsoft-edge-only-origin-trials)
@@ -190,18 +189,6 @@ See also:
 The subgroups WbGPU feature allows SIMD parallelism.  By using subgroups, threads within a group can perform collective operations.  This provides efficient communication and data sharing among groups of invocations.  These operations can be used to accelerate applications, by reducing memory overhead that's incurred by inter-invocation communication.
 
 See [WebGPU API](https://developer.mozilla.org/docs/Web/API/WebGPU_API) at MDN.
-
-
-<!-- ---------- -->
-###### `fetchLater()`
-
-The `fetchLater()` JavaScript method requests a deferred fetch.  After this method is called, the network request is queued by the browser, and is then invoked either:
-* When the document is destroyed.
-* After a certain time.<!-- todo: after a specified duration? -->
-
-The method returns a `FetchLaterResult` that contains a boolean field.  The value of the boolean field is updated when the deferred request has been sent.  When the request is successfully sent, the response is ignored by browser, including its body and headers.
-
-See [Window: fetch() method](https://developer.mozilla.org/docs/Web/API/Window/fetch) at MDN.
 
 
 <!-- ---------- -->


### PR DESCRIPTION
The `fetchLayer()` method did not ship with 134, as initially intended, it shipped in 135, and the 135 release notes correctly contains a note about it. So this PR removes the note from the 134 release notes.

Rendered article section for review:
* **Microsoft Edge 134 web platform release notes (Mar. 2025)** > **fechlater()**
   * `/web-platform/release-notes/134.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/134?branch=pr-en-us-3408#fetchlater
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/fetchlater/microsoft-edge/web-platform/release-notes/134.md#fetchlater
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/134#fetchlater
   * Removed the **fechlater()** h6 section & its local-toc entry.
   * Note that the section heading in 135 is "fetchLater API", and has slightly different content than the removed 134 section.
   https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/135#fetchlater-api

AB#56690278
