### PR TITLE
Commit the new release notes file if it was created

### DIFF
--- a/.github/workflows/webplat-relnotes.yaml
+++ b/.github/workflows/webplat-relnotes.yaml
@@ -34,13 +34,15 @@ jobs:
 
       - name: Commit changes
         run: |
-          if ! git diff --quiet; then
-            git config --local user.email "${{ github.actor }}@users.noreply.github.com"
-            git config --local user.name "${{ github.actor }}"
-            git checkout -b web-platform-release-notes
-            git add .
-            git commit -m "New beta web platform release notes"
-            git push origin web-platform-release-notes
+          files=$(git ls-files --others --exclude-standard)
+          if [ -n "$files" ]; then
+              echo "Committing the new release notes file."
+              git config --local user.email "${{ github.actor }}@users.noreply.github.com"
+              git config --local user.name "${{ github.actor }}"
+              git checkout -b web-platform-release-notes
+              git add .
+              git commit -m "New beta web platform release notes"
+              git push origin web-platform-release-notes
           else
-            echo "No changes to commit."
+              echo "No new files to add."
           fi


### PR DESCRIPTION
The previous workflow file was not checking for the existence of a new release notes file correctly. It was checking for diffs in existing files. Now, it checks if a new file was created.