### PR TITLE
Add ./ prefix in every source_path in Redirects file

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1339,602 +1339,602 @@
 // ============================================================================
 // Archived EdgeHTML content
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/autoplay-policies",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/autoplay-policies.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/flash",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/flash.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/reading-view",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/reading-view.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/search-provider-discovery",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/search-provider-discovery.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/index",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-12",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-12.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-13",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-13.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-14",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-14.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-15",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-15.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-16",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-16.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-17",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-17.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/javascript-version-information",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/javascript-version-information.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/payment-request-api",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/payment-request-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/web-authentication",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/web-authentication.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/web-notifications-api",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/web-notifications-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/command-line",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/command-line.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/console-api",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/console-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/error-and-status-codes",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/error-and-status-codes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/debugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/debugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/accessibility",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/accessibility.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/changes",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/changes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/computed",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/computed.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/dom-breakpoints",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/dom-breakpoints.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/events",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/events.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/fonts",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/fonts.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/styles",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/styles.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/emulation",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/emulation.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/memory",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/memory.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/network",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/network.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/performance",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/performance.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/service-workers",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/service-workers.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/storage",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/storage.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-16",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-16.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-17",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-17.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/clients",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/clients.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/debugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/debugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/page",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/page.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/runtime",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/schema",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/schema.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/http",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/http.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/clients",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/clients.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/css",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/css.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/debugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/debugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/dom",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/dom.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/domdebugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/domdebugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/overlay",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/overlay.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/page",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/page.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/runtime",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/schema",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/schema.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/http",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/http.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/api-support",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/extension-api-roadmap",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/extension-api-roadmap.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-apis",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-apis.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys/json-manifest-example",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys/json-manifest-example.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/extensions-for-enterprise",
+        "source_path": "./microsoft-edge/edgehtml/extensions/extensions-for-enterprise.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/getting-started",
+        "source_path": "./microsoft-edge/edgehtml/extensions/getting-started.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/accessibility",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/accessibility.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/adding-and-removing-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/adding-and-removing-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/creating-an-extension",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/creating-an-extension.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/debugging-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/debugging-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/design",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/design.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/internationalization",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/internationalization.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/native-messaging",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/native-messaging.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/creating-and-testing-extension-packages",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/creating-and-testing-extension-packages.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/extensions-in-the-windows-dev-center",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/extensions-in-the-windows-dev-center.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/localizing-extension-packages",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/localizing-extension-packages.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/running-the-windows-app-certification-kit",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/running-the-windows-app-certification-kit.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/using-manifoldjs-to-package-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/using-manifoldjs-to-package-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/guides/porting-chrome-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/porting-chrome-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/index",
+        "source_path": "./microsoft-edge/edgehtml/extensions/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/tips-and-tricks",
+        "source_path": "./microsoft-edge/edgehtml/extensions/tips-and-tricks.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/extensions/troubleshooting",
+        "source_path": "./microsoft-edge/edgehtml/extensions/troubleshooting.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/hosting-the-javascript-runtime",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/hosting-the-javascript-runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-propertyid-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-propertyid-constant.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-reference-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-reference-constant.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-runtime-handle-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-runtime-handle-constant.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-source-context-none-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-source-context-none-constant.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsaddref-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsaddref-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbackgroundworkitemcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbackgroundworkitemcallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbeforecollectcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbeforecollectcallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooleantobool-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooleantobool-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooltoboolean-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooltoboolean-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscallfunction-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscallfunction-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscollectgarbage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscollectgarbage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconstructobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconstructobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscontextref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscontextref-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoboolean-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoboolean-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetonumber-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetonumber-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetostring-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetostring-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearray-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearray-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearraybuffer-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearraybuffer-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatecontext-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatecontext-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatedataview-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatedataview-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalarraybuffer-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalarraybuffer-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatefunction-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatefunction-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatenamedfunction-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatenamedfunction-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreaterangeerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreaterangeerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatereferenceerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatereferenceerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateruntime-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateruntime-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesymbol-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesymbol-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
@@ -1944,747 +1944,747 @@
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypedarray-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypedarray-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypeerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypeerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateurierror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateurierror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdefineproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdefineproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisableruntimeexecution-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisableruntimeexecution-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisposeruntime-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisposeruntime-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdoubletonumber-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdoubletonumber-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsenableruntimeexecution-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsenableruntimeexecution-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsenumerateheap-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsenumerateheap-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsequals-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsequals-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jserrorcode-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jserrorcode-enumeration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsfinalizecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsfinalizecallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetandclearexception-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetandclearexception-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetarraybufferstorage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetarraybufferstorage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextdata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextdata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextofobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextofobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcurrentcontext-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcurrentcontext-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetdataviewstorage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetdataviewstorage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetextensionallowed-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetextensionallowed-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetfalsevalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetfalsevalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetglobalobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetglobalobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetnullvalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetnullvalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertydescriptor-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertydescriptor-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertynames-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertynames-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertysymbols-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertysymbols-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromname-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromname-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidtype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidtype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertynamefromid-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertynamefromid-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetprototype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetprototype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntime-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntime-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememorylimit-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememorylimit-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememoryusage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememoryusage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetstringlength-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetstringlength-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettruevalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettruevalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarrayinfo-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarrayinfo-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarraystorage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarraystorage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetundefinedvalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetundefinedvalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetvaluetype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetvaluetype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexception-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexception-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsidle-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsidle-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinspectabletoobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinspectabletoobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinstanceof-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinstanceof-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinttonumber-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinttonumber-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsisenumeratingheap-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsisenumeratingheap-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryallocationcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryallocationcallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryeventtype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryeventtype-enumeration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnativefunction-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnativefunction-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertodouble-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertodouble-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertoint-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertoint-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjectbeforecollectcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjectbeforecollectcallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjecttoinspectable-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjecttoinspectable-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparsescript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparsescript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspointertostring-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspointertostring-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspreventextension-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspreventextension-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallbackcontext-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallbackcontext-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectionenqueuecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectionenqueuecallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectwinrtnamespace-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectwinrtnamespace-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspromisecontinuationcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspromisecontinuationcallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidref-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidtype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidtype-enumeration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsref-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrelease-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrelease-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunscript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunscript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeattributes-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeattributes-enumeration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimehandle-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimehandle-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeversion-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeversion-enumeration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptloadsourcecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptloadsourcecallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptunloadcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptunloadcallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializescript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializescript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcontextdata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcontextdata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcurrentcontext-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcurrentcontext-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexception-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexception-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprojectionenqueuecallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprojectionenqueuecallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetpromisecontinuationcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetpromisecontinuationcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprototype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprototype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememorylimit-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememorylimit-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssourcecontext-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssourcecontext-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartdebugging-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartdebugging-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartprofiling-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartprofiling-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstopprofiling-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstopprofiling-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstrictequals-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstrictequals-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstringtopointer-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstringtopointer-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsthreadservicecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsthreadservicecallback-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jstypedarraytype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jstypedarraytype-enumeration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvalueref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvalueref-typedef.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetovariant-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetovariant-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetype-enumeration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvarianttovalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvarianttovalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/reference-javascript-runtime",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/reference-javascript-runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/javascript-runtime-hosting",
+        "source_path": "./microsoft-edge/edgehtml/hosting/javascript-runtime-hosting.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/deferredpermissionrequest",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/deferredpermissionrequest.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/focusnavigationevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/focusnavigationevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/index",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/longrunningscriptdetectedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/longrunningscriptdetectedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewasyncoperation",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewasyncoperation.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewprocess",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewprocess.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewsettings",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewsettings.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationcompletedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationcompletedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationeventwithreferrer",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationeventwithreferrer.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/permissionrequest",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/permissionrequest.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/permissionrequestedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/permissionrequestedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/scriptnotifyevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/scriptnotifyevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/unviewablecontentidentifiedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/unviewablecontentidentifiedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/webview/webresourcerequestedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/webresourcerequestedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/index",
+        "source_path": "./microsoft-edge/edgehtml/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/performance-analysis/index",
+        "source_path": "./microsoft-edge/edgehtml/performance-analysis/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/get-started",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/get-started.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/index",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/microsoft-store",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/microsoft-store.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/windows-features",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/windows-features.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/xbox-considerations",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/xbox-considerations.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/webdriver/index",
+        "source_path": "./microsoft-edge/edgehtml/webdriver/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/considerations-when-using-the-windows-runtime-api",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/considerations-when-using-the-windows-runtime-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/error-codes-for-windows-runtime-apps-using-javascript",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/error-codes-for-windows-runtime-apps-using-javascript.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/handling-windows-runtime-events-in-javascript",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/handling-windows-runtime-events-in-javascript.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/index",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/javascript-representation-of-windows-runtime-types",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/javascript-representation-of-windows-runtime-types.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/reference/msapp",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/reference/msapp.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/special-error-properties-from-asynchronous-windows-runtime-methods",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/special-error-properties-from-asynchronous-windows-runtime-methods.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/using-the-windows-runtime-in-javascript",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/using-the-windows-runtime-in-javascript.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/using-windows-runtime-asynchronous-methods",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/using-windows-runtime-asynchronous-methods.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/windows-runtime/windows-runtime-datetime-and-timespan-representations",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/windows-runtime-datetime-and-timespan-representations.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1939,7 +1939,7 @@
         "redirect_document_id": false
       },
       {
-        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesyntaxerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesyntaxerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -34,108 +34,108 @@
 // Microsoft Edge DevTools
       {
         // legacy "Overview of DevTools" url redirects to DevTools landing
-        "source_path": "microsoft-edge/devtools-guide-chromium/index.md", 
+        "source_path": "./microsoft-edge/devtools-guide-chromium/index.md", 
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/landing/index",
         "redirect_document_id": false
       },
       {
         // "Open DevTools" url redirects to "Overview of DevTools"
-        "source_path": "microsoft-edge/devtools-guide-chromium/open/index.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/open/index.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/overview",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/experimental-features/focus-mode.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/experimental-features/focus-mode.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/overview",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/experimental-features/copilot-explain.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/experimental-features/copilot-explain.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/console/copilot-explain-console",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/experimental-features/edge-command-palette.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/experimental-features/edge-command-palette.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/whats-new/2024/03/devtools-123#command-palette-experimental-feature-has-been-removed",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/beginners/css.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/beginners/css.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/css",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/beginners/html.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/beginners/html.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/dom",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/console/javascript.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/console/javascript.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/console/console-javascript",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/layers/layers-tool.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/layers/layers-tool.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/3d-view/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/console/log.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/console/log.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/console/console-log",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/storage/applicationcache.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/storage/applicationcache.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/customize/dark-theme.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/customize/dark-theme.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/landing/",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/customize/theme.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/customize/theme.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/landing/",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/about-panel-drawer-tools.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/about-panel-drawer-tools.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/accessibility/accessibility-testing-in-devtools.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/accessibility/accessibility-testing-in-devtools.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/accessibility/reference",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/javascript-profiler/javascript-profiler-tool.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/javascript-profiler/javascript-profiler-tool.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/performance/",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/evaluate-performance/index.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/performance/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/evaluate-performance/reference.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/evaluate-performance/reference.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/performance/reference",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/evaluate-performance/performance-reference.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/evaluate-performance/performance-reference.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/performance/performance-reference",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/evaluate-performance/unminify.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/evaluate-performance/unminify.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/performance/unminify",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide-chromium/evaluate-performance/selector-stats.md",
+        "source_path": "./microsoft-edge/devtools-guide-chromium/evaluate-performance/selector-stats.md",
         "redirect_url": "/microsoft-edge/devtools-guide-chromium/performance/selector-stats",
         "redirect_document_id": false
       },
@@ -148,73 +148,73 @@
 // ============================================================================
 // Microsoft Edge extensions
       {
-        "source_path": "microsoft-edge/extensions-chromium/enterprise/declare-permissions.md",
+        "source_path": "./microsoft-edge/extensions-chromium/enterprise/declare-permissions.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/developer-guide/declare-permissions",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/enterprise/match-patterns.md",
+        "source_path": "./microsoft-edge/extensions-chromium/enterprise/match-patterns.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/developer-guide/match-patterns",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/enterprise/hosting-and-updating.md",
+        "source_path": "./microsoft-edge/extensions-chromium/enterprise/hosting-and-updating.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/publish/hosting-and-updating",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/publish/contact-us.md",
+        "source_path": "./microsoft-edge/extensions-chromium/publish/contact-us.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/publish/contact-extensions-team",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/publish/upload-video.md",
+        "source_path": "./microsoft-edge/extensions-chromium/publish/upload-video.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/publish/publish-extension",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/store-policies/csp.md",
+        "source_path": "./microsoft-edge/extensions-chromium/store-policies/csp.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/developer-guide/csp",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/getting-started/part1-simple-extension.md",
+        "source_path": "./microsoft-edge/extensions-chromium/getting-started/part1-simple-extension.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/getting-started/picture-viewer-popup-webpage",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/getting-started/part2-content-scripts.md",
+        "source_path": "./microsoft-edge/extensions-chromium/getting-started/part2-content-scripts.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/getting-started/picture-inserter-content-script",
         "redirect_document_id": false
       },
 // Extensions > Update
       {
-        "source_path": "microsoft-edge/extensions-chromium/publish/update.md",
+        "source_path": "./microsoft-edge/extensions-chromium/publish/update.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/publish/update-extension",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/enterprise/auto-update.md",
+        "source_path": "./microsoft-edge/extensions-chromium/enterprise/auto-update.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/publish/auto-update",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/publish/update-extension.md",
+        "source_path": "./microsoft-edge/extensions-chromium/publish/update-extension.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/update/update-extension",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/publish/api/using-addons-api.md",
+        "source_path": "./microsoft-edge/extensions-chromium/publish/api/using-addons-api.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/update/api/using-addons-api",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md",
+        "source_path": "./microsoft-edge/extensions-chromium/publish/api/addons-api-reference.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/update/api/addons-api-reference",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/publish/auto-update.md",
+        "source_path": "./microsoft-edge/extensions-chromium/publish/auto-update.md",
         "redirect_url": "/microsoft-edge/extensions-chromium/update/auto-update",
         "redirect_document_id": false
       },
@@ -227,47 +227,47 @@
 // ============================================================================
 // Progressive Web Apps
       {
-        "source_path": "microsoft-edge/progressive-web-apps/index.md",
+        "source_path": "./microsoft-edge/progressive-web-apps/index.md",
         "redirect_url": "/microsoft-edge/progressive-web-apps-chromium/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/serviceworker.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/serviceworker.md",
         "redirect_url": "/microsoft-edge/progressive-web-apps-chromium/how-to/service-workers",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/webappmanifests.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/webappmanifests.md",
         "redirect_url": "/microsoft-edge/progressive-web-apps-chromium/how-to/web-app-manifests",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/get-started.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/get-started.md",
         "redirect_url": "/microsoft-edge/progressive-web-apps-chromium/how-to/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/experimental-features/index.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/experimental-features/index.md",
         "redirect_url": "/microsoft-edge/origin-trials/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/how-to/origin-trials.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/how-to/origin-trials.md",
         "redirect_url": "/microsoft-edge/origin-trials/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/offline.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/offline.md",
         "redirect_url": "/microsoft-edge/progressive-web-apps-chromium/how-to/offline",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/how-to/web-app-manifests.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/how-to/web-app-manifests.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-chromium/how-to/service-workers.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-chromium/how-to/service-workers.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Service_Worker_API/Using_Service_Workers",
         "redirect_document_id": false
       },
@@ -275,95 +275,95 @@
 // ============================================================================
 // WebView2
       {
-        "source_path": "microsoft-edge/hosting/webview2.md",
+        "source_path": "./microsoft-edge/hosting/webview2.md",
         "redirect_url": "/microsoft-edge/webview2/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview2/gettingstarted.md",
+        "source_path": "./microsoft-edge/hosting/webview2/gettingstarted.md",
         "redirect_url": "/microsoft-edge/webview2/get-started/win32",
         "redirect_document_id": false
       },
 
       // WebView2 Concepts:
       {
-        "source_path": "microsoft-edge/webview2/concepts/browserfeatures.md",
+        "source_path": "./microsoft-edge/webview2/concepts/browserfeatures.md",
         "redirect_url": "/microsoft-edge/webview2/concepts/browser-features",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/concepts/userdatafolder.md",
+        "source_path": "./microsoft-edge/webview2/concepts/userdatafolder.md",
         "redirect_url": "/microsoft-edge/webview2/concepts/user-data-folder",
         "redirect_document_id": false
       },
 
       // WebView2 Getting started:
       {
-        "source_path": "microsoft-edge/webview2/gettingstarted/win32.md",
+        "source_path": "./microsoft-edge/webview2/gettingstarted/win32.md",
         "redirect_url": "/microsoft-edge/webview2/get-started/win32",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/gettingstarted/winforms.md",
+        "source_path": "./microsoft-edge/webview2/gettingstarted/winforms.md",
         "redirect_url": "/microsoft-edge/webview2/get-started/winforms",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/gettingstarted/winui.md",
+        "source_path": "./microsoft-edge/webview2/gettingstarted/winui.md",
         "redirect_url": "/microsoft-edge/webview2/get-started/winui",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/gettingstarted/wpf.md",
+        "source_path": "./microsoft-edge/webview2/gettingstarted/wpf.md",
         "redirect_url": "/microsoft-edge/webview2/get-started/wpf",
         "redirect_document_id": false
       },
 
       // WebView2 How-to:
       {
-        "source_path": "microsoft-edge/webview2/howto/chromium-devtools-protocol.md",
+        "source_path": "./microsoft-edge/webview2/howto/chromium-devtools-protocol.md",
         "redirect_url": "/microsoft-edge/webview2/how-to/chromium-devtools-protocol",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/howto/debug.md",
+        "source_path": "./microsoft-edge/webview2/howto/debug.md",
         "redirect_url": "/microsoft-edge/webview2/how-to/debug",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/howto/js.md",
+        "source_path": "./microsoft-edge/webview2/howto/js.md",
         "redirect_url": "/microsoft-edge/webview2/how-to/javascript",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/howto/static.md",
+        "source_path": "./microsoft-edge/webview2/howto/static.md",
         "redirect_url": "/microsoft-edge/webview2/how-to/static",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/howto/webdriver.md",
+        "source_path": "./microsoft-edge/webview2/howto/webdriver.md",
         "redirect_url": "/microsoft-edge/webview2/how-to/webdriver",
         "redirect_document_id": false
       },
 
       // WebView2 Release Notes:
       {
-        "source_path": "microsoft-edge/hosting/webview2/releasenotes.md",
+        "source_path": "./microsoft-edge/hosting/webview2/releasenotes.md",
         "redirect_url": "/microsoft-edge/webview2/release-notes/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/releasenotes.md",
+        "source_path": "./microsoft-edge/webview2/releasenotes.md",
         "redirect_url": "/microsoft-edge/webview2/release-notes/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/release-notes.md",
+        "source_path": "./microsoft-edge/webview2/release-notes.md",
         "redirect_url": "/microsoft-edge/webview2/release-notes/index",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/release-notes/template-prerelease.md",
+        "source_path": "./microsoft-edge/webview2/release-notes/template-prerelease.md",
         "redirect_url": "/microsoft-edge/webview2/release-notes/index",
         "redirect_document_id": false
       },
@@ -375,478 +375,478 @@
 
       // WebView2 Reference:
       {
-        "source_path": "microsoft-edge/hosting/webview2/reference/icorewebview2.md",
+        "source_path": "./microsoft-edge/hosting/webview2/reference/icorewebview2.md",
         "redirect_url": "/microsoft-edge/webview2/reference/win32/icorewebview2",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview2/reference-webview2.md",
+        "source_path": "./microsoft-edge/hosting/webview2/reference-webview2.md",
         "redirect_url": "/microsoft-edge/webview2/webview2-api-reference",
         "redirect_document_id": false
       },
 
       // WebView2 Reference > .NET:
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515-reference-webview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515-reference-webview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538-reference-webview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538-reference-webview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628-reference-webview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628-reference-webview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/namespace-microsoft-web-webview2-core.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/namespace-microsoft-web-webview2-core.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/namespace-microsoft-web-webview2-core.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/namespace-microsoft-web-webview2-core.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/namespace-microsoft-web-webview2-core.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/namespace-microsoft-web-webview2-core.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2acceleratorkeypressedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2acceleratorkeypressedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2acceleratorkeypressedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2contentloadingeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2contentloadingeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2contentloadingeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2controller.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2controller.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2controller",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2deferral.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2deferral.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2deferral",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceiver.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceiver.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceiver",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2environment.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2environment.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2environment",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2environmentoptions.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2environmentoptions.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2movefocusrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2movefocusrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2movefocusrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2navigationcompletedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2navigationcompletedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2navigationcompletedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2navigationstartingeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2navigationstartingeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2navigationstartingeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2newwindowrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2newwindowrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2newwindowrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2permissionrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2permissionrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2permissionrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2physicalkeystatus.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2physicalkeystatus.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2physicalkeystatus",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2processfailedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2processfailedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2scriptdialogopeningeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2scriptdialogopeningeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2scriptdialogopeningeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2settings.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2settings.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2settings",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2sourcechangedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2sourcechangedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2sourcechangedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2webmessagereceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2webmessagereceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2webresourcerequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-corewebview2webresourcerequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webresourcerequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-edgenotfoundexception.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-515/microsoft-web-webview2-core-edgenotfoundexception.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.edgenotfoundexception",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2acceleratorkeypressedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2acceleratorkeypressedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2acceleratorkeypressedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2compositioncontroller.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2compositioncontroller.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2contentloadingeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2contentloadingeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2contentloadingeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2controller.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2controller.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2controller",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2deferral.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2deferral.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2deferral",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceiver.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceiver.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceiver",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2environment.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2environment.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2environment",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2environmentoptions.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2environmentoptions.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2matrix4x4.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2matrix4x4.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2matrix4x4",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2movefocusrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2movefocusrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2movefocusrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2navigationcompletedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2navigationcompletedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2navigationcompletedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2navigationstartingeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2navigationstartingeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2navigationstartingeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2newwindowrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2newwindowrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2newwindowrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2permissionrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2permissionrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2permissionrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2physicalkeystatus.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2physicalkeystatus.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2physicalkeystatus",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2pointerinfo.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2pointerinfo.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2pointerinfo",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2processfailedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2processfailedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2scriptdialogopeningeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2scriptdialogopeningeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2scriptdialogopeningeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2settings.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2settings.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2settings",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2sourcechangedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2sourcechangedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2sourcechangedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2webmessagereceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2webmessagereceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2webresourcerequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2webresourcerequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webresourcerequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2webresourceresponsereceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2webresourceresponsereceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webresourceresponsereceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2windowfeatures.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-corewebview2windowfeatures.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2windowfeatures",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-edgenotfoundexception.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-538/microsoft-web-webview2-core-edgenotfoundexception.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.edgenotfoundexception",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2acceleratorkeypressedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2acceleratorkeypressedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2acceleratorkeypressedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2compositioncontroller.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2compositioncontroller.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2compositioncontroller",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2contentloadingeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2contentloadingeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2contentloadingeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2controller.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2controller.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2controller",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2deferral.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2deferral.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2deferral",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceiver.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2devtoolsprotocoleventreceiver.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2devtoolsprotocoleventreceiver",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2environment.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2environment.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2environment",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2environmentoptions.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2environmentoptions.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2environmentoptions",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2httpheaderscollectioniterator.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2httpheaderscollectioniterator.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2httpheaderscollectioniterator",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2httprequestheaders.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2httprequestheaders.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2httprequestheaders",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2httpresponseheaders.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2httpresponseheaders.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2httpresponseheaders",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2matrix4x4.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2matrix4x4.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2matrix4x4",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2movefocusrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2movefocusrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2movefocusrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2navigationcompletedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2navigationcompletedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2navigationcompletedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2navigationstartingeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2navigationstartingeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2navigationstartingeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2newwindowrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2newwindowrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2newwindowrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2permissionrequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2permissionrequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2permissionrequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2physicalkeystatus.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2physicalkeystatus.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2physicalkeystatus",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2pointerinfo.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2pointerinfo.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2pointerinfo",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2processfailedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2processfailedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2scriptdialogopeningeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2scriptdialogopeningeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2scriptdialogopeningeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2settings.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2settings.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2settings",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2sourcechangedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2sourcechangedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2sourcechangedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webmessagereceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webmessagereceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webmessagereceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourcerequest.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourcerequest.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webresourcerequest",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourcerequestedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourcerequestedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webresourcerequestedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourceresponse.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourceresponse.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webresourceresponse",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourceresponsereceivedeventargs.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2webresourceresponsereceivedeventargs.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2webresourceresponsereceivedeventargs",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2windowfeatures.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-corewebview2windowfeatures.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.corewebview2windowfeatures",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-edgenotfoundexception.md",
+        "source_path": "./microsoft-edge/webview2/reference/dotnet/0-9-628/microsoft-web-webview2-core-edgenotfoundexception.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.core.edgenotfoundexception",
         "redirect_document_id": false
       },
 
       // WebView2 Reference > WinForms:
       {
-        "source_path": "microsoft-edge/webview2/reference/winforms/0-9-515-reference-webview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/winforms/0-9-515-reference-webview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.winforms",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/winforms/0-9-515/microsoft-web-webview2-winforms-webview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/winforms/0-9-515/microsoft-web-webview2-winforms-webview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.winforms.webview2",
         "redirect_document_id": false
       },
 
       // WebView2 Reference > WPF:
       {
-        "source_path": "microsoft-edge/webview2/reference/wpf/0-9-515-reference-webview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/wpf/0-9-515-reference-webview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.wpf",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/wpf/0-9-515/microsoft-web-webview2-wpf-corewebview2creationproperties.md",
+        "source_path": "./microsoft-edge/webview2/reference/wpf/0-9-515/microsoft-web-webview2-wpf-corewebview2creationproperties.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.wpf.corewebview2creationproperties",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview2/reference/wpf/0-9-515/microsoft-web-webview2-wpf-webview2.md",
+        "source_path": "./microsoft-edge/webview2/reference/wpf/0-9-515/microsoft-web-webview2-wpf-webview2.md",
         "redirect_url": "/dotnet/api/microsoft.web.webview2.wpf.webview2",
         "redirect_document_id": false
       },
