### PR TITLE
Update hub page from "Enterprise" to "Business"

### DIFF
--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Landing
-# docset landing page
+# docset landing page; https://learn.microsoft.com/microsoft-edge/developer/
 title: Microsoft Edge Developer documentation # < 60 chars
 summary: Development using Microsoft Edge DevTools, Microsoft Edge extensions, Progressive Web Apps, WebDriver automation, WebView2, and more. # < 160 chars
 

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -19,7 +19,7 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: learn
+      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference

--- a/microsoft-edge/developer/index.yml
+++ b/microsoft-edge/developer/index.yml
@@ -19,11 +19,11 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference
       # - linkListType: sample
+      # - linkListType: training
       # - linkListType: tutorial
       # - linkListType: video
       # - linkListType: whats-new

--- a/microsoft-edge/devtools/landing/index.yml
+++ b/microsoft-edge/devtools/landing/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Landing
-# DevTools landing page
+# DevTools landing page; https://learn.microsoft.com/microsoft-edge/devtools/landing/
 title: Microsoft Edge DevTools documentation
 summary: Development using DevTools in Microsoft Edge.
 

--- a/microsoft-edge/devtools/landing/index.yml
+++ b/microsoft-edge/devtools/landing/index.yml
@@ -23,11 +23,11 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference
       # - linkListType: sample
+      # - linkListType: training
       # - linkListType: tutorial
       # - linkListType: video
       # - linkListType: whats-new

--- a/microsoft-edge/devtools/landing/index.yml
+++ b/microsoft-edge/devtools/landing/index.yml
@@ -23,7 +23,7 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: learn
+      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference

--- a/microsoft-edge/extensions/landing/index.yml
+++ b/microsoft-edge/extensions/landing/index.yml
@@ -23,11 +23,11 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference
       # - linkListType: sample
+      # - linkListType: training
       # - linkListType: tutorial
       # - linkListType: video
       # - linkListType: whats-new

--- a/microsoft-edge/extensions/landing/index.yml
+++ b/microsoft-edge/extensions/landing/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Landing
-# Extensions landing page
+# Extensions landing page; https://learn.microsoft.com/microsoft-edge/extensions/landing/
 title: Microsoft Edge extensions documentation
 summary: Develop an extension (add-on) for Microsoft Edge.
 

--- a/microsoft-edge/extensions/landing/index.yml
+++ b/microsoft-edge/extensions/landing/index.yml
@@ -23,7 +23,7 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: learn
+      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -130,7 +130,7 @@ conceptualContent:
 
             - text: Manage Microsoft Edge for Business on iOS and Android with Intune
               url: /mem/intune/apps/manage-microsoft-edge  # https://learn.microsoft.com/mem/intune/apps/manage-microsoft-edge
-              itemType: reference  # or how-to-guide
+              itemType: how-to-guide
 
 # -----------------------------------------------------------------------------
 # Card r1c4
@@ -138,11 +138,11 @@ conceptualContent:
           links:
             - text: Security  # dest: Microsoft Edge security for your business
               url: /deployedge/ms-edge-security-for-business  # https://learn.microsoft.com/deployedge/ms-edge-security-for-business
-              itemType: reference  # or: concept, overview
+              itemType: concept
 
             - text: Privacy  # dest: Configure Microsoft Edge policies to support enterprise privacy
               url: /deployedge/microsoft-edge-enterprise-privacy-settings  # https://learn.microsoft.com/deployedge/microsoft-edge-enterprise-privacy-settings
-              itemType: reference  # or how-to-guide
+              itemType: how-to-guide
 
 # =============================================================================
 # Row 2 (3 cards, max 4)
@@ -453,7 +453,7 @@ conceptualContent:
               itemType: how-to-guide
 
 # =============================================================================
-# Row 3 (4 cards max) - adding cards changes layout to 3 per row
+# Row 3 (4 cards max) - hid b/c adding cards changes layout to 3 per row instead of 4 per row
 # -----------------------------------------------------------------------------
 # Card for toc bucket 10 - r_c_
 # Card r2c4

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -512,12 +512,12 @@ additionalContent:
           url: /answers/topics/ms-edge.html  # https://learn.microsoft.com/answers/tags/781/microsoft-edge
 # -----------------------------------------------------------------------------
 # Card
-        - summary: If your business needs immediate technical support for Microsoft Edge, 1-on-1 support from Microsoft is available using a variety of plans to help you get your required level of support.
+        - summary: If your business needs immediate technical support for Microsoft Edge, 1-on-1 support is available using a variety of plans.
           title: Microsoft Support for business
           url: https://support.microsoft.com/supportforbusiness/productselection?sapId=a77ee9b7-b6b6-aa08-d7b9-887ebe228207
 # -----------------------------------------------------------------------------
 # Card
-        - summary: Helpful support resources for end-users.
+        - summary: Support for end users (and Devs) about how to use Microsoft Edge features.
           title: Microsoft Edge help & learning
           url: https://support.microsoft.com/microsoft-edge
 

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Hub
-# hub page for Enterprise docset & Edge Dev docset
+# hub page for Enterprise docset & Edge Dev docset; https://learn.microsoft.com/microsoft-edge/
 title: Microsoft Edge documentation
-summary: Learn to use Microsoft Edge by browsing documentation, tutorials, and samples.  Includes information for users, developers, and administrators.
+summary: Explore documentation, references, and code samples to help you deploy, manage, and build with Microsoft Edge.
 brand: m365
 metadata:
   title: Microsoft Edge documentation
