### PR TITLE
Add required permissions to the release notes comparison workflow

### DIFF
--- a/.github/workflows/compare-release-notes.yml
+++ b/.github/workflows/compare-release-notes.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   compare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      models: read
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
This is a follow-up to PR:
* #3712

Files changed:

* `.github/workflows/compare-release-notes.yml`
   * Added the required permissions to the release notes comparison workflow.

AB#61081573