### PR TITLE
Remove a couple of outdated Edge versions and ignore release notes

### DIFF
--- a/microsoft-edge/dev-videos/index.md
+++ b/microsoft-edge/dev-videos/index.md
@@ -702,7 +702,7 @@ Covers:
 * Breakpoint icons are displayed when using Visual Studio Code themes.
 * DevTools extension for Visual Studio Code includes the latest tools, theme support, and helpful links.  JavaScript Debugger connection to remote workspaces.
 
-Update: Starting with Microsoft Edge 131, the Visual Studio Code themes feature is removed, and such themes revert to the default themes:
+Update: The Visual Studio Code themes feature is removed, and such themes revert to the default themes:
 * Light+
 * Dark+
 

--- a/microsoft-edge/dev-videos/index.md
+++ b/microsoft-edge/dev-videos/index.md
@@ -702,7 +702,7 @@ Covers:
 * Breakpoint icons are displayed when using Visual Studio Code themes.
 * DevTools extension for Visual Studio Code includes the latest tools, theme support, and helpful links.  JavaScript Debugger connection to remote workspaces.
 
-Update: The Visual Studio Code themes feature is removed, and such themes revert to the default themes:
+Update: The Themes feature of Visual Studio Code has been removed, and such themes revert to the default themes:
 * Light+
 * Dark+
 

