### PR TITLE
Remove Form steps in "Sign up for Ad Selection API"

### DIFF
--- a/microsoft-edge/origin-trials/index.md
+++ b/microsoft-edge/origin-trials/index.md
@@ -39,8 +39,6 @@ To register for an origin trial:
 
 1. Go to [Microsoft Edge Origin Trials](https://developer.microsoft.com/microsoft-edge/origin-trials).
 
-   To sign up for the Ad Selection API origin trial, instead see [Sign up for the Ad Selection API](../web-platform/ad-selection-api.md).
-
 1. Select an active trial.
 
 1. Click the **I Accept the Terms of Use** button.
@@ -139,8 +137,6 @@ To renew an origin trial token:
 
 1. Go to [Microsoft Edge Origin Trials](https://developer.microsoft.com/microsoft-edge/origin-trials).
 
-   For the Ad Selection API origin trial, instead see [Sign up for the Ad Selection API](../web-platform/ad-selection-api.md).
-
 1. In the **My Registered Trials** section, select an origin trial.
 
 1. In the **Registrations** section, in a token row that contains an **Expired** badge, click the **Renew** button:
@@ -192,18 +188,11 @@ To provide feedback about an origin trial:
 1. If a new issue is needed, click the **New issue** button.
 
 
-For the Ad Selection API origin trial, instead see [Provide feedback about the origin trial](../web-platform/ad-selection-api.md#provide-feedback-about-the-origin-trial) in _Sign up for the Ad Selection API_.
-
-
 <!-- ====================================================================== -->
 ## See also
 <!-- all links in the article -->
 
 * [Microsoft Edge Origin Trials](https://developer.microsoft.com/microsoft-edge/origin-trials) - Developer.microsoft.com.
-
-Ad Selection API:
-* [Sign up for the Ad Selection API](../web-platform/ad-selection-api.md)
-   * [Microsoft Edge Origin Trials](https://microsoftedge.github.io/MSEdgeExplainers/origin-trials/) - portal at Github.io, for the Ad Selection API origin trial only.
 
 External:
 * [Implementing feature detection](https://developer.mozilla.org/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection) - MDN.

--- a/microsoft-edge/web-platform/ad-selection-api.md
+++ b/microsoft-edge/web-platform/ad-selection-api.md
@@ -83,36 +83,9 @@ For each top-level domain that you intend to use with the Ad Selection API, fill
 
 To sign up for the **Ad Selection API** origin trial for a domain:
 
-1. Open [Ad Selection API Origin Trial Registration in Microsoft Edge](https://forms.office.com/r/eBhJt58Lks) in a new window or tab.
+1. First, do the steps in [Use origin trials in Microsoft Edge](../origin-trials/index.md).
 
-1. Click the **Start now** button.
-
-1. Read and agree to the terms of use, and then click the **Next** button.  The **Ad Selection API Origin Trial Registration** form opens:
-
-   ![Registration form](./ad-selection-api-images/reg-form.png)
-
-1. In the **Domain** text box, enter a single top-level domain:
-
-   You can configure the origin trial to support any of the following:
-   * A single domain, such as `https://example.com`, without supporting its subdomains.
-   * A single subdomain, such as `https://beta.example.com`.
-   * A domain, such as `https://example.com`, and its subdomains, such as `https://beta.example.com`.
-
-   Trailing paths and query parameters aren't supported.  If a URI is entered that has a trailing path or a query parameter, such as `https://example.com/path/new-feature`, the root domain (such as `https://example.com`) or subdomain will be registered, ignoring any trailing path or query parameters.
-
-1. In the **Subdomain Support** section, select the **Yes** or **No** option button:
-
-   * To use the origin trial at a domain (such as `https://example.com`) without supporting its subdomains (such as `https://beta.example.com`), select **No**.
-   * To use the origin trial only at a specific subdomain (such as `https://beta.example.com`), select **No**.
-   * To use the origin trial at a domain (such as `https://example.com`) and its subdomains (such as `https://beta.example.com`), select **Yes**.
-
-1. In the **Email Address** text box, provide a valid developer contact for the domain.
-
-1. Click the **Submit** button.
-
-   An origin trial token is generated for the top-level domain and is sent to you.
-
-1. Create a file that's named `ad-selection-attestations.json`, and host the file at the top-level domain, in the `/.well-known/` directory.  For example:
+1. Then create a file that's named `ad-selection-attestations.json`, and host the file at the top-level domain, in the `/.well-known/` directory.  For example:
 
    `https://contoso.example/.well-known/ad-selection-attestations.json`
 

--- a/microsoft-edge/web-platform/ad-selection-api.md
+++ b/microsoft-edge/web-platform/ad-selection-api.md
@@ -92,11 +92,6 @@ To sign up for the **Ad Selection API** origin trial for a domain:
    The `ad-selection-attestations.json` file must be published within **30 days** of receiving the OT token.  Hosting this JSON file is required, in order to complete your attestation and allow your code to access the Ad Selection API, to test the Ad Selection API with supported Microsoft Edge clients.
 
 
-<!-- ------------------------------ 
-#### Renewing the origin trial token
-todo -->
-
-
 <!-- ------------------------------ -->
 #### Example JSON file
 


### PR DESCRIPTION
Rendered article sections for review:
* **Sign up for the Ad Selection API** > **Sign-up and attestation requirements and process**
   * `/web-platform/ad-selection-api.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/ad-selection-api?branch=pr-en-us-3547#sign-up-and-attestation-requirements-and-process
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/ad-select-ot/microsoft-edge/web-platform/ad-selection-api.md#sign-up-and-attestation-requirements-and-process
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/ad-selection-api#sign-up-and-attestation-requirements-and-process
   * Replaced custom-form steps by link to OT article.

* **Use origin trials in Microsoft Edge**
   * `/origin-trials/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/origin-trials/index?branch=pr-en-us-3547
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/ad-select-ot/microsoft-edge/origin-trials/index.md
   * Before/live: https://learn.microsoft.com/microsoft-edge/origin-trials/
   * Removed special steps about Ad Selection API.

AB#58728823
