### PR TITLE
Add missing web platform 144 and 145 release notes entries

### DIFF
--- a/microsoft-edge/web-platform/release-notes/144.md
+++ b/microsoft-edge/web-platform/release-notes/144.md
@@ -24,6 +24,8 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Scroll-triggered animations](#scroll-triggered-animations)
   * [Styling SVG elements instantiated via `<use>`](#styling-svg-elements-instantiated-via-use)
   * [View Transitions waitUntil() method](#view-transitions-waituntil-method)
+  * [caret-shape](#caret-shape)
+  * [Style search results](#style-search-results)
 * [Web APIs](#web-apis)
   * [The Temporal API](#the-temporal-api)
   * [The clipboardchange event](#the-clipboardchange-event)
@@ -172,6 +174,26 @@ That normal behavior works for the vast majority of cases.  In some cases, howev
 See also:
 * [View Transition API](https://developer.mozilla.org/docs/Web/API/View_Transition_API) at MDN.
 * [CSS scroll-driven animations](https://developer.mozilla.org/docs/Web/CSS/Guides/Scroll-driven_animations) at MDN.
+
+
+<!-- ------------------------------ -->
+#### `caret-shape`
+
+The `caret-shape` CSS property allows you to specify the shape of the text insertion caret.
+
+See also:
+* [caret-shape](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/caret-shape) at MDN.
+
+
+<!-- ------------------------------ -->
+#### Style search results
+
+The `::search-text` pseudo-element allows you to style the portions of text that match a user's search query when the user searches within a page by using **Ctrl+F** or **Command+F**.
+
+The pseudo-element can be combined with the `:current` pseudo-class to style the currently highlighted search result differently from the other search results.
+
+See also:
+* [::search-text](https://drafts.csswg.org/css-pseudo-4/#selectordef-search-text) in _CSS Pseudo-Elements Module Level 4_.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/web-platform/release-notes/145.md
+++ b/microsoft-edge/web-platform/release-notes/145.md
@@ -30,6 +30,7 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Improved rendering for near circular border radius](#improved-rendering-for-near-circular-border-radius)
   * [text-justify](#text-justify)
   * [Monochrome emoji rendering in forced colors mode](#monochrome-emoji-rendering-in-forced-colors-mode)
+  * [Overscroll effect on nested scroll containers](#overscroll-effect-on-nested-scroll-containers)
 * [Web APIs](#web-apis)
   * [Origin API](#origin-api)
   * [PerformanceEntry presentationTime and paintTime properties](#performanceentry-painttime-and-presentationtime-properties)
@@ -183,6 +184,17 @@ To improve accessibility, Microsoft Edge now renders monochrome emojis in forced
 
 See also:
 * [forced-colors](https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@media/forced-colors) at MDN.
+
+
+<!-- ------------------------------ -->
+#### Overscroll effect on nested scroll containers
+
+On platforms which support the overscroll effect where users can scroll the page beyond the start or end of the content, such as on mobile devices, Microsoft Edge now applies this effect to nested scroll containers as well.
+
+You remain in control of the overscroll behavior by using the `overscroll-behavior` CSS property.
+
+See also:
+* [overscroll-behavior](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overscroll-behavior) at MDN.
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
Rendered article sections for review:

* **Microsoft Edge 145 web platform release notes (Feb. 2026)** > **Overscroll effect on nested scroll containers**
   * `/web-platform/release-notes/145.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/145?branch=pr-en-us-3685#overscroll-effect-on-nested-scroll-containers
   * External preview: 
   * Planned live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/145#overscroll-effect-on-nested-scroll-containers
   * New section.

* **Microsoft Edge 144 web platform release notes (Jan. 2026)**
   * `/web-platform/release-notes/144.md`
   * **caret-shape**
      * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/144?branch=pr-en-us-3685#caret-shape
      * External preview: 
      * Planned live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/144#caret-shape
      * New section.
   * **Style search results**
      * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/144?branch=pr-en-us-3685#style-search-results
      * External preview: 
      * Planned live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/144#style-search-results
      * New section.

AB#60697572