--- a/microsoft-edge/progressive-web-apps/how-to/app-actions.md
+++ b/microsoft-edge/progressive-web-apps/how-to/app-actions.md
@@ -260,7 +260,9 @@ The above code is not in [Demos/wami/manifest.json](https://github.com/Microsoft
 <!-- ====================================================================== -->
 ## Package a store PWA in Edge Stable
 
-At the current stage, your PWA needs to be packaged as a Microsoft Store PWA, to be called by the Windows App Actions framework.
+Next, your PWA needs to be packaged as a Microsoft Store PWA, to be called by the Windows App Actions framework.
+
+To package your PWA as a Microsoft Store PWA:
 
 1. Package your PWA for [PWABuilder.com](https://www.pwabuilder.com); see [Package your PWA for the Store](./microsoft-store.md#package-your-pwa-for-the-store) in _Publish a PWA to the Microsoft Store_.
 
@@ -284,7 +286,7 @@ At the current stage, your PWA needs to be packaged as a Microsoft Store PWA, to
 
    Before publishing your package, we recommend the above step.  If you don't set the initial availability of the app action to `false`, your action will only work if the user manually goes to `edge://flags` in Microsoft Edge and then enables the feature flag `#edge-app-actions-on-windows-for-web-apps`.
 
-   Setting the initial availability to `false` is needed because Microsoft Edge's support of App Actions on Windows in PWAs is controlled by the feature flag `#edge-app-actions-on-windows-for-web-apps`, and is disabled by default, because this is a new feature in the Edge browser and is currently in Developer Trial<!-- not Origin Trial--> stage, as of June 26, 2025.
+   Setting the initial availability to `false` is needed because Microsoft Edge's support of App Actions on Windows in PWAs is controlled by the feature flag `#edge-app-actions-on-windows-for-web-apps`, and is disabled by default, because this is a new feature in the Edge browser and is currently in Developer Trial<!-- not Origin Trial--> stage, as of June 26, 2025.<!-- todo: maintain date & "currently" -->
 
    When the feature flag `#edge-app-actions-on-windows-for-web-apps` is officially rolled out (later in 2025),<!-- todo: update after rolled out --> Microsoft Edge will automatically switch the actions that you defined in the action definition manifest file from `Disabled` to `Enabled`, allowing end users to utilize your app's actions without requiring any further changes on your part.
 

--- a/microsoft-edge/progressive-web-apps/how-to/app-actions.md
+++ b/microsoft-edge/progressive-web-apps/how-to/app-actions.md
@@ -286,7 +286,7 @@ To package your PWA as a Microsoft Store PWA:
 
    Before publishing your package, we recommend the above step.  If you don't set the initial availability of the app action to `false`, your action will only work if the user manually goes to `edge://flags` in Microsoft Edge and then enables the feature flag `#edge-app-actions-on-windows-for-web-apps`.
 
-   Setting the initial availability to `false` is needed because Microsoft Edge's support of App Actions on Windows in PWAs is controlled by the feature flag `#edge-app-actions-on-windows-for-web-apps`, and is disabled by default, because this is a new feature in the Edge browser and is currently in Developer Trial<!-- not Origin Trial--> stage, as of June 26, 2025.<!-- todo: maintain date & "currently" -->
+   Setting the initial availability to `false` is needed because Microsoft Edge's support of App Actions on Windows in PWAs is controlled by the feature flag `#edge-app-actions-on-windows-for-web-apps`, and is disabled by default, because this feature is currently in Developer Trial.
 
    When the feature flag `#edge-app-actions-on-windows-for-web-apps` is officially rolled out (later in 2025),<!-- todo: update after rolled out --> Microsoft Edge will automatically switch the actions that you defined in the action definition manifest file from `Disabled` to `Enabled`, allowing end users to utilize your app's actions without requiring any further changes on your part.
 

--- a/microsoft-edge/progressive-web-apps/how-to/app-actions.md
+++ b/microsoft-edge/progressive-web-apps/how-to/app-actions.md
@@ -260,9 +260,7 @@ The above code is not in [Demos/wami/manifest.json](https://github.com/Microsoft
 <!-- ====================================================================== -->
 ## Package a store PWA in Edge Stable
 
-At the current stage, your PWA needs to be packaged as a Microsoft Store PWA, to be called by the Windows App Actions framework.  You must use Microsoft Edge 137 or greater.
-
-1. Upgrade to Edge Stable 137 version.
+At the current stage, your PWA needs to be packaged as a Microsoft Store PWA, to be called by the Windows App Actions framework.
 
 1. Package your PWA for [PWABuilder.com](https://www.pwabuilder.com); see [Package your PWA for the Store](./microsoft-store.md#package-your-pwa-for-the-store) in _Publish a PWA to the Microsoft Store_.
 

--- a/scripts/report-references-to-old-versions.js
+++ b/scripts/report-references-to-old-versions.js
@@ -10,6 +10,7 @@ const FILES_TO_IGNORE = [
     '../microsoft-edge/webview2/release-notes/index.md',
     '../microsoft-edge/webview2/release-notes/archive.md',
     '../microsoft-edge/progressive-web-apps/whats-new/*.md',
+    '../microsoft-edge/web-platform/release-notes/*.md',
     // Experimental features also often have version numbers in them. Let's ignore them too.
     '../microsoft-edge/devtools/experimental-features/index.md',
     // Ignore the site-impacting-changes article, since this references older versions on purpose.


### PR DESCRIPTION
Rendered article sections for review:

* **Videos about web development with Microsoft Edge** > **Microsoft Edge | What's New in DevTools 94**
   * `/dev-videos/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/dev-videos/index?branch=pr-en-us-3562#microsoft-edge--whats-new-in-devtools-94
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/outdated-edge-versions/microsoft-edge/dev-videos/index.md#microsoft-edge--whats-new-in-devtools-94
   * Before/live: https://learn.microsoft.com/microsoft-edge/dev-videos/#microsoft-edge--whats-new-in-devtools-94
   * Removed a couple of outdated Edge versions from the docs.

* **Enable App Actions on Windows for a PWA** > **Package a store PWA in Edge Stable**
   * `/progressive-web-apps/how-to/app-actions.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/progressive-web-apps/how-to/app-actions?branch=pr-en-us-3562#package-a-store-pwa-in-edge-stable
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/outdated-edge-versions/microsoft-edge/progressive-web-apps/how-to/app-actions.md#package-a-store-pwa-in-edge-stable
   * Before/live: https://learn.microsoft.com/microsoft-edge/progressive-web-apps/how-to/app-actions#package-a-store-pwa-in-edge-stable
   * Removed a couple of outdated Edge versions from the docs.

* Script: `report-references-to-old-versions.js`
   * `/scripts/report-references-to-old-versions.js`
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/outdated-edge-versions/scripts/report-references-to-old-versions.js
   * Before/live: 
   * Updated the script to ignore the web platform release notes, since they are bound to always refer to old Edge versions.

Fixes #3560.

AB#59064709
