### PR TITLE
Add "Responsible AI" section in "Publish a Microsoft Edge extension"

### DIFF
--- a/microsoft-edge/extensions/publish/publish-extension.md
+++ b/microsoft-edge/extensions/publish/publish-extension.md
@@ -522,7 +522,7 @@ The AI-generated description feature has undergone substantial testing, to ident
 
 The following safeguards are in place for the AI-generated description:
 
-* The AI-generated description is based completely on the extension package, uploaded screenshots, and any prompt text that you provide.  See [Inputs used for the AI-generated description](#inputs-used-for-the-ai-generated-description), above.
+* The AI-generated description is based exclusively on the extension package, uploaded screenshots, and any prompt text that you provide.  See [Inputs used for the AI-generated description](#inputs-used-for-the-ai-generated-description), above.
 
 * Providing input prompt text is optional.
 


### PR DESCRIPTION
Rendered article sections for review:

* **Publish a Microsoft Edge extension**
   * `/extensions/publish/publish-extension.md`
   * **Generate the description with AI**
      * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/publish/publish-extension?branch=pr-en-us-3672#generate-the-description-with-ai
      * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/responsible/microsoft-edge/extensions/publish/publish-extension.md#generate-the-description-with-ai
      * Before/live: https://learn.microsoft.com/microsoft-edge/extensions/publish/publish-extension?branch=pr-en-us-3672#generate-the-description-with-ai
      * In step 3, changed from a sentence listing two inputs for the AI model, to a list of three inputs, including screenshots.
   * **Responsible AI for the AI-generated description of an extension**
      * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/publish/publish-extension?branch=pr-en-us-3672#responsible-ai-for-the-ai-generated-description-of-an-extension
      * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/responsible/microsoft-edge/extensions/publish/publish-extension.md#responsible-ai-for-the-ai-generated-description-of-an-extension
      * Planned live: https://learn.microsoft.com/microsoft-edge/extensions/publish/publish-extension#responsible-ai-for-the-ai-generated-description-of-an-extension
      * New section.

AB#60562251
