### PR TITLE
Update Windows 10 support info for WebView2

### DIFF
--- a/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
+++ b/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
@@ -164,10 +164,10 @@ Key compatibility limitations include the operating system and rendering in fram
 <!-- ------------------------------ -->
 #### Operating systems
 
-All hosting modes are supported wherever WebView2 is supported; that is, Windows 10 and later, and certain Windows Server versions.  Windows 7, 8 and 8.1 are no longer supported; Windows 7 and Windows 8 only support Windowed hosting, not Visual hosting.
+All hosting modes are supported wherever WebView2 is supported.
 
 See also:
-* [Windows 7 and 8](../index.md#windows-7-and-8) in _Introduction to Microsoft Edge WebView2_.
+* [Support Windows versions](../index.md#supported-windows-versions) in _Introduction to Microsoft Edge WebView2_.
 
 
 <!-- ------------------------------ -->
@@ -181,7 +181,6 @@ See also:
 <!-- all links in article, except api ref docs -->
 
 * [Overview of WebView2 APIs](./overview-features-apis.md)
-* [Windows 7 and 8](../index.md#windows-7-and-8) in _Introduction to Microsoft Edge WebView2_.
 <!-- omit:
 * [Enhance UI with the Visual layer (Windows App SDK/WinUI 3)](https://learn.microsoft.com/windows/apps/windows-app-sdk/composition) - Windows App Development. -->
 

--- a/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
+++ b/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
@@ -167,7 +167,7 @@ Key compatibility limitations include the operating system and rendering in fram
 All hosting modes are supported wherever WebView2 is supported.
 
 See also:
-* [Support Windows versions](../index.md#supported-windows-versions) in _Introduction to Microsoft Edge WebView2_.
+* [Supported Windows versions](../index.md#supported-windows-versions) in _Introduction to Microsoft Edge WebView2_.
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/webview2/index.md
+++ b/microsoft-edge/webview2/index.md
@@ -67,6 +67,8 @@ Hybrid apps, in the middle of this spectrum, allow you to enjoy the best of both
 
 The Windows operating systems that are supported by Webview2 are the same as those supported by Microsoft Edge.
 
+For more information about other supported operating systems, see [Microsoft Edge supported Operating Systems](/deployedge/microsoft-edge-supported-operating-systems).
+
 
 <!-- ------------------------------ -->
 #### Windows Client
@@ -82,8 +84,10 @@ WebView2 apps can run on the following versions of Windows Client:
 * Windows 10 Enterprise multi-session
 * Windows 10 IoT Enterprise SAC
 * Windows 10 IoT Enterprise 2019 LTSC
+* Windows 10 IoT Enterprise 2021 LTSC
 * Windows 11
 * Windows 11 Enterprise multi-session
+* Windows 11 IoT Enterprise 2024 LTSC
 
 For details, see [Windows Client](/deployedge/microsoft-edge-supported-operating-systems#windows-client) in _Microsoft Edge supported Operating Systems_.
 
@@ -99,22 +103,6 @@ WebView2 apps can run on the following versions of Windows Server:
 * Windows Server (SAC)
 
 For details, see [Windows Server](/deployedge/microsoft-edge-supported-operating-systems#windows-server) in _Microsoft Edge supported Operating Systems_.
-
-
-<!-- ------------------------------ -->
-#### Windows 7 and 8
-
-WebView2 Runtime version 109 is the final version that supports the following versions of Windows.  WebView2 Runtime and SDK version 110.0.1519.0 and higher don't support these operating systems.
-
-*  Windows Server 2008 R2
-*  Windows Server 2012
-*  Windows Server 2012 R2
-*  Windows 7
-*  Windows 8/8.1
-
-See also:
-* [Microsoft Edge supported Operating Systems](/deployedge/microsoft-edge-supported-operating-systems) - WebView2 support for Windows 7 and Windows Server 2008 R2 have the same support timeline as Microsoft Edge.
-* [Microsoft Edge and WebView2 ending support for Windows 7 and Windows 8/8.1](https://blogs.windows.com/msedgedev/2022/12/09/microsoft-edge-and-webview2-ending-support-for-windows-7-and-windows-8-8-1/)
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/archive.md
+++ b/microsoft-edge/webview2/release-notes/archive.md
@@ -8594,7 +8594,7 @@ This version of the WebView2 SDK requires Microsoft Edge version 80.0.314.0 or h
 <!-- ------------------------------ -->
 #### Changes
 
-*  Added support for Windows 7, Windows 8, and Windows 8.1.  See [Windows 7 and 8](../index.md#windows-7-and-8) in _Introduction to Microsoft Edge WebView2_.
+*  Added support for Windows 7, Windows 8, and Windows 8.1.  See [Support Windows versions](../index.md#supported-windows-versions) in _Introduction to Microsoft Edge WebView2_.
 *  Added Visual Studio and Visual Studio Code debug support for WebView2.  Now, debug your script in the WebView2 right from your IDE.  See [How to debug when developing with WebView2 controls](../how-to/debug.md).
 *  Added `Native Object Injection` for the running script in WebView2 to access an IDispatch object from the Win32 component of the app and access the properties of the IDispatch object.  See [AddRemoteObject](/microsoft-edge/webview2/reference/win32/iwebview2webview4?view=webview2-0.8.355&preserve-view=true#addremoteobject) ([#17](https://github.com/MicrosoftEdge/WebViewFeedback/issues/17)).
 *  Added `AcceleratorKeyPressed` event.  See [add_AcceleratorKeyPressed](/microsoft-edge/webview2/reference/win32/iwebview2webview4?view=webview2-0.8.355&preserve-view=true#add_acceleratorkeypressed) ([#57](https://github.com/MicrosoftEdge/WebViewFeedback/issues/57)).

--- a/microsoft-edge/webview2/release-notes/archive.md
+++ b/microsoft-edge/webview2/release-notes/archive.md
@@ -8594,7 +8594,7 @@ This version of the WebView2 SDK requires Microsoft Edge version 80.0.314.0 or h
 <!-- ------------------------------ -->
 #### Changes
 
-*  Added support for Windows 7, Windows 8, and Windows 8.1.  See [Support Windows versions](../index.md#supported-windows-versions) in _Introduction to Microsoft Edge WebView2_.
+*  Added support for Windows 7, Windows 8, and Windows 8.1.  See [Supported Windows versions](../index.md#supported-windows-versions) in _Introduction to Microsoft Edge WebView2_.
 *  Added Visual Studio and Visual Studio Code debug support for WebView2.  Now, debug your script in the WebView2 right from your IDE.  See [How to debug when developing with WebView2 controls](../how-to/debug.md).
 *  Added `Native Object Injection` for the running script in WebView2 to access an IDispatch object from the Win32 component of the app and access the properties of the IDispatch object.  See [AddRemoteObject](/microsoft-edge/webview2/reference/win32/iwebview2webview4?view=webview2-0.8.355&preserve-view=true#addremoteobject) ([#17](https://github.com/MicrosoftEdge/WebViewFeedback/issues/17)).
 *  Added `AcceleratorKeyPressed` event.  See [add_AcceleratorKeyPressed](/microsoft-edge/webview2/reference/win32/iwebview2webview4?view=webview2-0.8.355&preserve-view=true#add_acceleratorkeypressed) ([#57](https://github.com/MicrosoftEdge/WebViewFeedback/issues/57)).


### PR DESCRIPTION
Rendered article sections for review:

* **Introduction to Microsoft Edge WebView2** > **Supported Windows versions**
   * `/webview2/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/index?branch=pr-en-us-3512#supported-windows-versions
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/wv2-windows/microsoft-edge/webview2/index.md#supported-windows-versions
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/#supported-windows-versions
   * Added link [Microsoft Edge supported Operating Systems].
   * In **Windows Client** section, added two list items.
   * Removed **Windows 7 and 8** section.

* **Windowed vs. Visual hosting of WebView2** > **Operating systems**
   * `/webview2/concepts/windowed-vs-visual-hosting.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting?branch=pr-en-us-3512#operating-systems
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/wv2-windows/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md#operating-systems
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting#operating-systems
   * Removed Windows 7 & 8 details.
   * Changed See Also link from [Windows 7 and 8] to [Supported Windows versions].
   * See Also section: Removed link [Windows 7 and 8].

* **Archived Release Notes for the WebView2 SDK** > **0.8.314**
   * `/webview2/release-notes/archive.md`
   * Internal preview: https://review.learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive?branch=pr-en-us-3512#08314
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/wv2-windows/microsoft-edge/webview2/release-notes/archive.md#08314
   * Before/live: https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/archive#08314
   * Changed See link from [Windows 7 and 8] to [Supported Windows versions].

PR background:

The WV2 Windows client support information is out of date with https://learn.microsoft.com/en-us/deployedge/microsoft-edge-supported-operating-systems#windows-client
This PR updates that information.

Also added a link to the https://learn.microsoft.com/en-us/deployedge/microsoft-edge-supported-operating-systems at the top of the h2 section, to learn more about other OSes.

Now that we have that link, we can also safely remove the Windows 7/8 info, since support ended more than one year ago, and the linked page already has that information.

AB#58400617