@@ -24,13 +24,13 @@ highlightedContent:
 # Row 1 (4 cards)
 # -----------------------------------------------------------------------------
 # Card r1c1
-    - title: "Microsoft Edge (Official Stable Channel)"
+    - title: "WebView2"
       itemType: download
-      url: https://www.microsoft.com/edge
+      url: https://developer.microsoft.com/microsoft-edge/webview2/
 
 # -----------------------------------------------------------------------------
 # Card r1c2
-    - title: "Download Microsoft Edge for Business"
+    - title: "Microsoft Edge for Business"
       itemType: download
       url: https://www.microsoft.com/edge/business/download
 
@@ -42,33 +42,34 @@ highlightedContent:
 
 # -----------------------------------------------------------------------------
 # Card r1c4
-    - title: "Find out what's new"
-      itemType: learn
-      url: https://www.microsoft.com/microsoft-365/roadmap?filters=Microsoft%20Edge   # or https://www.microsoft.com/edge/update/latest (1 at a time)
+    - title: "Microsoft Edge Roadmap"
+      itemType: reference
+      url: https://www.microsoft.com/microsoft-365/roadmap?filters=Microsoft%20Edge   # https://www.microsoft.com/edge/update/latest (shows 1 at a time)
 
 # =============================================================================
 # Row 2 (4 cards)
 # -----------------------------------------------------------------------------
 # Card r2c1
-    - title: "Get support"
+    - title: "Get support"  # scrolls down to "Help and Support" hub page section
       itemType: reference
       url: /microsoft-edge/index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support
 
 # -----------------------------------------------------------------------------
 # Card r2c2
-    - title: "How to use Microsoft Edge"
+    - title: "How to use Microsoft Edge"  # end-user info at Support site
       itemType: learn
       url: https://support.microsoft.com/microsoft-edge?ocid=DMC-End-User-Support
 
 # -----------------------------------------------------------------------------
 # Card r2c3
-    - title: "Administer Microsoft Edge in the Enterprise"
+    - title: "Administer Microsoft Edge for Business"  # todo: goes to "Microsoft Edge Enterprise documentation" landing page, should instead scroll down to "Microsoft Edge for Business" hub page section, for consistent nav design
       itemType: learn
-      url: /deployedge/index
+      url: /deployedge/index  # https://learn.microsoft.com/deployedge/
+    # url: /microsoft-edge/index#microsoft-edge-for-business  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-business
 
 # -----------------------------------------------------------------------------
 # Card r2c4
-    - title: "Discover web developer features"
+    - title: "Discover web developer features"  # scrolls down to "Microsoft Edge for Developers" hub page section
       itemType: learn
       url: /microsoft-edge/index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers
 
@@ -78,7 +79,7 @@ conceptualContent:
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | training | overview | quickstart | reference | sample | tutorial | video | whats-new
 # Supports up to 3 subsections
   sections:
-    - title: Microsoft Edge for Enterprise # < 60 chars (optional)
+    - title: Microsoft Edge for Business # < 60 chars (optional)
       # summary:  # < 160 chars (optional)
       items:
 
@@ -86,47 +87,55 @@ conceptualContent:
 # Row 1 (4 cards)
 # -----------------------------------------------------------------------------
 # Card r1c1
-        - title: Learn about Microsoft Edge in the enterprise
+        - title: Learn about Microsoft Edge for Business
           links:
-            - url: /deployedge/microsoft-edge-channels
+            - url: /deployedge/microsoft-edge-channels  # https://learn.microsoft.com/deployedge/microsoft-edge-channels
               itemType: overview
               text: Microsoft Edge channel overview
 
-            - url: /deployedge/edge-ie-mode
+            - url: /deployedge/microsoft-edge-for-business  # https://learn.microsoft.com/deployedge/microsoft-edge-for-business
               itemType: reference
-              text: Use enterprise features
+              text: Use enterprise features  # dest: Microsoft Edge for Business
 
 # -----------------------------------------------------------------------------
 # Card r1c2
-        - title: Deploy and update Microsoft Edge
+        - title: Deploy and update Microsoft Edge for Business
           links:
-            - itemType: reference
-              text: Video - Deploy Microsoft Edge
-              url: /deployedge/microsoft-edge-video-deploy
-
-            - itemType: reference
+            - itemType: how-to-guide
               text: Deploy to Windows
-              url: /configmgr/apps/deploy-use/deploy-edge
+              url: /configmgr/apps/deploy-use/deploy-edge  # https://learn.microsoft.com/configmgr/apps/deploy-use/deploy-edge
 
-            - itemType: reference
+            - itemType: how-to-guide
               text: Deploy to macOS
-              url: /mem/intune/apps/apps-edge-macos
+              url: /mem/intune/apps/apps-edge-macos  # https://learn.microsoft.com/mem/intune/apps/apps-edge-macos
+
+            - itemType: how-to-guide
+              text: Deploy to BYOD devices
+              url: /deployedge/microsoft-edge-for-business-config-recommendations?form=MA13FQ#protecting-users-and-devices  # todo: omit ?form=MA13FQ
+              # https://learn.microsoft.com/deployedge/microsoft-edge-for-business-config-recommendations?form=MA13FQ#protecting-users-and-devices
+              # https://learn.microsoft.com/deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices
+
+            - itemType: how-to-guide
+              text: Deploy to mobile
+              url: /intune/intune-service/fundamentals/guided-scenarios-edge?form=MA13FJ  # todo: omit ?form=MA13FJ
+              # https://learn.microsoft.com/intune/intune-service/fundamentals/guided-scenarios-edge?form=MA13FJ
+              # https://learn.microsoft.com/intune/intune-service/fundamentals/guided-scenarios-edge
 
 # -----------------------------------------------------------------------------
 # Card r1c3
