### PR TITLE
Remove Sanitizer API from "Edge 145 web platform release notes"

### DIFF
--- a/microsoft-edge/web-platform/release-notes/145.md
+++ b/microsoft-edge/web-platform/release-notes/145.md
@@ -33,7 +33,6 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Overscroll effect on nested scroll containers](#overscroll-effect-on-nested-scroll-containers)
 * [Web APIs](#web-apis)
   * [Origin API](#origin-api)
-  * [Sanitizer API](#sanitizer-api)
   * [PerformanceEntry presentationTime and paintTime properties](#performanceentry-painttime-and-presentationtime-properties)
   * [Require sticky user activation or permission for clipboardchange events](#require-sticky-user-activation-or-permission-for-clipboardchange-events)
   * [onanimationcancel event handler](#onanimationcancel-event-handler)
@@ -220,17 +219,6 @@ Using the Origin API, you can do same-origin or same-site comparisons in a more 
 
 See also:
 * [The Origin interface](https://html.spec.whatwg.org/multipage/browsers.html#the-origin-interface)
-
-
-<!-- ------------------------------ -->
-#### Sanitizer API
-
-The Sanitizer API parses and inserts HTML into the DOM in a way that can prevent cross-site scripting attacks.
-
-The Sanitizer API is useful in cases where user input sanitization is necessary, but hard to implement correctly. The API offers a high-quality sanitization process with a default behavior that can be customized if necessary, improving the security of your web application.
-
-See also:
-* [HTML Sanitizer API](https://developer.mozilla.org/docs/Web/API/HTML_Sanitizer_API) at MDN.
 
 
 <!-- ------------------------------ -->


### PR DESCRIPTION
Rendered article sections for review:

* **Microsoft Edge 145 web platform release notes (Feb. 2026)** > **Sanitizer API**
   * `/web-platform/release-notes/145`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/145?branch=pr-en-us-3706#origin-api - the section above the removed section.
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/sanitizer-api-146/microsoft-edge/web-platform/release-notes/145.md#origin-api - the section above the removed section.
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/145#origin-api - the section above the removed section.
   * Removed h2 section.

AB#60914884