### PR TITLE
Add "Scoped custom element registries" in 146 RelNotes

### DIFF
--- a/microsoft-edge/web-platform/release-notes/146.md
+++ b/microsoft-edge/web-platform/release-notes/146.md
@@ -126,11 +126,11 @@ The following new Web API features are included in Microsoft Edge.
 <!-- ------------------------------ -->
 #### Scoped custom element registries
 
-You can now create new custom element registries that are separate from the global `window.customElements` registry, by using the `CustomElementRegistry()` constructor.
+You can now create custom element registries that are separate from the global `window.customElements` registry, by using the `CustomElementRegistry()` constructor.
 
-Creating custom registries is useful for multiple custom elements that have the same tag name to coexist.
+Creating custom registries is useful for allowing the coexistence of multiple custom elements that have the same tag name.
 
-For example, if you have two different versions of a library that both define a `<my-button>` custom element, you can create separate registries for each version of the library to avoid naming conflicts.
+For example, if you have two different versions of a library that both define a `<my-button>` custom element, you can create separate registries for each version of the library, to avoid naming conflicts.
 
 See also:
 * [CustomElementRegistry: CustomElementRegistry() constructor](https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/CustomElementRegistry) at MDN.


### PR DESCRIPTION
Rendered article sections for review:

* **Microsoft Edge 146 web platform release notes (Mar. 2026)** > **Scoped custom element registries**
   * `/web-platform/release-notes/146.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/146?branch=pr-en-us-3744#scoped-custom-element-registries
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/pabrosse/scer-146/microsoft-edge/web-platform/release-notes/146.md#scoped-custom-element-registries
   * Planned live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/146#scoped-custom-element-registries
   * New section.
   * Changed heading from:
     **LCP: match spec'd behavior for emitting candidates**
     to:
     **LCP matches spec'd behavior for emitting candidates**
   * Changed heading from:
     **Navigation API: add post-commit handler from precommit**
     to:
     **Navigation API: Add post-commit handler from precommit**

AB#61343459