-        - title: Configure Microsoft Edge
+        - title: Configure Microsoft Edge for Business
           links:
             - itemType: reference
-              text: Configure Microsoft Edge on Windows and macOS
-              url: /deployedge/configure-microsoft-edge
+              text: Configure Microsoft Edge for Business on Windows and macOS
+              url: /deployedge/configure-microsoft-edge  # https://learn.microsoft.com/deployedge/configure-microsoft-edge
 
             - itemType: reference
-              text: Set Microsoft Edge as the default browser
-              url: /deployedge/edge-default-browser
+              text: Set Microsoft Edge for Business as the default browser
+              url: /deployedge/edge-default-browser  # https://learn.microsoft.com/deployedge/edge-default-browser
 
             - itemType: reference
-              text: Manage Microsoft Edge on iOS and Android with Intune
-              url: /mem/intune/apps/manage-microsoft-edge
+              text: Manage Microsoft Edge for Business on iOS and Android with Intune
+              url: /mem/intune/apps/manage-microsoft-edge  # https://learn.microsoft.com/mem/intune/apps/manage-microsoft-edge
 
 # -----------------------------------------------------------------------------
 # Card r1c4
@@ -134,11 +143,11 @@ conceptualContent:
           links:
             - itemType: reference
               text: Security
-              url: /deployedge/ms-edge-security-for-business
+              url: /deployedge/ms-edge-security-for-business  # https://learn.microsoft.com/deployedge/ms-edge-security-for-business
 
             - itemType: reference
               text: Privacy
-              url: /deployedge/microsoft-edge-enterprise-privacy-settings
+              url: /deployedge/microsoft-edge-enterprise-privacy-settings  # https://learn.microsoft.com/deployedge/microsoft-edge-enterprise-privacy-settings
 
 # =============================================================================
 # Row 2 (3 cards, max 4)
@@ -148,11 +157,11 @@ conceptualContent:
           links:
             - itemType: reference
               text: Browser policy reference
-              url: /deployedge/microsoft-edge-policies
+              url: /deployedge/microsoft-edge-policies  # https://learn.microsoft.com/deployedge/microsoft-edge-policies
 
             - itemType: reference
               text: Update policy reference
-              url: /deployedge/microsoft-edge-update-policies
+              url: /deployedge/microsoft-edge-update-policies  # https://learn.microsoft.com/deployedge/microsoft-edge-update-policies
 
 # -----------------------------------------------------------------------------
 # Card r2c2
@@ -161,17 +170,18 @@ conceptualContent:
             - itemType: reference
               text: Enterprise tech community (Insider Focused)
               url: https://techcommunity.microsoft.com/t5/Enterprise/bd-p/EdgeInsiderEnterprise
-            # - itemType: reference
-            #   text: Troubleshoot Microsoft Edge
-            #   url: /deployedge/microsoft-edge-troubleshooting
+
+          # - itemType: reference
+          #   text: Troubleshoot Microsoft Edge
+          #   url: /deployedge/microsoft-edge-troubleshooting
 
 # -----------------------------------------------------------------------------
 # Card r2c3
         - title: Extensions for enterprise
           links:
             - itemType: overview
-              text: Manage Microsoft Edge extensions in the enterprise
-              url: /deployedge/microsoft-edge-manage-extensions
+              text: Manage Microsoft Edge extensions
+              url: /deployedge/microsoft-edge-manage-extensions  # https://learn.microsoft.com/deployedge/microsoft-edge-manage-extensions
 
             - itemType: reference
               text: Defining match patterns for an extension to access file URLs
@@ -508,7 +518,7 @@ additionalContent:
 # Card
         - summary: Get advice and answers from community experts.
           title: Community Support on Microsoft Q&A
-          url: /answers/topics/ms-edge.html
+          url: /answers/topics/ms-edge.html  # https://learn.microsoft.com/answers/tags/781/microsoft-edge
 # -----------------------------------------------------------------------------
 # Card
         - summary: If your business needs immediate technical support for Microsoft Edge, 1:1 support from Microsoft is available using a variety of plans to help you get your required level of support.
@@ -536,10 +546,10 @@ additionalContent:
               url: ./visual-studio-code/index.md
 
             - text: Microsoft Edge Privacy Whitepaper
-              url: /legal/microsoft-edge/privacy
+              url: /legal/microsoft-edge/privacy  # https://learn.microsoft.com/legal/microsoft-edge/privacy
 # -----------------------------------------------------------------------------
 # Card
         - title: Microsoft Edge Legacy documentation
           links:
             - text: Microsoft Edge Legacy documentation
-              url: /archive/microsoft-edge/legacy/developer/
+              url: /archive/microsoft-edge/legacy/developer/  # https://learn.microsoft.com/archive/microsoft-edge/legacy/developer/

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -26,7 +26,7 @@ highlightedContent:
 # Card r1c1
     - title: "WebView2"
       itemType: download
-      url: https://developer.microsoft.com/microsoft-edge/webview2/
+      url: https://developer.microsoft.com/microsoft-edge/webview2/#download
 
 # -----------------------------------------------------------------------------
 # Card r1c2
