### PR TITLE
Add "Microsoft Edge 139 web platform release notes" in TOC

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -30,9 +30,13 @@
           href: ./web-platform/release-notes/index.md
           displayName: what's new, announcements
 
+        - name: Microsoft Edge 139
+          href: ./web-platform/release-notes/139.md
+          displayName: Microsoft Edge 139 web platform release notes (Aug. 2025)  # page title
+
         - name: Microsoft Edge 138
           href: ./web-platform/release-notes/138.md
-          displayName: Microsoft Edge 137 web platform release notes (Jun. 2025)  # page title
+          displayName: Microsoft Edge 138 web platform release notes (Jun. 2025)  # page title
 
         - name: Microsoft Edge 137
           href: ./web-platform/release-notes/137.md


### PR DESCRIPTION
Rendered for review:

* **Microsoft Edge 139 web platform release notes (Aug. 2025)**
   * `web-platform/release-notes/139.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/139?branch=pr-en-us-3493
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/139-toc/microsoft-edge/web-platform/release-notes/139.md
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/139
   * Added TOC entry.

AB#58175887