### PR TITLE
Remove a feature from the web platform 141 release notes

### DIFF
--- a/microsoft-edge/web-platform/release-notes/141.md
+++ b/microsoft-edge/web-platform/release-notes/141.md
@@ -20,7 +20,6 @@ To stay up-to-date and get the latest web platform features, download a preview 
 * [Web platform features](#web-platform-features)
   * [CSS features](#css-features)
     * [CSS `::search-text` pseudo-element](#css-search-text-pseudo-element)
-    * [Support `width` and `height` presentational attributes on nested `<svg>` elements](#support-width-and-height-presentational-attributes-on-nested-svg-elements)
   * [Web APIs](#web-apis)
     * [`ariaNotify()` API](#arianotify-api)
     * [IndexedDB `getAllRecords()` method and `direction` option for `getAll()` and `getAllKeys()`](#indexeddb-getallrecords-method-and-direction-option-for-getall-and-getallkeys)
@@ -70,37 +69,6 @@ This allows you to change the foreground and background colors of search results
 
 See also:
 * [::search-text](https://drafts.csswg.org/css-pseudo-4/#selectordef-search-text) in _CSS Pseudo-Elements Module Level 4_.
-
-
-<!-- ---------- -->
-###### Support `width` and `height` presentational attributes on nested `<svg>` elements
-
-You can now use the `width` and `height` presentational attributes on nested `<svg>` elements, through both SVG markup and CSS.  This approach provides greater flexibility, allowing you to style SVG elements more efficiently within complex designs.
-
-With this feature, the following two HTML code snippets now produce the same output:
-
-```html
-<svg width="100px" height="100px">
-  <svg style="width:50px;height:50px;">
-    <circle cx="50px" cy="50px" r="40px" fill="green" />
-  </svg>
-</svg>
-```
-
-In the above example, the second line uses a `style` attribute that contains `width` and `height` values.
-
-```html
-<svg width="100px" height="100px">
-  <svg width="50px" height="50px">
-    <circle cx="50px" cy="50px" r="40px" fill="green" />
-  </svg>
-</svg>
-```
-
-In the above example, the second line uses separate `width` and `height` attributes.
-
-See also:
-* [`<svg>`](https://developer.mozilla.org/docs/Web/SVG/Reference/Element/svg) at MDN.
 
 
 <!-- ------------------------------ -->


### PR DESCRIPTION
Rendered article sections for review:

* **Microsoft Edge 141 web platform release notes (Oct. 2025)** > **Support `width` and `height` presentational attributes on nested `<svg>` elements**
   * `/web-platform/release-notes/141.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/141?branch=pr-en-us-3687#css-search-text-pseudo-element - the section was below this.
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/width-height-svg-141/microsoft-edge/web-platform/release-notes/141.md#css-search-text-pseudo-element - the section was below this.
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/141#css-search-text-pseudo-element - the section is or was below this.
   * Removed the entry/section.  
      * `width` and `height` attributes and CSS properties having an effect on nested `<svg>` elements was removed from 141, b/c it broke a few sites.
      * The section must be removed from the 141 release notes, then re-added to a release notes page when re-enabled later.

AB#60737805