@@ -111,15 +111,11 @@ conceptualContent:
 
             - itemType: how-to-guide
               text: Deploy to BYOD devices
-              url: /deployedge/microsoft-edge-for-business-config-recommendations?form=MA13FQ#protecting-users-and-devices  # todo: omit ?form=MA13FQ
-              # https://learn.microsoft.com/deployedge/microsoft-edge-for-business-config-recommendations?form=MA13FQ#protecting-users-and-devices
-              # https://learn.microsoft.com/deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices
+              url: /deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices  # https://learn.microsoft.com/deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices
 
             - itemType: how-to-guide
               text: Deploy to mobile
-              url: /intune/intune-service/fundamentals/guided-scenarios-edge?form=MA13FJ  # todo: omit ?form=MA13FJ
-              # https://learn.microsoft.com/intune/intune-service/fundamentals/guided-scenarios-edge?form=MA13FJ
-              # https://learn.microsoft.com/intune/intune-service/fundamentals/guided-scenarios-edge
+              url: /intune/intune-service/fundamentals/guided-scenarios-edge  # https://learn.microsoft.com/intune/intune-service/fundamentals/guided-scenarios-edge
 
 # -----------------------------------------------------------------------------
 # Card r1c3
@@ -180,7 +176,7 @@ conceptualContent:
         - title: Extensions for enterprise
           links:
             - itemType: overview
-              text: Manage Microsoft Edge extensions
+              text: Manage extensions for Microsoft Edge for Business
               url: /deployedge/microsoft-edge-manage-extensions  # https://learn.microsoft.com/deployedge/microsoft-edge-manage-extensions
 
             - itemType: reference

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -50,28 +50,27 @@ highlightedContent:
 # Row 2 (4 cards)
 # -----------------------------------------------------------------------------
 # Card r2c1
-    - title: "Get support"  # scrolls down to "Help and Support" hub page section
-      url: /microsoft-edge/index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support
-      itemType: reference
+    - title: "Microsoft Edge help & learning"  # end-user info at SMC
+      url: https://support.microsoft.com/microsoft-edge
+      itemType: learn
 
 # -----------------------------------------------------------------------------
 # Card r2c2
-    - title: "How to use Microsoft Edge"  # end-user info at Support site
-      url: https://support.microsoft.com/microsoft-edge?ocid=DMC-End-User-Support
+    - title: "Microsoft Edge for Business"  # scroll downs to "Microsoft Edge for Business" hub page section
+      url: /microsoft-edge/index#microsoft-edge-for-business  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-business
       itemType: learn
 
 # -----------------------------------------------------------------------------
 # Card r2c3
-    - title: "Administer Microsoft Edge for Business"  # todo: goes to "Microsoft Edge Enterprise documentation" landing page, should instead scroll down to "Microsoft Edge for Business" hub page section, for consistent nav design
-      url: /deployedge/index  # https://learn.microsoft.com/deployedge/
-    # url: /microsoft-edge/index#microsoft-edge-for-business  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-business
+    - title: "Microsoft Edge for Developers"  # scrolls down to "Microsoft Edge for Developers" hub page section
+      url: /microsoft-edge/index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers
       itemType: learn
 
 # -----------------------------------------------------------------------------
 # Card r2c4
-    - title: "Discover web developer features"  # scrolls down to "Microsoft Edge for Developers" hub page section
-      url: /microsoft-edge/index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers
-      itemType: learn
+    - title: "Help and Support"  # scrolls down to "Help and Support" hub page section
+      url: /microsoft-edge/index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support
+      itemType: reference
 
 # =============================================================================
 # "Microsoft Edge for Enterprise" section of hub page: 2 rows of up to 4 cards
@@ -89,61 +88,61 @@ conceptualContent:
 # Card r1c1
         - title: Learn about Microsoft Edge for Business
           links:
-            - url: /deployedge/microsoft-edge-channels  # https://learn.microsoft.com/deployedge/microsoft-edge-channels
+            - text: Microsoft Edge channel overview
+              url: /deployedge/microsoft-edge-channels  # https://learn.microsoft.com/deployedge/microsoft-edge-channels
               itemType: overview
-              text: Microsoft Edge channel overview
 
-            - url: /deployedge/microsoft-edge-for-business  # https://learn.microsoft.com/deployedge/microsoft-edge-for-business
+            - text: Use enterprise features  # dest: Microsoft Edge for Business
+              url: /deployedge/microsoft-edge-for-business  # https://learn.microsoft.com/deployedge/microsoft-edge-for-business
               itemType: reference
-              text: Use enterprise features  # dest: Microsoft Edge for Business
 
 # -----------------------------------------------------------------------------
 # Card r1c2
         - title: Deploy and update Microsoft Edge for Business
           links:
-            - itemType: how-to-guide
-              text: Deploy to Windows
+            - text: Deploy to Windows
               url: /configmgr/apps/deploy-use/deploy-edge  # https://learn.microsoft.com/configmgr/apps/deploy-use/deploy-edge
+              itemType: how-to-guide
 
-            - itemType: how-to-guide
-              text: Deploy to macOS
+            - text: Deploy to macOS
               url: /mem/intune/apps/apps-edge-macos  # https://learn.microsoft.com/mem/intune/apps/apps-edge-macos
+              itemType: how-to-guide
 