@@ -857,7 +857,7 @@
 // ============================================================================
 // Edge-specific web development tips
       {
-        "source_path": "microsoft-edge/web-platform/user-agent-string.md",
+        "source_path": "./microsoft-edge/web-platform/user-agent-string.md",
         "redirect_url": "/microsoft-edge/web-platform/user-agent-guidance",
         "redirect_document_id": false
       },
@@ -870,17 +870,17 @@
 // ============================================================================
 // Microsoft Edge IDE integration
       {
-        "source_path": "microsoft-edge/visual-studio-code/index.md",
+        "source_path": "./microsoft-edge/visual-studio-code/index.md",
         "redirect_url": "/microsoft-edge/visual-studio-code/ide-integration",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/visual-studio-code/elements-for-edge.md",
+        "source_path": "./microsoft-edge/visual-studio-code/elements-for-edge.md",
         "redirect_url": "/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/visual-studio-code/webhint.md",
+        "source_path": "./microsoft-edge/visual-studio-code/webhint.md",
         "redirect_url": "/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension",
         "redirect_document_id": false
       },
@@ -895,34 +895,34 @@
 // Redirects to Legal
       // DevTools:
       {
-        "source_path": "microsoft-edge/devtools-guide/devtools-preview_software-license-terms.md",
+        "source_path": "./microsoft-edge/devtools-guide/devtools-preview_software-license-terms.md",
         "redirect_url": "https://learn.microsoft.com/legal/microsoft-edge/devtools-preview_software-license-terms",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/devtools_software-license-terms.md",
+        "source_path": "./microsoft-edge/devtools-guide/devtools_software-license-terms.md",
         "redirect_url": "https://learn.microsoft.com/legal/microsoft-edge/microsoft-edge-devtools-license-terms",
         "redirect_document_id": false
       },
       // Extensions:
       {
-        "source_path": "microsoft-edge/extensions/microsoft-browser-extension-policy.md",
+        "source_path": "./microsoft-edge/extensions/microsoft-browser-extension-policy.md",
         "redirect_url": "https://learn.microsoft.com/legal/microsoft-edge/extensions/microsoft-browser-extension-policy",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/store-policies/ada-addendum.md",
+        "source_path": "./microsoft-edge/extensions-chromium/store-policies/ada-addendum.md",
         "redirect_url": "https://learn.microsoft.com/legal/microsoft-edge/extensions/ada-addendum",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions-chromium/store-policies/developer-policies.md",
+        "source_path": "./microsoft-edge/extensions-chromium/store-policies/developer-policies.md",
         "redirect_url": "https://learn.microsoft.com/legal/microsoft-edge/extensions/developer-policies",
         "redirect_document_id": false
       },
       // Privacy:
       {
-        "source_path": "microsoft-edge/privacy-whitepaper/index.md",
+        "source_path": "./microsoft-edge/privacy-whitepaper/index.md",
         "redirect_url": "https://learn.microsoft.com/legal/microsoft-edge/privacy",
         "redirect_document_id": false
       },
