### PR TITLE
Fix interop links in RelNotes

### DIFF
--- a/microsoft-edge/webview2/release-notes/archive.md
+++ b/microsoft-edge/webview2/release-notes/archive.md
@@ -740,6 +740,10 @@ n/a
   * [ICoreWebView2ExperimentalCompositionController6::add_DragStarting](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontroller6?view=webview2-1.0.3079-prerelease&preserve-view=true#add_dragstarting)
   * [ICoreWebView2ExperimentalCompositionController6::remove_DragStarting](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontroller6?view=webview2-1.0.3079-prerelease&preserve-view=true#remove_dragstarting)
 
+* [ICoreWebView2ExperimentalCompositionControllerInterop3](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontrollerinterop3?view=webview2-1.0.3079-prerelease&preserve-view=true)
+  * [ICoreWebView2ExperimentalCompositionControllerInterop3::add_DragStarting](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontrollerinterop3?view=webview2-1.0.3079-prerelease&preserve-view=true#add_dragstarting)
+  * [ICoreWebView2ExperimentalCompositionControllerInterop3::remove_DragStarting](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcompositioncontrollerinterop3?view=webview2-1.0.3079-prerelease&preserve-view=true#remove_dragstarting)
+
 * [ICoreWebView2ExperimentalDragStartingEventArgs](/microsoft-edge/webview2/reference/win32/icorewebview2experimentaldragstartingeventargs?view=webview2-1.0.3079-prerelease&preserve-view=true)
   * [ICoreWebView2ExperimentalDragStartingEventArgs::get_AllowedDropEffects](/microsoft-edge/webview2/reference/win32/icorewebview2experimentaldragstartingeventargs?view=webview2-1.0.3079-prerelease&preserve-view=true#get_alloweddropeffects)
   * [ICoreWebView2ExperimentalDragStartingEventArgs::get_Data](/microsoft-edge/webview2/reference/win32/icorewebview2experimentaldragstartingeventargs?view=webview2-1.0.3079-prerelease&preserve-view=true#get_data)

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -154,6 +154,11 @@ N/A
   * [ICoreWebView2CompositionController5::add_DragStarting](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller5?view=webview2-1.0.3712-prerelease&preserve-view=true#add_dragstarting)
   * [ICoreWebView2CompositionController5::remove_DragStarting](/microsoft-edge/webview2/reference/win32/icorewebview2compositioncontroller5?view=webview2-1.0.3712-prerelease&preserve-view=true#remove_dragstarting)
 
+<!-- exception: rt interop docs -->
+* [ICoreWebView2CompositionControllerInterop3](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop3?view=webview2-winrt-1.0.3712-prerelease&preserve-view=true)
+  * [ICoreWebView2CompositionControllerInterop3::add_DragStarting](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop3?view=webview2-winrt-1.0.3712-prerelease&preserve-view=true#add_dragstarting)
+  * [ICoreWebView2CompositionControllerInterop3::remove_DragStarting](/microsoft-edge/webview2/reference/winrt/interop/icorewebview2compositioncontrollerinterop3?view=webview2-winrt-1.0.3712-prerelease&preserve-view=true#remove_dragstarting)
+
 * [ICoreWebView2DragStartingEventArgs](/microsoft-edge/webview2/reference/win32/icorewebview2dragstartingeventargs?view=webview2-1.0.3712-prerelease&preserve-view=true)
   * [ICoreWebView2DragStartingEventArgs::get_AllowedDropEffects](/microsoft-edge/webview2/reference/win32/icorewebview2dragstartingeventargs?view=webview2-1.0.3712-prerelease&preserve-view=true#get_alloweddropeffects)
   * [ICoreWebView2DragStartingEventArgs::get_Data](/microsoft-edge/webview2/reference/win32/icorewebview2dragstartingeventargs?view=webview2-1.0.3712-prerelease&preserve-view=true#get_data)


### PR DESCRIPTION
Rendered article sections for review:

* **Release Notes for the WebView2 SDK** > **Customize the drag and drop behavior (DragStarting API)**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/index?branch=pr-en-us-3661#customize-the-drag-and-drop-behavior-dragstarting-api
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/interop/microsoft-edge/webview2/release-notes/index.md#customize-the-drag-and-drop-behavior-dragstarting-api
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#customize-the-drag-and-drop-behavior-dragstarting-api
   * Changed `ICoreWebView2CompositionControllerInterop3` links in Win32 tab to go to WinRT interop docs.
   * Removed member name from non-linked parent type in .NET tab: `CoreWebView2EnvironmentOptions` Class.

* **Archived Release Notes for the WebView2 SDK** > **Customize the drag and drop behavior (DragStarting API)**
   * `/webview2/release-notes/archive.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/archive?branch=pr-en-us-3661#customize-the-drag-and-drop-behavior-dragstarting-api
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/interop/microsoft-edge/webview2/release-notes/archive.md#customize-the-drag-and-drop-behavior-dragstarting-api
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/archive#customize-the-drag-and-drop-behavior-dragstarting-api
   * No change, kept the `ICoreWebView2ExperimentalCompositionControllerInterop3` links.

AB#60487438