-            - itemType: how-to-guide
-              text: Deploy to BYOD devices
+            - text: Deploy to BYOD devices
               url: /deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices  # https://learn.microsoft.com/deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices
+              itemType: how-to-guide
 
-            - itemType: how-to-guide
-              text: Deploy to mobile
+            - text: Deploy to mobile
               url: /intune/intune-service/fundamentals/guided-scenarios-edge  # https://learn.microsoft.com/intune/intune-service/fundamentals/guided-scenarios-edge
+              itemType: how-to-guide
 
 # -----------------------------------------------------------------------------
 # Card r1c3
         - title: Configure Microsoft Edge for Business
           links:
-            - itemType: reference
-              text: Configure Microsoft Edge for Business on Windows and macOS
+            - text: Configure Microsoft Edge for Business on Windows and macOS
               url: /deployedge/configure-microsoft-edge  # https://learn.microsoft.com/deployedge/configure-microsoft-edge
+              itemType: reference
 
-            - itemType: reference
-              text: Set Microsoft Edge for Business as the default browser
+            - text: Set Microsoft Edge for Business as the default browser
               url: /deployedge/edge-default-browser  # https://learn.microsoft.com/deployedge/edge-default-browser
+              itemType: reference
 
-            - itemType: reference
-              text: Manage Microsoft Edge for Business on iOS and Android with Intune
+            - text: Manage Microsoft Edge for Business on iOS and Android with Intune
               url: /mem/intune/apps/manage-microsoft-edge  # https://learn.microsoft.com/mem/intune/apps/manage-microsoft-edge
+              itemType: reference
 
 # -----------------------------------------------------------------------------
 # Card r1c4
         - title: Manage security and privacy
           links:
-            - itemType: reference
-              text: Security
+            - text: Security
               url: /deployedge/ms-edge-security-for-business  # https://learn.microsoft.com/deployedge/ms-edge-security-for-business
+              itemType: reference
 
-            - itemType: reference
-              text: Privacy
+            - text: Privacy
               url: /deployedge/microsoft-edge-enterprise-privacy-settings  # https://learn.microsoft.com/deployedge/microsoft-edge-enterprise-privacy-settings
+              itemType: reference
 
 # =============================================================================
 # Row 2 (3 cards, max 4)
@@ -151,41 +150,41 @@ conceptualContent:
 # Card r2c1
         - title: Policy reference
           links:
-            - itemType: reference
-              text: Browser policy reference
+            - text: Browser policy reference
               url: /deployedge/microsoft-edge-policies  # https://learn.microsoft.com/deployedge/microsoft-edge-policies
+              itemType: reference
 
-            - itemType: reference
-              text: Update policy reference
+            - text: Update policy reference
               url: /deployedge/microsoft-edge-update-policies  # https://learn.microsoft.com/deployedge/microsoft-edge-update-policies
+              itemType: reference
 
 # -----------------------------------------------------------------------------
 # Card r2c2
         - title: Engage with enterprise community
           links:
-            - itemType: reference
-              text: Enterprise tech community (Insider Focused)
+            - text: Enterprise tech community (Insider Focused)
               url: https://techcommunity.microsoft.com/t5/Enterprise/bd-p/EdgeInsiderEnterprise
+              itemType: reference
 
-          # - itemType: reference
-          #   text: Troubleshoot Microsoft Edge
+          # - text: Troubleshoot Microsoft Edge
           #   url: /deployedge/microsoft-edge-troubleshooting
+          #   itemType: reference
 
 # -----------------------------------------------------------------------------
 # Card r2c3
         - title: Extensions for enterprise
           links:
-            - itemType: overview
-              text: Manage extensions for Microsoft Edge for Business
+            - text: Manage extensions for Microsoft Edge for Business
               url: /deployedge/microsoft-edge-manage-extensions  # https://learn.microsoft.com/deployedge/microsoft-edge-manage-extensions
+              itemType: overview
 
-            - itemType: reference
-              text: Defining match patterns for an extension to access file URLs
+            - text: Defining match patterns for an extension to access file URLs
               url: ./extensions/developer-guide/match-patterns.md
+              itemType: reference
 
-            - itemType: reference
-              text: Extension hosting
+            - text: Extension hosting
               url: ./extensions/publish/hosting-and-updating.md
+              itemType: reference
 
 # -----------------------------------------------------------------------------
 # Card r2c4

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -17,7 +17,7 @@ metadata:
 # topmost section of hub page; 2 rows of 4 cards
 # Maximum of 8 items
 highlightedContent:
-# itemType: architecture | concept | deploy | download | get-started | how-to-guide | training | overview | quickstart | reference | sample | tutorial | video | whats-new
+# itemType: architecture | concept | deploy | download | get-started | how-to-guide | overview | quickstart | reference | sample | training | tutorial | video | whats-new
   items:
 
 # =============================================================================
@@ -75,7 +75,7 @@ highlightedContent:
 # =============================================================================
 # "Microsoft Edge for Enterprise" section of hub page: 2 rows of up to 4 cards
 conceptualContent:
-# itemType: architecture | concept | deploy | download | get-started | how-to-guide | training | overview | quickstart | reference | sample | tutorial | video | whats-new
+# itemType: architecture | concept | deploy | download | get-started | how-to-guide | overview | quickstart | reference | sample | training | tutorial | video | whats-new
 # Supports up to 3 subsections
   sections:
     - title: Microsoft Edge for Business # < 60 chars (optional)

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -52,19 +52,19 @@ highlightedContent:
 # Card r2c1
     - title: "Microsoft Edge help & learning"  # end-user info at SMC
       url: https://support.microsoft.com/microsoft-edge
