### PR TITLE
Install playwright to get Edge OTs

### DIFF
--- a/.github/workflows/webplat-relnotes.yaml
+++ b/.github/workflows/webplat-relnotes.yaml
@@ -24,6 +24,7 @@ jobs:
         run: |
           cd scripts
           npm install
+          npx playwright install
 
       - name: Generate release notes
         run: |


### PR DESCRIPTION
The release notes script is failing because the Playwright library (which we need to gather Edge OTs) needs an additional install command before it can be used. This PR fixes the failure by installing Playwright.