### PR TITLE
Update "Overview of WebView2 APIs" per June 2025 RelNotes

### DIFF
--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 05/05/2025
+ms.date: 06/03/2025
 ---
 # Overview of WebView2 APIs
 
@@ -2925,21 +2925,36 @@ See also [Enable or disable the browser responding to accelerator keys (shortcut
 
 WebView2 can specify a default background color.  The color can be any opaque color, or transparent.  This color will be used if the HTML page doesn't set its own background color.
 
+<!-- todo: maybe link, after PR 3449 merged
+See also:
+* [Set default background color on WebView2 initialization (DefaultBackgroundColor API)](../release-notes/index.md#set-default-background-color-on-webview2-initialization-defaultbackgroundcolor-api) in _Release Notes for the WebView2 SDK_.
+-->
+
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.DefaultBackgroundColor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controller.defaultbackgroundcolor)
+
+* `CoreWebView2ControllerOptions` Class:
+  * [CoreWebView2ControllerOptions.DefaultBackgroundColor Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.defaultbackgroundcolor)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * `CoreWebView2Controller` Class:
    * [CoreWebView2Controller.DefaultBackgroundColor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller#defaultbackgroundcolor)
 
+* `CoreWebView2ControllerOptions` Class:
+  * [CoreWebView2ControllerOptions.DefaultBackgroundColor Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions#defaultbackgroundcolor)
+
 ##### [Win32/C++](#tab/win32cpp)
 
 * `ICoreWebView2Controller2` interface:
-   * [ICoreWebView2Controller2::get_DefaultBackgroundColor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#get_defaultbackgroundcolor)
-   * [ICoreWebView2Controller2::put_DefaultBackgroundColor method](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#put_defaultbackgroundcolor)
+   * [ICoreWebView2Controller2::get_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#get_defaultbackgroundcolor)
+   * [ICoreWebView2Controller2::put_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controller2#put_defaultbackgroundcolor)
+
+* [ICoreWebView2ControllerOptions3](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3)
+  * [ICoreWebView2ControllerOptions3::get_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3#get_defaultbackgroundcolor)
+  * [ICoreWebView2ControllerOptions3::put_DefaultBackgroundColor](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions3#put_defaultbackgroundcolor)
 
 ---
 

--- a/microsoft-edge/webview2/concepts/overview-features-apis.md
+++ b/microsoft-edge/webview2/concepts/overview-features-apis.md
@@ -2925,10 +2925,8 @@ See also [Enable or disable the browser responding to accelerator keys (shortcut
 
 WebView2 can specify a default background color.  The color can be any opaque color, or transparent.  This color will be used if the HTML page doesn't set its own background color.
 
-<!-- todo: maybe link, after PR 3449 merged
 See also:
 * [Set default background color on WebView2 initialization (DefaultBackgroundColor API)](../release-notes/index.md#set-default-background-color-on-webview2-initialization-defaultbackgroundcolor-api) in _Release Notes for the WebView2 SDK_.
--->
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -42,7 +42,7 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 <!-- ------------------------------ -->
 #### Promotions
 
-The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 <!-- ---------- -->


### PR DESCRIPTION
Rendered article section for review:
* **Overview of WebView2 APIs** > **Default background color**
   * `/webview2/concepts/overview-features-apis.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/overview-features-apis?branch=pr-en-us-3463#default-background-color
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/overview-apis-june-2025/microsoft-edge/webview2/concepts/overview-features-apis.md#default-background-color
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/overview-features-apis#default-background-color
   * Added `CoreWebView2ControllerOptions.DefaultBackgroundColor` property, from June RelNotes: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#set-default-background-color-on-webview2-initialization-defaultbackgroundcolor-api

This PR also fixes issue in comment https://github.com/MicrosoftEdge/WebView2Announcements/issues/114#issuecomment-2934994311 --

* **Release Notes for the WebView2 SDK** > **Promotions**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/index?branch=pr-en-us-3463#promotions
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/promoted-in-release/microsoft-edge/webview2/release-notes/index.md#promotions
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#promotions
   * Changed from: 
      * The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
      * to:
      * The following APIs have been promoted to Stable and are now included in this Release SDK.

AB#57794631
