### PR TITLE
Fix "WebUI 2" typo in "Get started w/ wv2 in WinUI 2 (UWP) apps"

### DIFF
--- a/microsoft-edge/webview2/get-started/winui2.md
+++ b/microsoft-edge/webview2/get-started/winui2.md
@@ -272,11 +272,11 @@ Now you are ready to add WebView2 code to the project.  First, add a namespace r
 <!-- ====================================================================== -->
 ## Step 7 - Build and run the project containing the WebView2 control
 
-1. Click **Debug** > **Start Debugging** (**F5**).  (If building for HoloLens 2, see [Using Visual Studio to deploy and debug](/windows/mixed-reality/develop/advanced-concepts/using-visual-studio?tabs=hl2)). The app window opens, briefly showing the WebView2 WebUI grid:
+1. Click **Debug** > **Start Debugging** (**F5**).  (If building for HoloLens 2, see [Using Visual Studio to deploy and debug](/windows/mixed-reality/develop/advanced-concepts/using-visual-studio?tabs=hl2)). The app window opens, briefly showing the WebView2 WinUI grid:
 
-   ![During debugging, the WebView2 WebUI grid briefly appears](./winui2-images/winui2-getting-started-webview2-grid.png)
+   ![During debugging, the WebView2 WinUI grid briefly appears](./winui2-images/winui2-getting-started-webview2-grid.png)
 
-1. After a moment, the app window shows the Bing website in the WebView2 control for WebUI 2:
+1. After a moment, the app window shows the Bing website in the WebView2 control for WinUI 2:
 
    ![The sample app displays the Bing website](./winui2-images/winui2-getting-started-webview2-with-content.png)
 


### PR DESCRIPTION
Rendered article section for review:

* **Get started with WebView2 in WinUI 2 (UWP) apps** > **Step 7 - Build and run the project containing the WebView2 control**
   * `/webview2/get-started/winui2.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/get-started/winui2?branch=pr-en-us-3502#step-7---build-and-run-the-project-containing-the-webview2-control
   * External preview: https://github.com/mitchcapper/edge-developer/blob/winui2_not_webui2/microsoft-edge/webview2/get-started/winui2.md#step-7---build-and-run-the-project-containing-the-webview2-control
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/get-started/winui2#step-7---build-and-run-the-project-containing-the-webview2-control
   * Changed "WebUI" to "WinUI".
      * 0 hits on "webui" in repo.

PR background:

I feel these places are supposed to be WinUI 2 not WebUI 2.  WebUI 2 is 100% a developer sdk https://github.com/webui-dev/webui but pretty sure not at all what these docs are talking about :)

WebUI 2.0 is also some random naming MS gave to their new 'edge' UI framework that is purely internal, despite some news sources talking about MS releasing WebUI 2.0 itself:)   It however is also not what these docs are referring to.  Clearly someone at MS didn't google before writing the press release but that's a separate issue.     

Hopefully fixing these things will make it a bit less confusing that WebUI 2 is not a MS thing to use in development with WinUI2.

AB#58299740
