### PR TITLE
Remove "Request to get your extension featured" from "Released features"

### DIFF
--- a/microsoft-edge/extensions-chromium/whats-new/released-features.md
+++ b/microsoft-edge/extensions-chromium/whats-new/released-features.md
@@ -118,16 +118,6 @@ Microsoft Edge extensions now support Manifest V3.  See the blog post [Manifest 
 
 
 <!-- ====================================================================== -->
-## Request to get your extension featured
-
-You can request which collection your extension should be featured in at [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/).
-
-To submit a request, go to [Submit a request to add an extension to the collections on the Microsoft Edge Add-ons home page](https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbRw01UwyBfAxNna_1ZkP3X2VUN0lBSU1YMEU3VFY0VURRODEwSjgwU00yRy4u).
-
-*Released April 2021*
-
-
-<!-- ====================================================================== -->
 ## Localization of extension listings at Microsoft Edge Add-ons
 
 You can control localization of extension listings that are at [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/).  You can choose a subset of languages, instead of manually entering each language in the listing details on Microsoft Partner Center.  You can also elect to use the same marketing assets across all marketplaces.


### PR DESCRIPTION
Rendered article sections for review:
* **Released features for Microsoft Edge extensions** > **Request to get your extension featured**
   * `/extensions-chromium/whats-new/released-features.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions-chromium/whats-new/released-features?branch=pr-en-us-3440#request-to-get-your-extension-featured
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/bhuvanapriyap-patch-5/microsoft-edge/extensions-chromium/whats-new/released-features.md#request-to-get-your-extension-featured
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions-chromium/whats-new/released-features#request-to-get-your-extension-featured
   * Form is irrelevant, hence, removing.

AB#57434003