-      itemType: learn
+      itemType: training
 
 # -----------------------------------------------------------------------------
 # Card r2c2
     - title: "Microsoft Edge for Business"  # scroll downs to "Microsoft Edge for Business" hub page section
       url: /microsoft-edge/index#microsoft-edge-for-business  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-business
-      itemType: learn
+      itemType: training
 
 # -----------------------------------------------------------------------------
 # Card r2c3
     - title: "Microsoft Edge for Developers"  # scrolls down to "Microsoft Edge for Developers" hub page section
       url: /microsoft-edge/index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers
-      itemType: learn
+      itemType: training
 
 # -----------------------------------------------------------------------------
 # Card r2c4
@@ -88,7 +88,7 @@ conceptualContent:
 # Card r1c1
         - title: Learn about Microsoft Edge for Business
           links:
-            - text: Microsoft Edge channel overview
+            - text: Overview of the Microsoft Edge channels
               url: /deployedge/microsoft-edge-channels  # https://learn.microsoft.com/deployedge/microsoft-edge-channels
               itemType: overview
 
@@ -102,19 +102,19 @@ conceptualContent:
           links:
             - text: Deploy to Windows
               url: /configmgr/apps/deploy-use/deploy-edge  # https://learn.microsoft.com/configmgr/apps/deploy-use/deploy-edge
-              itemType: how-to-guide
+              itemType: deploy
 
             - text: Deploy to macOS
               url: /mem/intune/apps/apps-edge-macos  # https://learn.microsoft.com/mem/intune/apps/apps-edge-macos
-              itemType: how-to-guide
+              itemType: deploy
 
             - text: Deploy to BYOD devices
               url: /deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices  # https://learn.microsoft.com/deployedge/microsoft-edge-for-business-config-recommendations#protecting-users-and-devices
-              itemType: how-to-guide
+              itemType: deploy
 
             - text: Deploy to mobile
               url: /intune/intune-service/fundamentals/guided-scenarios-edge  # https://learn.microsoft.com/intune/intune-service/fundamentals/guided-scenarios-edge
-              itemType: how-to-guide
+              itemType: deploy
 
 # -----------------------------------------------------------------------------
 # Card r1c3
@@ -122,27 +122,27 @@ conceptualContent:
           links:
             - text: Configure Microsoft Edge for Business on Windows and macOS
               url: /deployedge/configure-microsoft-edge  # https://learn.microsoft.com/deployedge/configure-microsoft-edge
-              itemType: reference
+              itemType: how-to-guide
 
             - text: Set Microsoft Edge for Business as the default browser
               url: /deployedge/edge-default-browser  # https://learn.microsoft.com/deployedge/edge-default-browser
-              itemType: reference
+              itemType: how-to-guide
 
             - text: Manage Microsoft Edge for Business on iOS and Android with Intune
               url: /mem/intune/apps/manage-microsoft-edge  # https://learn.microsoft.com/mem/intune/apps/manage-microsoft-edge
-              itemType: reference
+              itemType: reference  # or how-to-guide
 
 # -----------------------------------------------------------------------------
 # Card r1c4
         - title: Manage security and privacy
           links:
-            - text: Security
+            - text: Security  # dest: Microsoft Edge security for your business
               url: /deployedge/ms-edge-security-for-business  # https://learn.microsoft.com/deployedge/ms-edge-security-for-business
-              itemType: reference
+              itemType: reference  # or: concept, overview
 
-            - text: Privacy
+            - text: Privacy  # dest: Configure Microsoft Edge policies to support enterprise privacy
               url: /deployedge/microsoft-edge-enterprise-privacy-settings  # https://learn.microsoft.com/deployedge/microsoft-edge-enterprise-privacy-settings
-              itemType: reference
+              itemType: reference  # or how-to-guide
 
 # =============================================================================
 # Row 2 (3 cards, max 4)
@@ -150,11 +150,11 @@ conceptualContent:
 # Card r2c1
         - title: Policy reference
           links:
-            - text: Browser policy reference
+            - text: Browser policy reference  # dest: Microsoft Edge - Policies
               url: /deployedge/microsoft-edge-policies  # https://learn.microsoft.com/deployedge/microsoft-edge-policies
               itemType: reference
 
-            - text: Update policy reference
+            - text: Update policy reference  # dest: Microsoft Edge - Update policies
               url: /deployedge/microsoft-edge-update-policies  # https://learn.microsoft.com/deployedge/microsoft-edge-update-policies
               itemType: reference
 
@@ -164,11 +164,7 @@ conceptualContent:
           links:
             - text: Enterprise tech community (Insider Focused)
               url: https://techcommunity.microsoft.com/t5/Enterprise/bd-p/EdgeInsiderEnterprise
-              itemType: reference
-
-          # - text: Troubleshoot Microsoft Edge
-          #   url: /deployedge/microsoft-edge-troubleshooting
-          #   itemType: reference
+              itemType: reference  # forum-posts filter
 
 # -----------------------------------------------------------------------------
 # Card r2c3
@@ -179,11 +175,11 @@ conceptualContent:
               itemType: overview
 
             - text: Defining match patterns for an extension to access file URLs
-              url: ./extensions/developer-guide/match-patterns.md
+              url: ./extensions/developer-guide/match-patterns.md  # https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/match-patterns
               itemType: reference
 
             - text: Extension hosting
