### PR TITLE
Create new branch names for relnotes and avoid re-opening issue if a relnote already exists

### DIFF
--- a/.github/workflows/webplat-relnotes.yaml
+++ b/.github/workflows/webplat-relnotes.yaml
@@ -30,19 +30,4 @@ jobs:
       - name: Generate release notes
         run: |
           cd scripts
-          token=${{ secrets.GITHUB_TOKEN }} node web-platform-release-notes.js
-
-      - name: Commit changes if needed
-        run: |
-          files=$(git ls-files --others --exclude-standard)
-          if [ -n "$files" ]; then
-              echo "Committing the new release notes file."
-              git config --local user.email "${{ github.actor }}@users.noreply.github.com"
-              git config --local user.name "${{ github.actor }}"
-              git checkout -b web-platform-release-notes
-              git add .
-              git commit -m "New beta web platform release notes"
-              git push origin web-platform-release-notes
-          else
-              echo "No new files to add."
-          fi
+          actor=${{ github.actor }} token=${{ secrets.GITHUB_TOKEN }} node web-platform-release-notes.js

--- a/scripts/web-platform-release-notes.js
+++ b/scripts/web-platform-release-notes.js
@@ -208,7 +208,7 @@ async function main() {
 
   const draftAlreadyExists = await releaseNotesDraftAlreadyExists(nextBetaVersion, branchName);
   if (draftAlreadyExists) {
-    console.error(`A draft release notes for the next beta version ${nextBetaVersion} already exist on the ${branchName} branch.`);
+    console.error(`Draft release notes for the next beta version ${nextBetaVersion} already exist on the ${branchName} branch.`);
     process.exit(0);
   }
 

--- a/scripts/web-platform-release-notes.js
+++ b/scripts/web-platform-release-notes.js
@@ -31,8 +31,14 @@ function longDate(dateString) {
 }
 
 async function execute(cmd) {
-  const stdout = await execSync(cmd);
-  return stdout.toString();
+  try {
+    const stdout = await execSync(cmd);
+    return stdout.toString();
+  } catch (error) {
+    console.error(`Error executing command "${cmd}": ${error.message}`);
+    console.log(error.stdout.toString());
+    process.exit(1);
+  }
 }
 
 async function releaseNotesAlreadyExists(version) {
@@ -326,15 +332,15 @@ async function main() {
 
   console.log(`Committing the new file to branch ${branchName}...`);
 
-  console.log("Configuring git");
-  await execute(`git config --local user.email "${ process.env.action }@users.noreply.github.com"`);
-  await execute(`git config --local user.name "${ process.env.action }"`);
+  console.log(`Configuring git with ${ process.env.actor }`);
+  await execute(`git config --local user.email "${ process.env.actor }@users.noreply.github.com"`);
+  await execute(`git config --local user.name "${ process.env.actor }"`);
   
   console.log(`Creating branch ${branchName}`);
   await execute(`git checkout -b ${branchName}`);
   
   console.log(`Adding and committing the new file`);
-  await execute(`git add .`);
+  await execute(`git add ${releaseNotesPath}`);
   await execute(`git commit -m "New web platform release notes for ${nextBetaVersion}"`);
   
   console.log(`Pushing the file to the remote repo`);


### PR DESCRIPTION
So far, we've been reusing the same branch name for web platform release notes. This change creates a unique branch name every time, which should make it easier to work on the PR.

This should also fix the problem where the release notes script kept re-creating new issues every day, even for release notes that already exist.