### PR TITLE
APIs promoted to Stable in Release SDK

### DIFF
--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -42,7 +42,7 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 <!-- ------------------------------ -->
 #### Promotions
 
-The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
+The following APIs have been promoted to Stable and are now included in this Release SDK.
 
 
 <!-- ---------- -->


### PR DESCRIPTION
This PR fixes issue in comment https://github.com/MicrosoftEdge/WebView2Announcements/issues/114#issuecomment-2934994311

Rendered article sections for review:
* **Release Notes for the WebView2 SDK** > **Promotions**
   * `path`
   * Internal preview: 
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#promotions
   * Changed from: 
      * The following APIs have been promoted from Experimental to Stable in this Prerelease SDK.
      * to:
      * The following APIs have been promoted to Stable and are now included in this Release SDK.

AB# pending
