### PR TITLE
WebView2 Release Notes for Oct. 2025 Prerelease SDK

### DIFF
--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -65,6 +65,91 @@ This Release SDK includes the following bug fixes.
 <!-- end of Oct 2025 Release SDK -->
 
 
+<!-- Oct 2025 Prerelease SDK -->
+<!-- ====================================================================== -->
+## 1.0.3590-prerelease
+
+Release Date: October 7, 2025
+
+[NuGet package for WebView2 SDK 1.0.3590-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.3590-prerelease)
+
+For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 142.0.3590.0 or higher.
+
+
+<!-- ------------------------------ -->
+#### General changes
+<!-- omit section if empty; usually empty -->
+
+
+<!-- ------------------------------ -->
+#### Experimental APIs
+
+No Experimental APIs have been added in this Prerelease SDK.
+The following APIs are in Phase 1: Experimental in Prerelease, and have been added in this Prerelease SDK.
+
+
+<!-- ---------- -->
+###### heading
+
+description
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+##### [Win32/C++](#tab/win32cpp)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Promotions
+
+No APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, in this Prerelease SDK.
+The following APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, and are included in this Prerelease SDK.
+
+
+<!-- ---------- -->
+###### heading
+
+description
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+##### [Win32/C++](#tab/win32cpp)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Bug fixes
+
+There are no bug fixes in this Prerelease SDK.
+This Prerelease SDK includes the following bug fixes.
+
+
+<!-- ---------- -->
+###### Runtime and SDK
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### Runtime-only
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### SDK-only
+
+* Fixed behavior.  ([Issue #]())
+
+<!-- end of Oct 2025 Prerelease SDK -->
+
+
 <!-- Sep 2025 Release SDK -->
 <!-- ====================================================================== -->
 ## 1.0.3485.44


### PR DESCRIPTION
Rendered article sections for review:

* **Release Notes for the WebView2 SDK** > **1.0.3590-prerelease** todo: update anchors
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/index?branch=pr-en-us-3572#
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/wv2-relnotes-oct-2025/microsoft-edge/webview2/release-notes/index.md#10353750
   * Planned live: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/#10353750
   * New section.

AB#59673335