@@ -930,392 +930,392 @@
 // ============================================================================
 // Redirects to MDN
       {
-        "source_path": "microsoft-edge/dev-guide/css/animations.md",
+        "source_path": "./microsoft-edge/dev-guide/css/animations.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Animations/Using_CSS_animations",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/calc-function.md",
+        "source_path": "./microsoft-edge/dev-guide/css/calc-function.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/calc",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/filter-effects.md",
+        "source_path": "./microsoft-edge/dev-guide/css/filter-effects.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/filter",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/flexbox.md",
+        "source_path": "./microsoft-edge/dev-guide/css/flexbox.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/Flexbox",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/gradients.md",
+        "source_path": "./microsoft-edge/dev-guide/css/gradients.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Images/Using_CSS_gradients",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/grid-layout.md",
+        "source_path": "./microsoft-edge/dev-guide/css/grid-layout.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/length-units-relative-and-absolute.md",
+        "source_path": "./microsoft-edge/dev-guide/css/length-units-relative-and-absolute.md",
         "redirect_url": "https://developer.mozilla.org/docs/Learn/CSS/Introduction_to_CSS/Values_and_units",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/media-queries.md",
+        "source_path": "./microsoft-edge/dev-guide/css/media-queries.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/media-query-listeners.md",
+        "source_path": "./microsoft-edge/dev-guide/css/media-query-listeners.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/MediaQueryList",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/multi-column-layout.md",
+        "source_path": "./microsoft-edge/dev-guide/css/multi-column-layout.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Columns",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/supports-at-rule.md",
+        "source_path": "./microsoft-edge/dev-guide/css/supports-at-rule.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/@supports",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/transforms.md",
+        "source_path": "./microsoft-edge/dev-guide/css/transforms.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Transforms",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/transitions.md",
+        "source_path": "./microsoft-edge/dev-guide/css/transitions.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/fullscreen-api.md",
+        "source_path": "./microsoft-edge/dev-guide/device/fullscreen-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Fullscreen_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/geolocation.md",
+        "source_path": "./microsoft-edge/dev-guide/device/geolocation.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Geolocation",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/high-dpi-support.md",
+        "source_path": "./microsoft-edge/dev-guide/device/high-dpi-support.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Window/devicePixelRatio",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/screen-orientation-api.md",
+        "source_path": "./microsoft-edge/dev-guide/device/screen-orientation-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/ScreenOrientation",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom.md",
+        "source_path": "./microsoft-edge/dev-guide/dom.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/DOM",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/index.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/DOM",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/dom-event-constructors.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/dom-event-constructors.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/DOM",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/gamepad-api.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/gamepad-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Gamepad_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/input-method-editor-api.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/input-method-editor-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Mozilla/IME_handling_guide",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/mutation-observers.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/mutation-observers.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/MutationObserver",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/pointer-events.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/pointer-events.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/PointerEvent",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/pointer-lock.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/pointer-lock.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Pointer_Lock_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/touch-events.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/touch-events.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/TouchEvent",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/dom/xpath.md",
+        "source_path": "./microsoft-edge/dev-guide/dom/xpath.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/TouchEvent",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/graphics.md",
+        "source_path": "./microsoft-edge/dev-guide/graphics.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/Guide/Graphics",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/graphics/index.md",
+        "source_path": "./microsoft-edge/dev-guide/graphics/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/Guide/Graphics",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/graphics/canvas.md",
+        "source_path": "./microsoft-edge/dev-guide/graphics/canvas.md",
         "redirect_url": "https://developer.mozilla.org/docs/HTML/Canvas",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/graphics/svg.md",
+        "source_path": "./microsoft-edge/dev-guide/graphics/svg.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/SVG",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/graphics/webgl.md",
+        "source_path": "./microsoft-edge/dev-guide/graphics/webgl.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/WebGL",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5.md",
+        "source_path": "./microsoft-edge/dev-guide/html5.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/HTML5",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/index.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/HTML5",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/audio.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/audio.md",
         "redirect_url": "https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/file-api.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/file-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/file",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/folder-upload.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/folder-upload.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/File_and_Directory_Entries_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/sandbox.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/sandbox.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/selection-api.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/selection-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Selection_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/video.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/video.md",
         "redirect_url": "https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/multimedia.md",
+        "source_path": "./microsoft-edge/dev-guide/multimedia.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/multimedia/index.md",
+        "source_path": "./microsoft-edge/dev-guide/multimedia/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/multimedia/encrypted-media-extensions.md",
+        "source_path": "./microsoft-edge/dev-guide/multimedia/encrypted-media-extensions.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Encrypted_Media_Extensions_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/multimedia/media-capture-and-streams.md",
+        "source_path": "./microsoft-edge/dev-guide/multimedia/media-capture-and-streams.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Media_Streams_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/multimedia/media-source-extensions.md",
+        "source_path": "./microsoft-edge/dev-guide/multimedia/media-source-extensions.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Media_Source_Extensions_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/multimedia/web-audio.md",
+        "source_path": "./microsoft-edge/dev-guide/multimedia/web-audio.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Web_Audio_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/multimedia/web-speech-api.md",
+        "source_path": "./microsoft-edge/dev-guide/multimedia/web-speech-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Web_Speech_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/networking-and-connectivity.md",
+        "source_path": "./microsoft-edge/dev-guide/networking-and-connectivity.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/networking-and-connectivity/index.md",
+        "source_path": "./microsoft-edge/dev-guide/networking-and-connectivity/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/networking-and-connectivity/application-cache.md",
+        "source_path": "./microsoft-edge/dev-guide/networking-and-connectivity/application-cache.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Window/applicationCache",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/networking-and-connectivity/http2.md",
+        "source_path": "./microsoft-edge/dev-guide/networking-and-connectivity/http2.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/HTTP",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/networking-and-connectivity/websocket.md",
+        "source_path": "./microsoft-edge/dev-guide/networking-and-connectivity/websocket.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/WebSocket",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance.md",
+        "source_path": "./microsoft-edge/dev-guide/performance.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/index.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/animation-timing-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/animation-timing-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/window/requestAnimationFrame",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/beacon-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/beacon-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/efficient-script-yielding.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/efficient-script-yielding.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Window/setImmediate",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/fetch-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/fetch-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Fetch_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/navigation-timing-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/navigation-timing-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Navigation_timing_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/page-visibility-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/page-visibility-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Page_Visibility_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/prerender-and-prefetch-support.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/prerender-and-prefetch-support.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/HTTP/Link_prefetching_FAQ",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/resource-timing-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/resource-timing-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Resource_Timing_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/streams-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/streams-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Streams_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/user-timing-api.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/user-timing-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/PerformanceMark",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/performance/xmlhttprequest.md",
+        "source_path": "./microsoft-edge/dev-guide/performance/xmlhttprequest.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/XHR_(XMLHttpRequest)",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/realtime-communication.md",
+        "source_path": "./microsoft-edge/dev-guide/realtime-communication.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/realtime-communication/index.md",
+        "source_path": "./microsoft-edge/dev-guide/realtime-communication/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/realtime-communication/message-channels.md",
+        "source_path": "./microsoft-edge/dev-guide/realtime-communication/message-channels.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/MessageChannel/MessageChannel",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/security.md",
+        "source_path": "./microsoft-edge/dev-guide/security.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/security/index.md",
+        "source_path": "./microsoft-edge/dev-guide/security/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/security/content-security-policy.md",
+        "source_path": "./microsoft-edge/dev-guide/security/content-security-policy.md",
         "redirect_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/security/hsts.md",
+        "source_path": "./microsoft-edge/dev-guide/security/hsts.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/HSTS",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/security/meta-referrer.md",
+        "source_path": "./microsoft-edge/dev-guide/security/meta-referrer.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Document/referrer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/security/web-cryptography-api.md",
+        "source_path": "./microsoft-edge/dev-guide/security/web-cryptography-api.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Web_Crypto_API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/storage.md",
+        "source_path": "./microsoft-edge/dev-guide/storage.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/storage/index.md",
+        "source_path": "./microsoft-edge/dev-guide/storage/index.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/storage/indexeddb.md",
+        "source_path": "./microsoft-edge/dev-guide/storage/indexeddb.md",
         "redirect_url": "https://developer.mozilla.org/docs/Glossary/IndexedDB",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/storage/web-and-offline-storage.md",
+        "source_path": "./microsoft-edge/dev-guide/storage/web-and-offline-storage.md",
         "redirect_url": "https://developer.mozilla.org/docs/Web/API/Web_Storage_API",
         "redirect_document_id": false
       },