-              url: ./extensions/publish/hosting-and-updating.md
+              url: ./extensions/publish/hosting-and-updating.md  # https://learn.microsoft.com/microsoft-edge/extensions/publish/hosting-and-updating
               itemType: reference
 
 # -----------------------------------------------------------------------------
@@ -516,13 +512,13 @@ additionalContent:
           url: /answers/topics/ms-edge.html  # https://learn.microsoft.com/answers/tags/781/microsoft-edge
 # -----------------------------------------------------------------------------
 # Card
-        - summary: If your business needs immediate technical support for Microsoft Edge, 1:1 support from Microsoft is available using a variety of plans to help you get your required level of support.
-          title: Microsoft Support for Business
+        - summary: If your business needs immediate technical support for Microsoft Edge, 1-on-1 support from Microsoft is available using a variety of plans to help you get your required level of support.
+          title: Microsoft Support for business
           url: https://support.microsoft.com/supportforbusiness/productselection?sapId=a77ee9b7-b6b6-aa08-d7b9-887ebe228207
 # -----------------------------------------------------------------------------
 # Card
-        - summary: Helpful support resources for users is available.
-          title: User Support
+        - summary: Helpful support resources for end-users.
+          title: Microsoft Edge help & learning
           url: https://support.microsoft.com/microsoft-edge
 
 # =============================================================================

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -25,53 +25,53 @@ highlightedContent:
 # -----------------------------------------------------------------------------
 # Card r1c1
     - title: "WebView2"
-      itemType: download
       url: https://developer.microsoft.com/microsoft-edge/webview2/#download
+      itemType: download
 
 # -----------------------------------------------------------------------------
 # Card r1c2
     - title: "Microsoft Edge for Business"
-      itemType: download
       url: https://www.microsoft.com/edge/business/download
+      itemType: download
 
 # -----------------------------------------------------------------------------
 # Card r1c3
     - title: "Microsoft Edge Insider Channels"
-      itemType: download
       url: https://www.microsoft.com/edge/download/insider
+      itemType: download
 
 # -----------------------------------------------------------------------------
 # Card r1c4
     - title: "Microsoft Edge Roadmap"
-      itemType: reference
       url: https://www.microsoft.com/microsoft-365/roadmap?filters=Microsoft%20Edge   # https://www.microsoft.com/edge/update/latest (shows 1 at a time)
+      itemType: reference
 
 # =============================================================================
 # Row 2 (4 cards)
 # -----------------------------------------------------------------------------
 # Card r2c1
     - title: "Get support"  # scrolls down to "Help and Support" hub page section
-      itemType: reference
       url: /microsoft-edge/index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support
+      itemType: reference
 
 # -----------------------------------------------------------------------------
 # Card r2c2
     - title: "How to use Microsoft Edge"  # end-user info at Support site
-      itemType: learn
       url: https://support.microsoft.com/microsoft-edge?ocid=DMC-End-User-Support
+      itemType: learn
 
 # -----------------------------------------------------------------------------
 # Card r2c3
     - title: "Administer Microsoft Edge for Business"  # todo: goes to "Microsoft Edge Enterprise documentation" landing page, should instead scroll down to "Microsoft Edge for Business" hub page section, for consistent nav design
-      itemType: learn
       url: /deployedge/index  # https://learn.microsoft.com/deployedge/
     # url: /microsoft-edge/index#microsoft-edge-for-business  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-business
+      itemType: learn
 
 # -----------------------------------------------------------------------------
 # Card r2c4
     - title: "Discover web developer features"  # scrolls down to "Microsoft Edge for Developers" hub page section
-      itemType: learn
       url: /microsoft-edge/index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers
+      itemType: learn
 
 # =============================================================================
 # "Microsoft Edge for Enterprise" section of hub page: 2 rows of up to 4 cards

--- a/microsoft-edge/index.yml
+++ b/microsoft-edge/index.yml
@@ -24,25 +24,25 @@ highlightedContent:
 # Row 1 (4 cards)
 # -----------------------------------------------------------------------------
 # Card r1c1
-    - title: "WebView2"
-      url: https://developer.microsoft.com/microsoft-edge/webview2/#download
-      itemType: download
-
-# -----------------------------------------------------------------------------
-# Card r1c2
-    - title: "Microsoft Edge for Business"
+    - title: Microsoft Edge for Business
       url: https://www.microsoft.com/edge/business/download
       itemType: download
 
 # -----------------------------------------------------------------------------
-# Card r1c3
-    - title: "Microsoft Edge Insider Channels"
+# Card r1c2
+    - title: Microsoft Edge Insider Channels
       url: https://www.microsoft.com/edge/download/insider
       itemType: download
 
 # -----------------------------------------------------------------------------
+# Card r1c3
+    - title: WebView2
+      url: https://developer.microsoft.com/microsoft-edge/webview2/#download
+      itemType: download
+
+# -----------------------------------------------------------------------------
 # Card r1c4
-    - title: "Microsoft Edge Roadmap"
+    - title: Microsoft Edge Roadmap
       url: https://www.microsoft.com/microsoft-365/roadmap?filters=Microsoft%20Edge   # https://www.microsoft.com/edge/update/latest (shows 1 at a time)
       itemType: reference
 
@@ -50,27 +50,27 @@ highlightedContent:
 # Row 2 (4 cards)
 # -----------------------------------------------------------------------------
 # Card r2c1
