### PR TITLE
Link to Ad Selection docs in Legal repo

### DIFF
--- a/microsoft-edge/web-platform/ad-selection-api.md
+++ b/microsoft-edge/web-platform/ad-selection-api.md
@@ -30,6 +30,8 @@ The Ad Selection API provides user-relevant ads on your site without using third
     * [Deployment guide](#deployment-guide)
 * [Use the Ad Selection API on your website](#use-the-ad-selection-api-on-your-website)
 * [Provide feedback about the origin trial](#provide-feedback-about-the-origin-trial)
+* [Terms of Use](#terms-of-use)
+* [Data Protection Addendum](#data-protection-addendum)
 * [See also](#see-also)
 
 The Ad Selection API can be used by:

--- a/microsoft-edge/web-platform/ad-selection-api.md
+++ b/microsoft-edge/web-platform/ad-selection-api.md
@@ -312,6 +312,18 @@ To provide feedback about the Ad Selection API origin trial, create a new issue 
 
 
 <!-- ====================================================================== -->
+## Terms of Use
+
+See [Terms of Use for Ad Selection API](/legal/microsoft-edge/ad-selection-api/terms-of-use).
+
+
+<!-- ====================================================================== -->
+## Data Protection Addendum
+
+See [Data Protection Addendum for the Ad Selection API](/legal/microsoft-edge/ad-selection-api/dpa).
+
+
+<!-- ====================================================================== -->
 ## See also
 <!-- all links in article -->
 


### PR DESCRIPTION
Related PR:
* [PR 2028](https://github.com/MicrosoftDocs/DocsLegal-pr/pull/2028) (PR: Terms of Use for Ad Selection API) in Legal Docs repo.

Rendered article sections for review:

* **Sign up for the Ad Selection API**
   * `/web-platform/ad-selection-api.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/ad-selection-api?branch=pr-en-us-3533
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/ad-legal/microsoft-edge/web-platform/ad-selection-api.md
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/ad-selection-api
   * Added two h2 sections linking to Legal docs:
      * Terms of Use
      * Data Protection Addendum

AB#58587765
