### PR TITLE
WebView2 Release Notes for May 2025 Prerelease SDK

### DIFF
--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 04/07/2025
+ms.date: 05/12/2025
 ---
 # Release Notes for the WebView2 SDK
 
@@ -26,6 +26,83 @@ Nov 2024
 moved to archive:
 Oct 2024
 -->
+
+
+<!-- May 2025 Prerelease SDK -->
+<!-- ====================================================================== -->
+## 1.0.####-prerelease
+
+Release Date: May 12, 2025
+
+[NuGet package for WebView2 SDK 1.0.####-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.####-prerelease)
+
+For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version ###.0.####.0 or higher.
+
+
+<!-- ------------------------------ -->
+#### Experimental APIs
+
+No Experimental APIs have been added in this Prerelease SDK.
+The following Experimental APIs have been added in this Prerelease SDK.
+
+
+<!-- ---------- -->
+###### heading
+
+description
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+##### [Win32/C++](#tab/win32cpp)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Promotions
+
+No APIs have been promoted from Experimental to Stable in this Prerelease SDK.
+The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
+
+
+<!-- ---------- -->
+###### heading
+
+description
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+##### [Win32/C++](#tab/win32cpp)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Bug fixes
+
+
+<!-- ---------- -->
+###### Runtime and SDK
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### Runtime-only
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### SDK-only
+
+* Fixed behavior.  ([Issue #]())
+
+<!-- end of May 2025 Prerelease SDK -->
 
 
 <!-- Apr 2025 Release SDK -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -116,17 +116,20 @@ The following APIs have been promoted from Experimental to Stable in this Prerel
 <!-- ---------- -->
 ###### Set default background color on WebView2 initialization (DefaultBackgroundColor API)
 
-The DefaultBackgroundColor API allows users to set the `DefaultBackgroundColor` property at initialization. This prevents a disruptive white flash during the WebView2 loading process.
-
-description
+The DefaultBackgroundColor API allows users to set the `DefaultBackgroundColor` property at initialization.  This prevents a disruptive white flash during the WebView2 loading process.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
+* `CoreWebView2ControllerOptions` Class:
+   * [CoreWebView2ControllerOptions.DefaultBackgroundColor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.defaultbackgroundcolor?view=webview2-dotnet-1.0.3296-prerelease&preserve-view=true)
+
 ##### [WinRT/C#](#tab/winrtcsharp)
-* [CoreWebView2ControllerOptions Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.3296-prerelease&preserve-view=true)
-  
+
+* `CoreWebView2ControllerOptions` Class:
+   * [CoreWebView2ControllerOptions.DefaultBackgroundColor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.3296-prerelease&preserve-view=true#defaultbackgroundcolor)
 
 ##### [Win32/C++](#tab/win32cpp)
+
 * [ICoreWebView2ControllerOptions3](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3?view=webview2-1.0.3296-prerelease&preserve-view=true)
   * [ICoreWebView2ControllerOptions3::get_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3?view=webview2-1.0.3296-prerelease&preserve-view=true#get_defaultbackgroundcolor)
   * [ICoreWebView2ControllerOptions3::put_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3?view=webview2-1.0.3296-prerelease&preserve-view=true#put_defaultbackgroundcolor)
@@ -141,13 +144,10 @@ description
 <!-- ---------- -->
 ###### Runtime-only
 
-* Fixed Find bar not appearing back when window shift happens.
-* Fixed a bug where app was not able to cancel navigation to login pages via NavigationStarting event.
+* Fixed the **Find** bar no longer appearing after the window is shifted.
+* Fixed a bug where the app wasn't able to cancel navigation to login pages via the `NavigationStarting` event.
 * Fixed an issue where downloads from within the default browser frame didn't complete.  ([Issue #5196](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5196))
 * Fixed an issue where the pipe name was incorrectly returned, leading to a crash in some UWP apps. 
-
-
-<!-- ---------- -->
 
 <!-- end of May 2025 Prerelease SDK -->
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -92,54 +92,45 @@ Use this API to manage iframe tracking on a page that contains multiple levels o
 
 <!-- May 2025 Prerelease SDK -->
 <!-- ====================================================================== -->
-## 1.0.####-prerelease
+## 1.0.3296-prerelease
 
 Release Date: May 12, 2025
 
-[NuGet package for WebView2 SDK 1.0.####-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.####-prerelease)
+[NuGet package for WebView2 SDK 1.0.3296-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.3296-prerelease)
 
-For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version ###.0.####.0 or higher.
+For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 137.0.3296.0 or higher.
 
 
 <!-- ------------------------------ -->
 #### Experimental APIs
 
 No Experimental APIs have been added in this Prerelease SDK.
-The following Experimental APIs have been added in this Prerelease SDK.
-
-
-<!-- ---------- -->
-###### heading
-
-description
-
-##### [.NET/C#](#tab/dotnetcsharp)
-
-##### [WinRT/C#](#tab/winrtcsharp)
-
-##### [Win32/C++](#tab/win32cpp)
-
----
 
 
 <!-- ------------------------------ -->
 #### Promotions
 
-No APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
 
 
 <!-- ---------- -->
-###### heading
+###### Set default background color on WebView2 initialization (DefaultBackgroundColor API)
+
+The DefaultBackgroundColor API allows users to set the `DefaultBackgroundColor` property at initialization. This prevents a disruptive white flash during the WebView2 loading process.
 
 description
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
+* [CoreWebView2ControllerOptions Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.3296-prerelease&preserve-view=true)
+  
 
 ##### [Win32/C++](#tab/win32cpp)
-
+* [ICoreWebView2ControllerOptions3](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3?view=webview2-1.0.3296-prerelease&preserve-view=true)
+  * [ICoreWebView2ControllerOptions3::get_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3?view=webview2-1.0.3296-prerelease&preserve-view=true#get_defaultbackgroundcolor)
+  * [ICoreWebView2ControllerOptions3::put_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3?view=webview2-1.0.3296-prerelease&preserve-view=true#put_defaultbackgroundcolor)
+ 
 ---
 
 
@@ -148,21 +139,15 @@ description
 
 
 <!-- ---------- -->
-###### Runtime and SDK
-
-* Fixed behavior.  ([Issue #]())
-
-
-<!-- ---------- -->
 ###### Runtime-only
 
-* Fixed behavior.  ([Issue #]())
+* Fixed Find bar not appearing back when window shift happens.
+* Fixed a bug where app was not able to cancel navigation to login pages via NavigationStarting event.
+* Fixed an issue where downloads from within the default browser frame didn't complete.  ([Issue #5196](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5196))
+* Fixed an issue where the pipe name was incorrectly returned, leading to a crash in some UWP apps. 
 
 
 <!-- ---------- -->
-###### SDK-only
-
-* Fixed behavior.  ([Issue #]())
 
 <!-- end of May 2025 Prerelease SDK -->
 


### PR DESCRIPTION
Article sections for review:

* **Release Notes for the WebView2 SDK** > **version-prerelease**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/index?branch=pr-en-us-3441#103296-prerelease
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/wv2-relnotes-may-2025-prerelease/microsoft-edge/webview2/release-notes/index.md#103296-prerelease
   * Planned live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#103296-prerelease
   * New section.

AB#57443156