@@ -1323,7 +1323,7 @@
 // ============================================================================
 // Redirects to external webpages
       {
-        "source_path": "microsoft-edge/dev-guide/realtime-communication/object-rtc-api.md",
+        "source_path": "./microsoft-edge/dev-guide/realtime-communication/object-rtc-api.md",
         "redirect_url": "https://ortc.org",
         "redirect_document_id": false
       },
@@ -1331,7 +1331,7 @@
 // ============================================================================
 // WebDriver: "microsoft / edge-selenium-tools" repo
       {
-        "source_path": "microsoft-edge/webdriver-chromium/verify-selenium-tools.md",
+        "source_path": "./microsoft-edge/webdriver-chromium/verify-selenium-tools.md",
         "redirect_url": "https://github.com/microsoft/edge-selenium-tools/wiki/using-gpg-to-verify-selenium-tools-for-microsoft-edge-releases",
         "redirect_document_id": false
       },
@@ -1339,1352 +1339,1352 @@
 // ============================================================================
 // Archived EdgeHTML content
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/browser-features",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/browser-features/autoplay-policies",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/autoplay-policies",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/browser-features/flash",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/flash",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/browser-features/reading-view",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/reading-view",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/browser-features/search-provider-discovery",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/browser-features/search-provider-discovery",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/index",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-12",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-12",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-13",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-13",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-14",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-14",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-15",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-15",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-16",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-16",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-17",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/edgehtml-17",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/whats-new/javascript-version-information",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/whats-new/javascript-version-information",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/windows-integration",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/windows-integration/payment-request-api",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/payment-request-api",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/windows-integration/web-authentication",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/web-authentication",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/dev-guide/windows-integration/web-notifications-api",
+        "source_path": "./microsoft-edge/edgehtml/dev-guide/windows-integration/web-notifications-api",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/console",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/console/command-line",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/command-line",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/console/console-api",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/console-api",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/console/error-and-status-codes",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/console/error-and-status-codes",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/debugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/debugger",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements/accessibility",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/accessibility",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements/changes",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/changes",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements/computed",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/computed",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements/dom-breakpoints",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/dom-breakpoints",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements/events",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/events",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements/fonts",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/fonts",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/elements/styles",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/elements/styles",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/emulation",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/emulation",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/memory",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/memory",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/network",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/network",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/performance",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/performance",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/service-workers",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/service-workers",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/storage",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/storage",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/whats-new",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-16",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-16",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-17",
+        "source_path": "./microsoft-edge/edgehtml/devtools-guide/whats-new/edgehtml-17",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/clients",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/clients",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/domains/debugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/debugger",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/domains/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/domains/page",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/page",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/domains/runtime",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/runtime",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/domains/schema",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/domains/schema",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/http",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/http",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.1/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.1/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/clients",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/clients",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/css",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/css",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/debugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/debugger",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/dom",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/dom",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/domdebugger",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/domdebugger",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/overlay",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/overlay",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/page",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/page",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/runtime",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/runtime",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/domains/schema",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/domains/schema",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/http",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/http",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/0.2/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/0.2/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/devtools-protocol/index",
+        "source_path": "./microsoft-edge/edgehtml/devtools-protocol/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/api-support",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/api-support/extension-api-roadmap",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/extension-api-roadmap",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/api-support/supported-apis",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-apis",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys/json-manifest-example",
+        "source_path": "./microsoft-edge/edgehtml/extensions/api-support/supported-manifest-keys/json-manifest-example",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/extensions-for-enterprise",
+        "source_path": "./microsoft-edge/edgehtml/extensions/extensions-for-enterprise",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/getting-started",
+        "source_path": "./microsoft-edge/edgehtml/extensions/getting-started",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/accessibility",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/accessibility",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/adding-and-removing-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/adding-and-removing-extensions",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/creating-an-extension",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/creating-an-extension",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/debugging-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/debugging-extensions",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/design",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/design",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/internationalization",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/internationalization",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/native-messaging",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/native-messaging",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/packaging",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/packaging/creating-and-testing-extension-packages",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/creating-and-testing-extension-packages",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/packaging/extensions-in-the-windows-dev-center",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/extensions-in-the-windows-dev-center",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/packaging/localizing-extension-packages",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/localizing-extension-packages",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/packaging/running-the-windows-app-certification-kit",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/running-the-windows-app-certification-kit",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/packaging/using-manifoldjs-to-package-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/packaging/using-manifoldjs-to-package-extensions",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/guides/porting-chrome-extensions",
+        "source_path": "./microsoft-edge/edgehtml/extensions/guides/porting-chrome-extensions",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/index",
+        "source_path": "./microsoft-edge/edgehtml/extensions/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/tips-and-tricks",
+        "source_path": "./microsoft-edge/edgehtml/extensions/tips-and-tricks",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/extensions/troubleshooting",
+        "source_path": "./microsoft-edge/edgehtml/extensions/troubleshooting",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/hosting-the-javascript-runtime",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/hosting-the-javascript-runtime",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-propertyid-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-propertyid-constant",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-reference-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-reference-constant",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-runtime-handle-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-invalid-runtime-handle-constant",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/js-source-context-none-constant",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/js-source-context-none-constant",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsaddref-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsaddref-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsbackgroundworkitemcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbackgroundworkitemcallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsbeforecollectcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbeforecollectcallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooleantobool-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooleantobool-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooltoboolean-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsbooltoboolean-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscallfunction-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscallfunction-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscollectgarbage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscollectgarbage-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsconstructobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconstructobject-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscontextref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscontextref-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoboolean-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoboolean-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetonumber-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetonumber-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetoobject-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetostring-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsconvertvaluetostring-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearray-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearray-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearraybuffer-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatearraybuffer-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatecontext-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatecontext-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatedataview-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatedataview-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateerror-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalarraybuffer-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalarraybuffer-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateexternalobject-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatefunction-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatefunction-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatenamedfunction-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatenamedfunction-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateobject-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreaterangeerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreaterangeerror-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatereferenceerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatereferenceerror-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateruntime-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateruntime-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesymbol-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesymbol-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesyntaxerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatesyntaxerror-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypedarray-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypedarray-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypeerror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreatetypeerror-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateurierror-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jscreateurierror-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsdefineproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdefineproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteindexedproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdeleteproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisableruntimeexecution-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisableruntimeexecution-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisposeruntime-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdisposeruntime-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsdoubletonumber-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsdoubletonumber-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsenableruntimeexecution-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsenableruntimeexecution-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsenumerateheap-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsenumerateheap-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsequals-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsequals-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jserrorcode-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jserrorcode-enumeration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsfinalizecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsfinalizecallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetandclearexception-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetandclearexception-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetarraybufferstorage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetarraybufferstorage-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextdata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextdata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextofobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcontextofobject-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcurrentcontext-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetcurrentcontext-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetdataviewstorage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetdataviewstorage-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetextensionallowed-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetextensionallowed-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetexternaldata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetfalsevalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetfalsevalue-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetglobalobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetglobalobject-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetindexedproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetnullvalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetnullvalue-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertydescriptor-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertydescriptor-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertynames-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertynames-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertysymbols-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetownpropertysymbols-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromname-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromname-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidtype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertyidtype-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertynamefromid-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetpropertynamefromid-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetprototype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetprototype-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntime-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntime-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememorylimit-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememorylimit-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememoryusage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetruntimememoryusage-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetstringlength-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetstringlength-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettruevalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettruevalue-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarrayinfo-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarrayinfo-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarraystorage-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgettypedarraystorage-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetundefinedvalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetundefinedvalue-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetvaluetype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsgetvaluetype-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexception-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexception-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasexternaldata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasindexedproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jshasproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jshasproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsidle-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsidle-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsinspectabletoobject-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinspectabletoobject-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsinstanceof-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinstanceof-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsinttonumber-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsinttonumber-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsisenumeratingheap-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsisenumeratingheap-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryallocationcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryallocationcallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryeventtype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsmemoryeventtype-enumeration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsnativefunction-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnativefunction-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertodouble-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertodouble-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertoint-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsnumbertoint-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjectbeforecollectcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjectbeforecollectcallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjecttoinspectable-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsobjecttoinspectable-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsparsescript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparsescript-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscript-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jspointertostring-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspointertostring-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jspreventextension-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspreventextension-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallbackcontext-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectioncallbackcontext-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectionenqueuecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectionenqueuecallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectwinrtnamespace-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsprojectwinrtnamespace-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jspromisecontinuationcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspromisecontinuationcallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidref-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidtype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jspropertyidtype-enumeration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsref-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsrelease-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrelease-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunscript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunscript-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscript-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeattributes-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeattributes-enumeration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimehandle-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimehandle-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeversion-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsruntimeversion-enumeration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptloadsourcecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptloadsourcecallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptunloadcallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializedscriptunloadcallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializescript-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsserializescript-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcontextdata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcontextdata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcurrentcontext-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetcurrentcontext-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexception-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexception-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetexternaldata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetindexedproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprojectionenqueuecallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprojectionenqueuecallback-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetpromisecontinuationcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetpromisecontinuationcallback-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetproperty-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetproperty-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprototype-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetprototype-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememorylimit-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssetruntimememorylimit-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jssourcecontext-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jssourcecontext-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartdebugging-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartdebugging-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartprofiling-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstartprofiling-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsstopprofiling-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstopprofiling-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsstrictequals-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstrictequals-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsstringtopointer-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsstringtopointer-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsthreadservicecallback-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsthreadservicecallback-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jstypedarraytype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jstypedarraytype-enumeration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsvalueref-typedef",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvalueref-typedef",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetovariant-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetovariant-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetype-enumeration",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvaluetype-enumeration",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/jsvarianttovalue-function",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/jsvarianttovalue-function",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/reference-javascript-runtime",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/reference-javascript-runtime",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis",
+        "source_path": "./microsoft-edge/edgehtml/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/javascript-runtime-hosting",
+        "source_path": "./microsoft-edge/edgehtml/hosting/javascript-runtime-hosting",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/deferredpermissionrequest",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/deferredpermissionrequest",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/focusnavigationevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/focusnavigationevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/index",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/longrunningscriptdetectedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/longrunningscriptdetectedevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/mswebviewasyncoperation",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewasyncoperation",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/mswebviewprocess",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewprocess",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/mswebviewsettings",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/mswebviewsettings",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/navigationcompletedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationcompletedevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/navigationevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/navigationeventwithreferrer",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/navigationeventwithreferrer",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/permissionrequest",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/permissionrequest",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/permissionrequestedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/permissionrequestedevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/scriptnotifyevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/scriptnotifyevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/unviewablecontentidentifiedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/unviewablecontentidentifiedevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/hosting/webview/webresourcerequestedevent",
+        "source_path": "./microsoft-edge/edgehtml/hosting/webview/webresourcerequestedevent",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/index",
+        "source_path": "./microsoft-edge/edgehtml/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/performance-analysis/index",
+        "source_path": "./microsoft-edge/edgehtml/performance-analysis/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/progressive-web-apps/get-started",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/get-started",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/progressive-web-apps/index",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/progressive-web-apps/microsoft-store",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/microsoft-store",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/progressive-web-apps/windows-features",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/windows-features",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/progressive-web-apps/xbox-considerations",
+        "source_path": "./microsoft-edge/edgehtml/progressive-web-apps/xbox-considerations",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/webdriver/index",
+        "source_path": "./microsoft-edge/edgehtml/webdriver/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/considerations-when-using-the-windows-runtime-api",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/considerations-when-using-the-windows-runtime-api",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/error-codes-for-windows-runtime-apps-using-javascript",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/error-codes-for-windows-runtime-apps-using-javascript",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/handling-windows-runtime-events-in-javascript",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/handling-windows-runtime-events-in-javascript",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/index",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/index",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/javascript-representation-of-windows-runtime-types",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/javascript-representation-of-windows-runtime-types",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/reference/msapp",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/reference/msapp",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/special-error-properties-from-asynchronous-windows-runtime-methods",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/special-error-properties-from-asynchronous-windows-runtime-methods",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/using-the-windows-runtime-in-javascript",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/using-the-windows-runtime-in-javascript",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/using-windows-runtime-asynchronous-methods",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/using-windows-runtime-asynchronous-methods",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/edgehtml/windows-runtime/windows-runtime-datetime-and-timespan-representations",
+        "source_path": "./microsoft-edge/edgehtml/windows-runtime/windows-runtime-datetime-and-timespan-representations",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
@@ -2692,1647 +2692,1647 @@
 // ============================================================================
 // Old redirects (to /archive/)
       {
-        "source_path": "microsoft-edge/dev-guide.md",
+        "source_path": "./microsoft-edge/dev-guide.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/index.md",
+        "source_path": "./microsoft-edge/dev-guide/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser.md",
+        "source_path": "./microsoft-edge/dev-guide/browser.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser/index.md",
+        "source_path": "./microsoft-edge/dev-guide/browser/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser/flash.md",
+        "source_path": "./microsoft-edge/dev-guide/browser/flash.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser/reading-view.md",
+        "source_path": "./microsoft-edge/dev-guide/browser/reading-view.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser/search-provider-discovery.md",
+        "source_path": "./microsoft-edge/dev-guide/browser/search-provider-discovery.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser-features.md",
+        "source_path": "./microsoft-edge/dev-guide/browser-features.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser-features/index.md",
+        "source_path": "./microsoft-edge/dev-guide/browser-features/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser-features/autoplay-policies.md",
+        "source_path": "./microsoft-edge/dev-guide/browser-features/autoplay-policies.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser-features/flash.md",
+        "source_path": "./microsoft-edge/dev-guide/browser-features/flash.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser-features/reading-view.md",
+        "source_path": "./microsoft-edge/dev-guide/browser-features/reading-view.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/browser-features/search-provider-discovery.md",
+        "source_path": "./microsoft-edge/dev-guide/browser-features/search-provider-discovery.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css.md",
+        "source_path": "./microsoft-edge/dev-guide/css.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/index.md",
+        "source_path": "./microsoft-edge/dev-guide/css/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/exclusions.md",
+        "source_path": "./microsoft-edge/dev-guide/css/exclusions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/newly-supported-properties-and-pseudo-classes.md",
+        "source_path": "./microsoft-edge/dev-guide/css/newly-supported-properties-and-pseudo-classes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/css/regions.md",
+        "source_path": "./microsoft-edge/dev-guide/css/regions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device.md",
+        "source_path": "./microsoft-edge/dev-guide/device.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/index.md",
+        "source_path": "./microsoft-edge/dev-guide/device/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/device-orientation-and-motion-events.md",
+        "source_path": "./microsoft-edge/dev-guide/device/device-orientation-and-motion-events.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/payment-request-api.md",
+        "source_path": "./microsoft-edge/dev-guide/device/payment-request-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/web-authentication.md",
+        "source_path": "./microsoft-edge/dev-guide/device/web-authentication.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/device/web-notifications-api.md",
+        "source_path": "./microsoft-edge/dev-guide/device/web-notifications-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/html5/newly-supported-elements-and-attributes.md",
+        "source_path": "./microsoft-edge/dev-guide/html5/newly-supported-elements-and-attributes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/tools.md",
+        "source_path": "./microsoft-edge/dev-guide/tools.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/tools/index.md",
+        "source_path": "./microsoft-edge/dev-guide/tools/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/tools/console-logging-api.md",
+        "source_path": "./microsoft-edge/dev-guide/tools/console-logging-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/tools/webdriver.md",
+        "source_path": "./microsoft-edge/dev-guide/tools/webdriver.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/index.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/edgehtml-12.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/edgehtml-12.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/edgehtml-13.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/edgehtml-13.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/edgehtml-14.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/edgehtml-14.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/edgehtml-15.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/edgehtml-15.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/edgehtml-16.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/edgehtml-16.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/edgehtml-17.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/edgehtml-17.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/whats-new/javascript-version-information.md",
+        "source_path": "./microsoft-edge/dev-guide/whats-new/javascript-version-information.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/windows-integration.md",
+        "source_path": "./microsoft-edge/dev-guide/windows-integration.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/windows-integration/index.md",
+        "source_path": "./microsoft-edge/dev-guide/windows-integration/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/windows-integration/payment-request-api.md",
+        "source_path": "./microsoft-edge/dev-guide/windows-integration/payment-request-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/windows-integration/web-authentication.md",
+        "source_path": "./microsoft-edge/dev-guide/windows-integration/web-authentication.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/dev-guide/windows-integration/web-notifications-api.md",
+        "source_path": "./microsoft-edge/dev-guide/windows-integration/web-notifications-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide.md",
+        "source_path": "./microsoft-edge/devtools-guide.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/index.md",
+        "source_path": "./microsoft-edge/devtools-guide/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/console.md",
+        "source_path": "./microsoft-edge/devtools-guide/console.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/console/index.md",
+        "source_path": "./microsoft-edge/devtools-guide/console/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/console/command-line.md",
+        "source_path": "./microsoft-edge/devtools-guide/console/command-line.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/console/console-api.md",
+        "source_path": "./microsoft-edge/devtools-guide/console/console-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/console/error-and-status-codes.md",
+        "source_path": "./microsoft-edge/devtools-guide/console/error-and-status-codes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/debugger.md",
+        "source_path": "./microsoft-edge/devtools-guide/debugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/debugger/index.md",
+        "source_path": "./microsoft-edge/devtools-guide/debugger/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/debugger/cookies.md",
+        "source_path": "./microsoft-edge/devtools-guide/debugger/cookies.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/debugger/indexeddb.md",
+        "source_path": "./microsoft-edge/devtools-guide/debugger/indexeddb.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/debugger/progressive-web-apps.md",
+        "source_path": "./microsoft-edge/devtools-guide/debugger/progressive-web-apps.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/debugger/progressive-web-apps/index.md",
+        "source_path": "./microsoft-edge/devtools-guide/debugger/progressive-web-apps/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/debugger/web-storage.md",
+        "source_path": "./microsoft-edge/devtools-guide/debugger/web-storage.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/index.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/accessibility.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/accessibility.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/changes.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/changes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/computed.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/computed.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/dom-breakpoints.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/dom-breakpoints.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/events.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/events.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/fonts.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/fonts.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/elements/styles.md",
+        "source_path": "./microsoft-edge/devtools-guide/elements/styles.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/emulation.md",
+        "source_path": "./microsoft-edge/devtools-guide/emulation.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/memory.md",
+        "source_path": "./microsoft-edge/devtools-guide/memory.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/network.md",
+        "source_path": "./microsoft-edge/devtools-guide/network.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/performance.md",
+        "source_path": "./microsoft-edge/devtools-guide/performance.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/whats-new.md",
+        "source_path": "./microsoft-edge/devtools-guide/whats-new.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/whats-new/index.md",
+        "source_path": "./microsoft-edge/devtools-guide/whats-new/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/whats-new/edgehtml-16.md",
+        "source_path": "./microsoft-edge/devtools-guide/whats-new/edgehtml-16.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/whats-new/edgehtml-17.md",
+        "source_path": "./microsoft-edge/devtools-guide/whats-new/edgehtml-17.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/service-workers.md",
+        "source_path": "./microsoft-edge/devtools-guide/service-workers.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-guide/storage.md",
+        "source_path": "./microsoft-edge/devtools-guide/storage.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/index.md",
+        "source_path": "./microsoft-edge/devtools-protocol/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/index.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/clients.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/clients.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/domains.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/domains.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/domains/index.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/domains/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/domains/debugger.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/domains/debugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/domains/page.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/domains/page.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/domains/runtime.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/domains/runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/domains/schema.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/domains/schema.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.1/http.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.1/http.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/index.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/clients.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/clients.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/index.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/css.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/css.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/debugger.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/debugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/dom.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/dom.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/domdebugger.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/domdebugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/overlay.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/overlay.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/page.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/page.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/runtime.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/domains/schema.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/domains/schema.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/devtools-protocol/0.2/http.md",
+        "source_path": "./microsoft-edge/devtools-protocol/0.2/http.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions.md",
+        "source_path": "./microsoft-edge/extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/index.md",
+        "source_path": "./microsoft-edge/extensions/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/api-support.md",
+        "source_path": "./microsoft-edge/extensions/api-support.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/api-support/index.md",
+        "source_path": "./microsoft-edge/extensions/api-support/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/api-support/extension-api-roadmap.md",
+        "source_path": "./microsoft-edge/extensions/api-support/extension-api-roadmap.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/api-support/supported-apis.md",
+        "source_path": "./microsoft-edge/extensions/api-support/supported-apis.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/api-support/supported-manifest-keys.md",
+        "source_path": "./microsoft-edge/extensions/api-support/supported-manifest-keys.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/api-support/supported-manifest-keys/index.md",
+        "source_path": "./microsoft-edge/extensions/api-support/supported-manifest-keys/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/api-support/supported-manifest-keys/json-manifest-example.md",
+        "source_path": "./microsoft-edge/extensions/api-support/supported-manifest-keys/json-manifest-example.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/extensions-for-enterprise.md",
+        "source_path": "./microsoft-edge/extensions/extensions-for-enterprise.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/getting-started.md",
+        "source_path": "./microsoft-edge/extensions/getting-started.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides.md",
+        "source_path": "./microsoft-edge/extensions/guides.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/index.md",
+        "source_path": "./microsoft-edge/extensions/guides/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/accessibility.md",
+        "source_path": "./microsoft-edge/extensions/guides/accessibility.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/adding-and-removing-extensions.md",
+        "source_path": "./microsoft-edge/extensions/guides/adding-and-removing-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/creating-an-extension.md",
+        "source_path": "./microsoft-edge/extensions/guides/creating-an-extension.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/debugging-extensions.md",
+        "source_path": "./microsoft-edge/extensions/guides/debugging-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/design.md",
+        "source_path": "./microsoft-edge/extensions/guides/design.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/internationalization.md",
+        "source_path": "./microsoft-edge/extensions/guides/internationalization.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/native-messaging.md",
+        "source_path": "./microsoft-edge/extensions/guides/native-messaging.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/packaging.md",
+        "source_path": "./microsoft-edge/extensions/guides/packaging.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/packaging/index.md",
+        "source_path": "./microsoft-edge/extensions/guides/packaging/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/packaging/creating-and-testing-extension-packages.md",
+        "source_path": "./microsoft-edge/extensions/guides/packaging/creating-and-testing-extension-packages.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/packaging/extensions-in-the-windows-dev-center.md",
+        "source_path": "./microsoft-edge/extensions/guides/packaging/extensions-in-the-windows-dev-center.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/packaging/localization-extension-packages.md",
+        "source_path": "./microsoft-edge/extensions/guides/packaging/localization-extension-packages.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/packaging/running-the-windows-app-certification-kit.md",
+        "source_path": "./microsoft-edge/extensions/guides/packaging/running-the-windows-app-certification-kit.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions.md",
+        "source_path": "./microsoft-edge/extensions/guides/packaging/using-manifoldjs-to-package-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/guides/porting-chrome-extensions.md",
+        "source_path": "./microsoft-edge/extensions/guides/porting-chrome-extensions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/tips-and-tricks.md",
+        "source_path": "./microsoft-edge/extensions/tips-and-tricks.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/extensions/troubleshooting.md",
+        "source_path": "./microsoft-edge/extensions/troubleshooting.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/console.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/console.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/console/index.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/console/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/console/command-line.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/console/command-line.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/console/console-api.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/console/console-api.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/console/error-and-status-codes.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/console/error-and-status-codes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/debugger.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/debugger.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/debugger/index.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/debugger/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/debugger/cookies.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/debugger/cookies.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/debugger/progressive-web-apps/index.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/debugger/progressive-web-apps/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/debugger/web-storage.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/debugger/web-storage.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/developer-tools-keyboard-shortcuts.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/developer-tools-keyboard-shortcuts.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/index.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/accessibility.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/accessibility.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/changes.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/changes.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/computed.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/computed.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/dom-breakpoints.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/dom-breakpoints.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/events.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/events.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/fonts.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/fonts.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/elements/styles.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/elements/styles.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/emulation.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/emulation.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/experiments.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/experiments.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/memory.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/memory.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/network.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/network.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/performance.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/performance.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/f12-devtools-guide/whats-new.md",
+        "source_path": "./microsoft-edge/f12-devtools-guide/whats-new.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/index.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/hosting-the-javascript-runtime.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/hosting-the-javascript-runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/javascript-runtime-typedefs-constants-and-enumerations.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsaddref-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsaddref-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsbooleantobool-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsbooleantobool-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsbooltoboolean-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsbooltoboolean-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscallfunction-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscallfunction-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscollectgarbage-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscollectgarbage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsconstructobject-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsconstructobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsconvertvaluetoboolean-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsconvertvaluetoboolean-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsconvertvaluetonumber-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsconvertvaluetonumber-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsconvertvaluetoobject-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsconvertvaluetoobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsconvertvaluetostring-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsconvertvaluetostring-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatearray-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatearray-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatearraybuffer-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatearraybuffer-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatecontext-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatecontext-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatedataview-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatedataview-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreateerror-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreateerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreateexternalarraybuffer-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreateexternalarraybuffer-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreateexternalobject-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreateexternalobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatefunction-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatefunction-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatenamedfunction-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatenamedfunction-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreateobject-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreateobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreaterangeerror-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreaterangeerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatereferenceerror-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatereferenceerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreateruntime-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreateruntime-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatesymbol-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatesymbol-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatesyntaxerror-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatesyntaxerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatetypeerror-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatetypeerror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreatetypedarray-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreatetypedarray-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jscreateurierror-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jscreateurierror-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsdefineproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsdefineproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsdeleteindexedproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsdeleteindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsdeleteproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsdeleteproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsdisableruntimeexecution-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsdisableruntimeexecution-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsdisposeruntime-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsdisposeruntime-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsdoubletonumber-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsdoubletonumber-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsenableruntimeexecution-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsenableruntimeexecution-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsenumerateheap-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsenumerateheap-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsequals-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsequals-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetandclearexception-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetandclearexception-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetarraybufferstorage-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetarraybufferstorage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetcontextdata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetcontextdata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetcontextofobject-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetcontextofobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetcurrentcontext-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetcurrentcontext-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetdataviewstorage-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetdataviewstorage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetextensionallowed-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetextensionallowed-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetexternaldata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetfalsevalue-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetfalsevalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetglobalobject-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetglobalobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetindexedpropertiesexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetindexedproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetnullvalue-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetnullvalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetownpropertydescriptor-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetownpropertydescriptor-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetownpropertynames-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetownpropertynames-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetownpropertysymbols-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetownpropertysymbols-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetpropertyidfromname-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetpropertyidfromname-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetpropertyidfromsymbol-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetpropertyidtype-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetpropertyidtype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetpropertynamefromid-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetpropertynamefromid-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetprototype-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetprototype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetruntime-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetruntime-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetruntimememorylimit-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetruntimememorylimit-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetruntimememoryusage-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetruntimememoryusage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetstringlength-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetstringlength-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetsymbolfrompropertyid-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgettruevalue-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgettruevalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgettypedarrayinfo-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgettypedarrayinfo-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgettypedarraystorage-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgettypedarraystorage-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetundefinedvalue-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetundefinedvalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsgetvaluetype-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsgetvaluetype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jshasexception-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jshasexception-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jshasexternaldata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jshasexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jshasindexedpropertiesexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jshasindexedproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jshasindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jshasproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jshasproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsidle-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsidle-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsinspectabletoobject-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsinspectabletoobject-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsinstanceof-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsinstanceof-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsinttonumber-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsinttonumber-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsisenumeratingheap-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsisenumeratingheap-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsisruntimeexecutiondisabled-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsnumbertodouble-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsnumbertodouble-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsnumbertoint-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsnumbertoint-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsobjecttoinspectable-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsobjecttoinspectable-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsparsescript-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsparsescript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsparseserializedscript-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsparseserializedscript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsparseserializedscriptwithcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jspointertostring-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jspointertostring-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jspreventextension-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jspreventextension-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsprojectwinrtnamespace-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsprojectwinrtnamespace-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsrelease-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsrelease-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsrunscript-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsrunscript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsrunserializedscript-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsrunserializedscript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsrunserializedscriptwithcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsserializescript-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsserializescript-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetcontextdata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetcontextdata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetcurrentcontext-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetcurrentcontext-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetexception-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetexception-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetexternaldata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetindexedpropertiestoexternaldata-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetindexedproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetindexedproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetobjectbeforecollectcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetprojectionenqueuecallback-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetprojectionenqueuecallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetpromisecontinuationcallback-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetpromisecontinuationcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetproperty-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetproperty-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetprototype-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetprototype-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetruntimebeforecollectcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetruntimememoryallocationcallback-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jssetruntimememorylimit-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jssetruntimememorylimit-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsstartdebugging-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsstartdebugging-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsstartprofiling-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsstartprofiling-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsstopprofiling-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsstopprofiling-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsstrictequals-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsstrictequals-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsstringtopointer-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsstringtopointer-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsvaluetovariant-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsvaluetovariant-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/jsvarianttovalue-function.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/jsvarianttovalue-function.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/reference-javascript-runtime.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/reference-javascript-runtime.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis.md",
+        "source_path": "./microsoft-edge/hosting/chakra-hosting/targeting-edge-vs-legacy-engines-in-jsrt-apis.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/javascript-runtime-hosting.md",
+        "source_path": "./microsoft-edge/hosting/javascript-runtime-hosting.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview.md",
+        "source_path": "./microsoft-edge/hosting/webview.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/index.md",
+        "source_path": "./microsoft-edge/hosting/webview/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/deferredpermissionrequest.md",
+        "source_path": "./microsoft-edge/hosting/webview/deferredpermissionrequest.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/focusnavigationevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/focusnavigationevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/longrunningscriptdetectedevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/longrunningscriptdetectedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/mswebviewasyncoperation.md",
+        "source_path": "./microsoft-edge/hosting/webview/mswebviewasyncoperation.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/mswebviewprocess.md",
+        "source_path": "./microsoft-edge/hosting/webview/mswebviewprocess.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/mswebviewsettings.md",
+        "source_path": "./microsoft-edge/hosting/webview/mswebviewsettings.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/navigationcompletedevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/navigationcompletedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/navigationevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/navigationevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/navigationeventwithreferrer.md",
+        "source_path": "./microsoft-edge/hosting/webview/navigationeventwithreferrer.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/permissionrequest.md",
+        "source_path": "./microsoft-edge/hosting/webview/permissionrequest.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/permissionrequestedevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/permissionrequestedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/scriptnotifyevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/scriptnotifyevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/unviewablecontentidentifiedevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/unviewablecontentidentifiedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/hosting/webview/webresourcerequestedevent.md",
+        "source_path": "./microsoft-edge/hosting/webview/webresourcerequestedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/performance-analysis.md",
+        "source_path": "./microsoft-edge/performance-analysis.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/performance-analysis/index.md",
+        "source_path": "./microsoft-edge/performance-analysis/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-edgehtml.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-edgehtml.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-edgehtml/index.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-edgehtml/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-edgehtml/get-started.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-edgehtml/get-started.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-edgehtml/microsoft-store.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-edgehtml/microsoft-store.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-edgehtml/windows-features.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-edgehtml/windows-features.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/progressive-web-apps-edgehtml/xbox-considerations.md",
+        "source_path": "./microsoft-edge/progressive-web-apps-edgehtml/xbox-considerations.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver.md",
+        "source_path": "./microsoft-edge/webdriver.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/index.md",
+        "source_path": "./microsoft-edge/webdriver/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/dialogs.md",
+        "source_path": "./microsoft-edge/webdriver/dialogs.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/element-inspection.md",
+        "source_path": "./microsoft-edge/webdriver/element-inspection.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/input.md",
+        "source_path": "./microsoft-edge/webdriver/input.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/navigation.md",
+        "source_path": "./microsoft-edge/webdriver/navigation.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/screenshots.md",
+        "source_path": "./microsoft-edge/webdriver/screenshots.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/script-execution.md",
+        "source_path": "./microsoft-edge/webdriver/script-execution.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/server.md",
+        "source_path": "./microsoft-edge/webdriver/server.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/sessions.md",
+        "source_path": "./microsoft-edge/webdriver/sessions.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webdriver/window.md",
+        "source_path": "./microsoft-edge/webdriver/window.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview.md",
+        "source_path": "./microsoft-edge/webview.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/index.md",
+        "source_path": "./microsoft-edge/webview/index.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/deferredpermissionrequest.md",
+        "source_path": "./microsoft-edge/webview/deferredpermissionrequest.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/focusnavigationevent.md",
+        "source_path": "./microsoft-edge/webview/focusnavigationevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/longrunningscriptdetectedevent.md",
+        "source_path": "./microsoft-edge/webview/longrunningscriptdetectedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/mswebviewasyncoperation.md",
+        "source_path": "./microsoft-edge/webview/mswebviewasyncoperation.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/mswebviewprocess.md",
+        "source_path": "./microsoft-edge/webview/mswebviewprocess.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/mswebviewsettings.md",
+        "source_path": "./microsoft-edge/webview/mswebviewsettings.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/navigationcompletedevent.md",
+        "source_path": "./microsoft-edge/webview/navigationcompletedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/navigationevent.md",
+        "source_path": "./microsoft-edge/webview/navigationevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/navigationeventwithreferrer.md",
+        "source_path": "./microsoft-edge/webview/navigationeventwithreferrer.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/permissionrequest.md",
+        "source_path": "./microsoft-edge/webview/permissionrequest.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/permissionrequestedevent.md",
+        "source_path": "./microsoft-edge/webview/permissionrequestedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/scriptnotifyevent.md",
+        "source_path": "./microsoft-edge/webview/scriptnotifyevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/unviewablecontentidentifiedevent.md",
+        "source_path": "./microsoft-edge/webview/unviewablecontentidentifiedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       },
       {
-        "source_path": "microsoft-edge/webview/webresourcerequestedevent.md",
+        "source_path": "./microsoft-edge/webview/webresourcerequestedevent.md",
         "redirect_url": "/archive/microsoft-edge/legacy/developer",
         "redirect_document_id": false
       }


### PR DESCRIPTION
To review: Test some redirects in "Archived EdgeHTML content" section.

In `.openpublishing.redirection.json`:
* On every `source_path` line:
   * Added `./` to start.
   * Added `.md` to end of every line in "Archived EdgeHTML content" section.
* To facilitate Maintenance, clearly differentiated the type of path in line 1 vs. line 2 of every entry:
   * Used the same two standard patterns that are used throughout the repo.
   * Conformed the string format to the meaning of the field names:
      * "source_path" is a relative file <ins>path</ins> including the `.md` filename.
      * "redirect_url" is a LMC <ins>URL</ins>, without the `http://learn.microsoft.com` prefix.

AB#57015587