-    - title: "Microsoft Edge help & learning"  # end-user info at SMC
-      url: https://support.microsoft.com/microsoft-edge
-      itemType: training
-
-# -----------------------------------------------------------------------------
-# Card r2c2
-    - title: "Microsoft Edge for Business"  # scroll downs to "Microsoft Edge for Business" hub page section
+    - title: Microsoft Edge for Business  # scrolls down to hub page section
       url: /microsoft-edge/index#microsoft-edge-for-business  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-business
       itemType: training
 
 # -----------------------------------------------------------------------------
-# Card r2c3
-    - title: "Microsoft Edge for Developers"  # scrolls down to "Microsoft Edge for Developers" hub page section
+# Card r2c2
+    - title: Microsoft Edge for Developers  # scrolls down to hub page section
       url: /microsoft-edge/index#microsoft-edge-for-developers  # https://learn.microsoft.com/microsoft-edge/#microsoft-edge-for-developers
       itemType: training
 
 # -----------------------------------------------------------------------------
-# Card r2c4
-    - title: "Help and Support"  # scrolls down to "Help and Support" hub page section
+# Card r2c3
+    - title: Help and Support  # scrolls down to hub page section
       url: /microsoft-edge/index#help-and-support  # https://learn.microsoft.com/microsoft-edge/#help-and-support
-      itemType: reference
+      itemType: training
+
+# -----------------------------------------------------------------------------
+# Card r2c4
+    - title: Microsoft Edge help & learning  # end-user info at SMC (member of above)
+      url: https://support.microsoft.com/microsoft-edge
+      itemType: training
 
 # =============================================================================
 # "Microsoft Edge for Enterprise" section of hub page: 2 rows of up to 4 cards
@@ -507,18 +507,18 @@ additionalContent:
       items:
 # -----------------------------------------------------------------------------
 # Card
-        - summary: Get advice and answers from community experts.
-          title: Community Support on Microsoft Q&A
+        - title: Community Support on Microsoft Q&A
+          summary: Get advice and answers from community experts.
           url: /answers/topics/ms-edge.html  # https://learn.microsoft.com/answers/tags/781/microsoft-edge
 # -----------------------------------------------------------------------------
 # Card
-        - summary: If your business needs immediate technical support for Microsoft Edge, 1-on-1 support is available using a variety of plans.
-          title: Microsoft Support for business
+        - title: Microsoft Support for business
+          summary: If your business needs immediate technical support for Microsoft Edge, 1-on-1 support is available using a variety of plans.
           url: https://support.microsoft.com/supportforbusiness/productselection?sapId=a77ee9b7-b6b6-aa08-d7b9-887ebe228207
 # -----------------------------------------------------------------------------
 # Card
-        - summary: Support for end users (and Devs) about how to use Microsoft Edge features.
-          title: Microsoft Edge help & learning
+        - title: Microsoft Edge help & learning
+          summary: Support for end users about how to use Microsoft Edge features.
           url: https://support.microsoft.com/microsoft-edge
 
 # =============================================================================

--- a/microsoft-edge/progressive-web-apps/landing/index.yml
+++ b/microsoft-edge/progressive-web-apps/landing/index.yml
@@ -24,11 +24,11 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference
       # - linkListType: sample
+      # - linkListType: training
       # - linkListType: tutorial
       # - linkListType: video
       # - linkListType: whats-new

--- a/microsoft-edge/progressive-web-apps/landing/index.yml
+++ b/microsoft-edge/progressive-web-apps/landing/index.yml
@@ -24,7 +24,7 @@ metadata:
       # - linkListType: download
       # - linkListType: get-started
       # - linkListType: how-to-guide
-      # - linkListType: learn
+      # - linkListType: training
       # - linkListType: overview
       # - linkListType: quickstart
       # - linkListType: reference

--- a/microsoft-edge/progressive-web-apps/landing/index.yml
+++ b/microsoft-edge/progressive-web-apps/landing/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Landing
-# PWA landing page
+# PWA landing page; https://learn.microsoft.com/microsoft-edge/progressive-web-apps/landing/
 title: Progressive Web Apps (PWAs) documentation
 summary: Develop a web app that can be installed and run on all devices, from one codebase. Provide a native-like UX, or run in the browser.
 # summary < 160 chars; cursor 169

--- a/microsoft-edge/webview2/landing/index.yml
+++ b/microsoft-edge/webview2/landing/index.yml
@@ -1,5 +1,5 @@
 ### YamlMime:Landing
-# WebView2 landing page
+# WebView2 landing page; https://learn.microsoft.com/microsoft-edge/webview2/landing/
 title: WebView2 documentation
 summary: Embed web technologies (HTML, CSS, and JavaScript) in your native apps.
 


### PR DESCRIPTION
Rendered hub page for review:

* **Microsoft Edge documentation**
   * `~/index.yml`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/index?branch=pr-en-us-3503
   * External preview (raw): https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/hub/microsoft-edge/index.yml
   * Before/live: https://learn.microsoft.com/microsoft-edge/
   * Changed topmost section & **Microsoft Edge for Business** section per "Microsoft Edge documentation homepage changes July 25.docx".
      * Instead of topmost section linking away to landing page for Business, scrolled down to that section of hub page (like for Dev section).
      * In topmost section, reseq'd cards within rows.
   * Improved itemType values (icons & headings for doc-type).
      * Updated from "learn" to "training".
   * In **Help and Support** section, improved verbose descriptions.
   * Added comments, to support Maint & doc-design.

AB#58227113
