### PR TITLE
Remove HEVC support in WebRTC from 136 relnotes

### DIFF
--- a/microsoft-edge/web-platform/release-notes/136.md
+++ b/microsoft-edge/web-platform/release-notes/136.md
@@ -33,7 +33,6 @@ To stay up-to-date and get the latest web platform features, download a preview 
     * [Captured surface resolution](#captured-surface-resolution)
     * [Dispatching click events to captured pointer](#dispatching-click-events-to-captured-pointer)
     * [Explicit compile hints with magic comments](#explicit-compile-hints-with-magic-comments)
-    * [H265 (HEVC) codec support in WebRTC](#h265-hevc-codec-support-in-webrtc)
     * [H26x codec support updates for MediaRecorder](#h26x-codec-support-updates-for-mediarecorder)
     * [Language support for `CanvasTextDrawingStyles`](#language-support-for-canvastextdrawingstyles)
     * [Permissions Policy reports for iframes](#permissions-policy-reports-for-iframes)
@@ -212,16 +211,6 @@ _Magic comments_ are comments that send a signal to the browser that the functio
 In JavaScript, magic comments are comments that start with `//#`.
 
 See [Explainer for Explicit JavaScript Compile Hints](https://github.com/WICG/explicit-javascript-compile-hints-file-based/blob/main/README.md).
-
-
-<!-- ---------- -->
-###### H265 (HEVC) codec support in WebRTC
-
-The H265 (HEVC) codec has increased compression efficiency (higher quality per bitrate) relative to VP8/VP9/H264, and has very strong hardware support.
-
-Support for the H265 (HEVC) codec in WebRTC improves the visual experience, increases battery life, and reduces the risk of performance issues.
-
-See [WebRTC API](https://developer.mozilla.org/docs/Web/API/WebRTC_API) at MDN.
 
 
 <!-- ---------- -->


### PR DESCRIPTION
Rendered article sections for review:

* **Microsoft Edge 136 web platform release notes (May 2025)** > **H265 (HEVC) codec support in WebRTC**
   * `/web-platform/release-notes/136.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/136?branch=pr-en-us-3669#h265-hevc-codec-support-in-webrtc
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/136#h265-hevc-codec-support-in-webrtc
   * Removed section.

AB#60536847
