### PR TITLE
Implement memory polling in DevTools extension

### DIFF
--- a/microsoft-edge/extensions/developer-guide/devtools-extension.md
+++ b/microsoft-edge/extensions/developer-guide/devtools-extension.md
@@ -350,7 +350,7 @@ The above code snippet does the following:
 
 1. Creates a new panel `Sample Panel` in DevTools.
    
-1. When the panel is displayed the panel.js sets a timer to run code every second after the panel is shown.
+1. When the panel is displayed, `panel.js` sets a timer to run code every second after the panel is shown.
 
 1. When the timer fires, the `chrome.system.memory.getInfo` method is used to retrieve the available and total memory capacity of the device and these values are displayed in the corresponding DOM elements.
 


### PR DESCRIPTION
Rendered article section for review:

* **Create a DevTools extension, adding a custom tool tab and panel** > **Step 3: Display memory information by calling extension APIs**
   * `/extensions/developer-guide/devtools-extension.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/developer-guide/devtools-extension?branch=pr-en-us-3628
   * External preview: https://github.com/MichelLaplane/edge-developer/blob/patch-1/microsoft-edge/extensions/developer-guide/devtools-extension.md#step-3-display-memory-information-by-calling-extension-apis
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/devtools-extension
   * Added memory polling functionality to the DevTools extension panel.
      * Added `panel.js` code listing.

According to AI:  
This PR refactors the DevTools extension tutorial in Step 3 to move the memory polling logic from devtools.js into a separate panel.js file that runs in the panel's context. This improves the architecture by handling visibility changes and avoiding unnecessary API calls when the panel is hidden.  Key changes:
* Moved memory polling logic from devtools.js to a new panel.js file with visibility-aware start/stop functions
* Simplified devtools.js to only create the panel and log lifecycle events
* Updated explanation text to reflect the new architecture

Related PRs:
* https://github.com/MicrosoftDocs/edge-developer/pull/3616 - Docs repo
* https://github.com/MicrosoftEdge/Demos/pull/106 - Demos repo

The present PR might imply changing code in the Demos repo.

AB#60079014
