### PR TITLE
Add h2 section "Suppressing updating of the WebView2 Runtime"

### DIFF
--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -9,6 +9,9 @@ ms.subservice: webview
 ms.date: 06/27/2024
 ---
 # Distribute your app and the WebView2 Runtime
+<!-- todo: mention key words in title:
+# Distribute your app and the WebView2 Runtime (Evergreen vs. fixed)
+-->
 
 When releasing an app that uses Microsoft Edge WebView2, you need to distribute the WebView2 Runtime, either by distributing the automatically updated _Evergreen_ Runtime, or by distributing a _Fixed Version_ of the Runtime.
 

--- a/microsoft-edge/webview2/concepts/enterprise.md
+++ b/microsoft-edge/webview2/concepts/enterprise.md
@@ -31,7 +31,7 @@ To configure update policies for Microsoft Edge (and the WebView2 Runtime), see 
 
 
 <!-- ------------------------------ -->
-#### Suppressing updating of the WebView2 Runtime
+#### Suppressing WebView2 Runtime updates
 
 An IT admin can suppress updating of the WebView2 Runtime, if auto-updating needs to be suppressed for a short time.  After the time period, updating of the WebView2 Runtime resumes.  The [UpdatesSuppressed](/deployedge/microsoft-edge-update-policies#updatessuppressed) policy allows an IT admin to set the time during each day at which to suppress auto-update for both Microsoft Edge and the WebView2 Runtime.  This enables an IT admin to configure preferences and proxies once for both the browser and the WebView2 Runtime, to control their network bandwidth and traffic, or for other purposes.
 
@@ -41,7 +41,7 @@ However, users should not stop updating their WebView2 Runtime; users should not
 <!-- ---------- -->
 ###### Evergreen Runtime is recommended, rather than a fixed version
 
-Using the Evergreen WebView2 Runtime is recommended, unless business-critical requirements necessitate a fixed version of the WebView2 Runtime.  Using the Evergreen WebView2 Runtime:
+Using the Evergreen WebView2 Runtime is recommended, unless business-critical requirements necessitate using a fixed version of the WebView2 Runtime.  Using the Evergreen WebView2 Runtime:
 * Helps minimize exposure to known vulnerabilities.
 * Ensures timely security improvements.
 * Ensures that WebView2 benefits from continuous security updates that are delivered through Microsoft Edge releases.


### PR DESCRIPTION
Rendered article section for review:

* **Enterprise management of WebView2 Runtimes** > **Suppressing WebView2 Runtime updates**
   * `/webview2/concepts/enterprise.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/enterprise?branch=pr-en-us-3597#suppressing-webview2-runtime-updates
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/suppress-runtime/microsoft-edge/webview2/concepts/enterprise.md#suppressing-webview2-runtime-updates
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/enterprise#suppressing-webview2-runtime-updates
   * New section.
   * Reworked article, eg updated link text and redir'd urls.
   * Added comment about title such as **Distribute your app and the WebView2 Runtime (Evergreen vs. fixed)**; ie break up that article into two.

AB#59705625
