### PR TITLE
Remove breaking change from "Release Notes for WebView2 SDK"

### DIFF
--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -70,19 +70,6 @@ Release Date: November 07, 2025
 For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 143.0.3650.0 or higher.
 
 
-
-<!-- ------------------------------ -->
-#### Breaking changes
-
-
-<!-- ---------- -->
-###### Don't start navigation until `NewWindowRequested` event completes
-
-Don't start WebView2 navigation until the `NewWindowRequested` event is completed, because the event blocks the parent frame's JavaScript until completion.
-
-This is a potentially breaking change; you might need to revise your code.
-
-
 <!-- ------------------------------ -->
 #### Experimental APIs
 


### PR DESCRIPTION
Rendered article sections for review:

* **Release Notes for the WebView2 SDK** > **1.0.3650-prerelease**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/?branch=pr-en-us-3649#103650-prerelease
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/not-breaking/microsoft-edge/webview2/release-notes/index.md#103650-prerelease
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#breaking-changes
   * After/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#103650-prerelease
   * Removed **Breaking changes** section.

AB#60253823
