### PR TITLE
Microsoft Edge 149 web platform release notes (Jun. 2026)

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -30,6 +30,10 @@
           href: ./web-platform/release-notes/index.md
           displayName: what's new, announcements
 
+        - name: Microsoft Edge 149
+          href: ./web-platform/release-notes/149.md
+          displayName: Microsoft Edge 149 web platform release notes (Jun. 2026)  # page title
+
         - name: Microsoft Edge 148
           href: ./web-platform/release-notes/148.md
           displayName: Microsoft Edge 148 web platform release notes (May 2026)  # page title
@@ -66,13 +70,13 @@
           href: ./web-platform/release-notes/140.md
           displayName: Microsoft Edge 140 web platform release notes (Sep. 2025)  # page title
 
-        - name: Microsoft Edge 139
-          href: ./web-platform/release-notes/139.md
-          displayName: Microsoft Edge 139 web platform release notes (Aug. 2025)  # page title
-
         # keep 10 items above
         - name: Archive
           items:
+            - name: Microsoft Edge 139
+              href: ./web-platform/release-notes/139.md
+              displayName: Microsoft Edge 139 web platform release notes (Aug. 2025)  # page title
+
             - name: Microsoft Edge 138
               href: ./web-platform/release-notes/138.md
               displayName: Microsoft Edge 138 web platform release notes (Jun. 2025)  # page title

--- a/microsoft-edge/web-platform/release-notes/147.md
+++ b/microsoft-edge/web-platform/release-notes/147.md
@@ -76,10 +76,7 @@ To stay up-to-date and get the latest web platform features, download a preview 
 <!-- ====================================================================== -->
 ## Edge DevTools
 
-See [What's new in Microsoft Edge DevTools](../../devtools/whats-new/index.md).
-<!-- todo: when exists, use instead:
 See [What's new in DevTools (Microsoft Edge 147)](../../devtools/whats-new/147.md).
--->
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/web-platform/release-notes/148.md
+++ b/microsoft-edge/web-platform/release-notes/148.md
@@ -33,10 +33,8 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Support for avar2 in OpenType font format](#support-for-avar2-in-opentype-font-format)
   * [Pointer event suppression on drag start](#pointer-event-suppression-on-drag-start)
   * [Prompt API](#prompt-api)
-  * [Reuse `no-store` images when same `src` is reassigned](#reuse-no-store-images-when-same-src-is-reassigned)
   * [Web Authentication Immediate UI mode](#web-authentication-immediate-ui-mode)
   * [WebGPU `linear_indexing` feature](#webgpu-linear_indexing-feature)
-  * [WebSocket disconnection on bfcache entry](#websocket-disconnection-on-bfcache-entry)
   * [Always negotiate data channels in WebRTC](#always-negotiate-data-channels-in-webrtc)
 * [Origin trials](#origin-trials)
   * [Writer API](#writer-api)
@@ -319,20 +317,6 @@ See also:
 
 
 <!-- ------------------------------ -->
-#### Reuse `no-store` images when same `src` is reassigned
-
-When you reassign the same `src` value to an `<img>` element, the browser now reuses the already-decoded image from the document, even if the image was served with `Cache-Control: no-store`.  This avoids an unnecessary network re-fetch and improves performance.
-
-Previously, the browser would re-fetch the image, even though the image was already decoded and available in the document.
-
-This web interoperability fix aligns Microsoft Edge with Firefox and Safari.
-
-See also:
-* [\<img\>: The Image Embed element](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/img) at MDN.
-* [Cache-Control header](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Cache-Control) at MDN.
-
-
-<!-- ------------------------------ -->
 #### Web Authentication Immediate UI mode
 
 Most sign-in experiences on the web require a sign-in page that offers multiple options, such as username/password fields, federated sign-in buttons, and passkey buttons.  When the browser already knows about passkeys or passwords for a site, the Web Authentication Immediate UI mode can make the sign-in page unnecessary.
@@ -357,20 +341,6 @@ These built-in values provide a convenient single-dimensional index for compute 
 
 See also:
 * [WebGPU API](https://developer.mozilla.org/docs/Web/API/WebGPU_API) at MDN.
-
-
-<!-- ------------------------------ -->
-#### WebSocket disconnection on bfcache entry
-
-Open WebSocket connections are now closed when a page enters the back/forward cache (bfcache), instead of preventing the page from being cached.
-
-Previously, a page with an active WebSocket connection couldn't be stored in the bfcache.  With this change, more pages benefit from instant backward and forward navigation.
-
-Your page receives a `close` event on each affected `WebSocket` when the page enters the bfcache.  Listen for the `pageshow` event, and then reconnect when `event.persisted` is `true`.
-
-See also:
-* [WebSocket](https://developer.mozilla.org/docs/Web/API/WebSocket) at MDN.
-* [Working with the bfcache](https://developer.mozilla.org/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications#working_with_the_bfcache) at MDN.
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -1,0 +1,781 @@
+---
+title: Microsoft Edge 149 web platform release notes (Jun 2026)
+description: Microsoft Edge 149 web platform release notes (Jun 2026)
+author: MSEdgeTeam
+ms.author: msedgedevrel
+ms.topic: conceptual
+ms.service: microsoft-edge
+ms.date: 
+---
+# Microsoft Edge 149 web platform release notes (Jun 2026)
+<!-- todo: update date: field to:
+ms.date: 
+per build report, must be < 30 days in future
+-->
+
+The following are the new web platform features and updates in Microsoft Edge 149, which releases on Jun. 4, 2026.
+
+To stay up-to-date and get the latest web platform features, download a preview channel of Microsoft Edge (Beta, Dev, or Canary); go to [Become a Microsoft Edge Insider](https://www.microsoft.com/edge/download/insider).
+
+**Detailed contents:**
+
+* [Edge DevTools](#edge-devtools)
+* [WebView2](#webview2)
+* [CSS/SVG/Web API features](#csssvgweb-api-features)
+  
+  * [CSS Gap Decorations](#css-gap-decorations)
+  
+  * [Capability Elements &lt;usermedia&gt; MVP](#capability-elements-usermedia-mvp)
+  
+  * [Clip Text overflow on user interaction](#clip-text-overflow-on-user-interaction)
+  
+  * [Disable SVG filters on plugins and cross-origin/restricted iframes](#disable-svg-filters-on-plugins-and-cross-origin-restricted-iframes)
+  
+  * [Intl.Locale.prototype.variants](#intl-locale-prototype-variants)
+  
+  * [OpaqueRange](#opaquerange)
+  
+  * [PWA origin migration](#pwa-origin-migration)
+  
+  * [Payment Request: Allow payment handlers to report back internal errors](#payment-request-allow-payment-handlers-to-report-back-internal-errors)
+  
+  * [Programmatic scroll promises](#programmatic-scroll-promises)
+  
+  * [Remove explicit border color UA stylesheet rule for tables](#remove-explicit-border-color-ua-stylesheet-rule-for-tables)
+  
+  * [Resource Timing: Add spec-compliant Service Worker Router timing fields](#resource-timing-add-spec-compliant-service-worker-router-timing-fields)
+  
+  * [Respect autocorrect=&quot;off&quot; for Windows touch keyboard in TSF](#respect-autocorrect-off-for-windows-touch-keyboard-in-tsf)
+  
+  * [Selective Clipboard Format Read](#selective-clipboard-format-read)
+  
+  * [Support &#39;path-length&#39; as a CSS property.](#support-path-length-as-a-css-property)
+  
+  * [Support path() and shape() in shape-outside](#support-path-and-shape-in-shape-outside)
+  
+  * [Support rect() and xywh() in shape-outside](#support-rect-and-xywh-in-shape-outside)
+  
+  * [User action pseudo class top layer boundary](#user-action-pseudo-class-top-layer-boundary)
+  
+  * [Web app scope system accent color](#web-app-scope-system-accent-color)
+  
+  * [image-rendering: crisp-edges](#image-rendering-crisp-edges)
+  
+* [Deprecated or removed features](#deprecated-or-removed-features)
+  
+  
+* [Origin trials](#origin-trials)
+  
+  * [SharedArrayBuffers in non-isolated pages on Desktop platforms](#sharedarraybuffers-in-non-isolated-pages-on-desktop-platforms)
+  
+  * [Incoming Call Notifications](#incoming-call-notifications)
+  
+  * [Proofreader API](#proofreader-api)
+  
+  * [Prompt API](#prompt-api)
+  
+  * [WebAssembly Custom Descriptors](#webassembly-custom-descriptors)
+  
+  * [UserMediaElement](#usermediaelement)
+  
+  * [Soft Navigation Heuristics](#soft-navigation-heuristics)
+  
+  * [Enhanced Canvas TextMetrics](#enhanced-canvas-textmetrics)
+  
+  * [WebNN](#webnn)
+  
+  * [focusgroup](#focusgroup)
+  
+  * [URL and eval hashes in CSP script-src](#url-and-eval-hashes-in-csp-script-src)
+  
+  * [WebAppInstallation](#webappinstallation)
+  
+  * [OpaqueRange](#opaquerange)
+  
+  * [html-in-canvas](#html-in-canvas)
+  
+  * [Digital Credentials API - Issuance Support](#digital-credentials-api-issuance-support)
+  
+  * [PrerenderUntilScript](#prerenderuntilscript)
+  
+  * [WebAudio Configurable Render Quantum](#webaudio-configurable-render-quantum)
+  
+  * [PrerenderActivationByFormSubmission](#prerenderactivationbyformsubmission)
+  
+  * [CPU Performance API](#cpu-performance-api)
+  
+  * [Connection Allowlists](#connection-allowlists)
+  
+  * [Prerendering cross-origin iframes](#prerendering-cross-origin-iframes)
+  
+  * [Container Timing](#container-timing)
+  
+  * [Long Animation Frames - separate style and layout durations](#long-animation-frames-separate-style-and-layout-durations)
+  
+  * [Prompt API Sampling Parameters](#prompt-api-sampling-parameters)
+  
+  * [HTML Install Element](#html-install-element)
+  
+  * [Declarative CSS Module Scripts](#declarative-css-module-scripts)
+  
+  * [Autofill Event](#autofill-event)
+  
+
+
+<!-- ====================================================================== -->
+## Edge DevTools
+
+See [What's new in Microsoft Edge DevTools](../../devtools/whats-new/index.md).
+<!-- todo: when exists, use instead:
+See [What's new in DevTools (Microsoft Edge 149)](../../devtools/whats-new/149.md).
+-->
+
+
+<!-- ====================================================================== -->
+## WebView2
+
+See [Release notes for the WebView2 SDK](../../webview2/release-notes/index.md).
+<!-- todo: when exists, use instead:
+See [Release SDK 1.0.nnnn.nn, for Runtime nnn](../../webview2/release-notes/index.md#10nnnnnn) (Jun 2026) in _Release notes for the WebView2 SDK_.
+-->
+
+
+<!-- ====================================================================== -->
+## CSS features
+
+The following new Cascading Style Sheets (CSS) features are included in Microsoft Edge.
+
+## Web APIs
+
+The following new Web API features are included in Microsoft Edge.
+
+**TODO: MOVE THE BELOW FEATURES IN THE CORRECT H2 HEADINGS ABOVE.**
+
+
+
+<!-- ------------------------------ -->
+#### CSS Gap Decorations
+
+CSS Gap Decorations enables styling of gaps in container layouts like Grid and Flexbox, similar to ‘column-rule’ in multicol layout. This feature is highly requested by web authors who must use hacks to style the gaps in Grid and Flexbox layouts today.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Capability Elements &lt;usermedia&gt; MVP
+
+Usermedia Capability Element, is a declarative, user-activated control for accessing the starting and interacting with media streams.
+
+This addresses the long-standing problem of permission prompts being triggered directly from JavaScript without a strong signal of user intent. By embedding a browser-controlled element in the page, the user's click provides a clear, intentional signal. This enables a much better prompt UX and, crucially, provides a simple recovery path for users who have previously denied the permission.
+
+Note: This feature was previously developed and tested in an Origin Trial as the more generic <permission> element. Based on feedback from developers and other browser vendors, it has evolved into capability-specific elements to provide a more tailored and powerful developer experience.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Clip Text overflow on user interaction
+
+When a user interacts (editing or caret navigation) with text which has ‘text-overflow: ellipsis’ set, the text switches temporarily from ellipsis to clip allowing the user to see and interact with the hidden overflow content. This feature applies to all editable and non-editable elements. For form controls (textarea, input), the behavior is already supported.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Disable SVG filters on plugins and cross-origin/restricted iframes
+
+This launch prevents SVG filters from being applied to cross-origin/restricted iframes (e.g., sandboxed ones) and embedded plugins (e.g., pdfs). When a frame/plugin would be painted with an SVG filter effect, the effect tree is traversed to find the highest ancestor without SVG filters, and that effect is then applied instead.
+
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Intl.Locale.prototype.variants
+
+Add Intl.Locale.prototype.variants as stated in 
+https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
+and also accept "variants" in option bag in Intl.Locale consturctor
+as in https://tc39.es/ecma402/#sec-updatelanguageid
+The changes to ECMA402 is merged in 
+ https://github.com/tc39/ecma402/pull/960
+and the test code in test262 are merged in  in https://github.com/tc39/test262/pull/4474/
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### OpaqueRange
+
+`OpaqueRange` represents a live span of text within a form control’s value, such as a `<textarea>` or text-based `<input>`, so developers can work with value text using range-like APIs.
+
+It enables operations such as `getBoundingClientRect()`, `getClientRects()`, and integration with the CSS Custom Highlight API for UI such as inline suggestions, highlights, and anchored popovers. It preserves encapsulation by exposing only value offsets while returning `null` for `startContainer` and `endContainer`, so DOM endpoints and internal structure are not exposed.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### PWA origin migration
+
+When a user installs a Progressive Web App (PWA), its identity and security context are tightly bound to its web origin, for example, `app.example.com`. This presents a significant challenge for developers who need to change their PWA's origin due to rebranding, domain restructuring, or technical re-architecture. Currently, such a change forces users to manually uninstall the old app and reinstall the new one, leading to a disruptive experience and potential user loss. Chrome 149 introduces a mechanism for developers to seamlessly migrate an installed PWA to a new, same-site origin, preserving user trust and permissions.
+
+The [WebAppInstallForceList](https://chromeenterprise.google/policies/#WebAppInstallForceList) policy will block migration. Since enterprise policies around web applications are primarily based on URLs and origins, there is a risk that a migration would bypass certain policies an admin might have configured. No migration will be offered to the user when an app is force-installed by their enterprise administrator, and instead a banner will be shown explaining this to the user.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Payment Request: Allow payment handlers to report back internal errors
+
+Enables payment handlers that are accessed via the Payment Request API to return distinct errors for "user cancelled" vs "internal payment app error". This allows web developers to build better flows for users, e.g. by retrying or falling back to a different flow when an internal app error occurs, whilst properly stopping the flow if the user wants to cancel.
+
+The Web-based Payment Handler API can indicate this difference based on what error they use to reject the promised passed to PaymentRequestEvent.respondWith. If the promise is rejected with an OperationError, then "internal app error" (OperationError) is returned to the merchant via the PaymentRequest.show(), otherwise "user cancel" (AbortError) is returned.
+
+Native app payment handler infrastructure is similarly updated, but is out of scope for web APIs.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Programmatic scroll promises
+
+Web developers currently have no way to know when a programmatic smooth-scroll has completed. This feature provides a solution to the problem: make the programmatic scroll methods return Promise objects that get resolved on scroll completion.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Remove explicit border color UA stylesheet rule for tables
+
+This change removes the erroneous `border-color: gray` CSS rule from the UA stylesheet for the `<table>` element.
+
+The spec does not contain this rule:
+
+https://html.spec.whatwg.org/multipage/rendering.html#tables-2
+
+and it causes the borders to incorrectly not default to currentColor. Neither Firefox nor Webkit have this `gray` border color rule in their UA stylesheet, leading to interop problems.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Resource Timing: Add spec-compliant Service Worker Router timing fields
+
+Adds the `workerMatchedRouterSource` and `workerFinalRouterSource` attributes to the Resource Timing and Navigation Timing APIs. These attributes allow developers to identify which Service Worker Static Router rule was matched and the final source used for the request.
+
+Note on Deprecation: This change focuses exclusively on adding the spec-compliant fields. We will be sending a separate Intent to Deprecate (I2D) for the existing non-compliant fields (`workerMatchedSourceType` and `workerFinalSourceType`) once we have gathered sufficient usage data from our UseCounters.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Respect autocorrect=&quot;off&quot; for Windows touch keyboard in TSF
+
+The HTML autocorrect attribute allows web authors to control whether autocorrection should be applied to user input in editable elements including <input>, <textarea>, and contenteditable hosts. On Windows, the touch keyboard ignores this attribute and always autocorrects words. For example, typing "truf" followed by space in an element with autocorrect="off" yields "true " instead of preserving "truf ". This feature makes Chrome's TSF integration detect and revert touch keyboard autocorrections when the focused editable element has autocorrect="off" set.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Selective Clipboard Format Read
+
+Enhances the Asynchronous Clipboard API by deferring actual clipboard data retrieval from the OS until the web application calls getType(). Instead of eagerly fetching all available formats at read() time, the browser now returns ClipboardItem objects with available MIME types but without the underlying data, and reads from the OS clipboard only when getType() is invoked.
+
+    const items = await navigator.clipboard.read(); // No data read yet
+    const text = await items.getType('text/plain'); // Only 'text/plain' data 
+                                                                                 read here
+
+This reduces CPU usage, improves the perceived responsiveness of the API call, and optimizes the browser's power consumption.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Support &#39;path-length&#39; as a CSS property.
+
+This change introduces a new CSS property, 'path-length', which maps to the existing SVG 'pathLength' presentation attribute. It applies to SVG geometry elements that support 'pathLength' (including <path>, <circle>, <rect>, <line>, <polyline>, <polygon>, and <ellipse>).
+
+Exposing 'pathLength' as a CSS property allows authors to specify it via stylesheets, inline styles, and animations, enabling it to participate in normal CSS cascading, specificity, transitions, and animations. The property affects all computations that depend on the total path length, including stroke dash rendering and text positioning along a <textPath>.
+
+CSS declarations override the presentation attribute following standard CSS precedence rules. The initial value of 'path-length' is 'none', which represents the absence of an author-supplied path length and is distinct from an explicit numeric value such as '0'.
+
+Existing attribute-only behavior is preserved when the feature is disabled.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Support path() and shape() in shape-outside
+
+Adds support for the path() and shape() shape functions in the CSS shape-outside property. These functions allow developers to define float exclusion shapes using rectangle coordinates.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Support rect() and xywh() in shape-outside
+
+Adds support for the rect() and xywh() basic shape functions in the CSS shape-outside property. These functions allow developers to define float exclusion shapes using rectangle coordinates, aligning Chrome with Firefox and Safari which already support this feature.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### User action pseudo class top layer boundary
+
+This feature represents the behavior described in this section of the CSS spec:
+
+https://www.w3.org/TR/selectors-4/#useraction-pseudos
+
+which says that :hover, :active, and :focus-within match on the parents of elements, but only up to the first top layer element in the parent chain. The change for Chromium is that last "up to the top layer" part of this behavior.
+
+Concretely, this means that for this structure:
+
+```
+<main>
+  <div popover>
+    <button></button>
+  </div>
+</main>
+<script>document.querySelector('[popover]').showPopover();</script>
+```
+
+if the user hovers the `<button>`, then the `:hover` pseudo class will match the `<button>`, and the popover, but will not match the `<main>` element.
+
+The rationale behind this change is that typically top layer elements are rendered "elsewhere", in a location that is disconnected from the parent element visually. So it typically does not make sense to change the styles of the parent element when the top layer element is hovered or activated, for example.
+
+The customizable-<select> implementation shipped in Chromium has this logic hard-coded for the specific case of the select `::picker()` popover. That special case logic will be removed when this feature ships.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Web app scope system accent color
+
+Currently, if the `accent-color` property for form controls are set to `auto`, they adopt the system accent color set by the user in their operating system. This happens in all contexts whether on the web or in an installed web application. Current feature state: https://chromestatus.com/feature/6548224737017856
+
+AccentColor and AccentColorText CSS keywords, which also adopt the system accent color, pose a significant fingerprinting vector if exposed widely on the web. As such, they're currently planned to only be available in installed web app contexts. We want system accent color exposure to match across all vectors, so we should scope `accent-color: auto` to only be available in installed web app contexts as well. This introduces more consistent developer and user expectations for system colors and aligns with fingerprinting restrictions for AccentColor[Text].
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### image-rendering: crisp-edges
+
+"image-rendering: crisp-edges" indicates that image should be scaled in a way that preserves contrast and edges, and which avoids smoothing colors or introducing blur to the image in the process
+
+Note: spec wise this is technically different than 'pixelated'. In actual implementations it is not. Spec wise 'pixelated' = use any process the UA wants to make the result look pixelated. nearest-neighbor is acceptable. 'crisp-edges' = use any process you want that preserves contrast, edges, and avoids blending colors, nearest-neighbor is acceptable. Both Firefox and Safari use treat both as synonym and use nearest-neighbor for both.
+
+See also:
+* []()
+
+
+<!-- ------------------------------ -->
+#### Deprecated or removed features
+
+**TODO: CHECK THE FEATURES LISTED BELOW AND ADD THEM TO THE SITE-COMPAT-IMPACTING-CHANGES ARTICLE.**
+
+
+
+
+
+<!-- ====================================================================== -->
+## Origin trials
+
+The following are origin trials for new experimental APIs that are available in Microsoft Edge.
+
+Origin trials let you try experimental APIs on your own live website for a limited time.  To learn more about origin trials, see [Use origin trials in Microsoft Edge](../../origin-trials/index.md).
+
+For the full list of available origin trials, see [Microsoft Edge Origin Trials](https://developer.microsoft.com/microsoft-edge/origin-trials/).
+
+
+
+<!-- ------------------------------ -->
+#### SharedArrayBuffers in non-isolated pages on Desktop platforms
+
+Expires on May 19, 2026.
+
+Temporary extension for ungated use of SharedArrayBuffers in pages that are not cross-origin isolated.
+
+* [Explainer](https://developer.chrome.com/blog/enabling-shared-array-buffer/)
+* [Feedback](https://bugs.chromium.org/p/chromium/issues/entry?components=Internals%3ESandbox%3ESiteIsolation)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/5745776f-9ff4-47fd-81f2-beaf6c2c50c6)
+
+
+
+<!-- ------------------------------ -->
+#### Incoming Call Notifications
+
+Expires on May 19, 2026.
+
+Extend the Notifications API to allow installed PWA&#39;s to send incoming call notifications - i.e., notifications with call-styled buttons and a ringtone. This extension will help VoIP web apps to create more engaging experiences by making it easier for users to easily recognize a calling notification and answer it. Besides that, this feature will help bridge the gap between native and web implementations of apps that have them both.
+
+* [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Notifications/notifications_actions_customization.md)
+* [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/699bfcb9-7bf2-414b-8158-af775f52ac03)
+
+
+
+<!-- ------------------------------ -->
+#### Proofreader API
+
+Expires on May 19, 2026.
+
+The Proofreader API is a JavaScript API that proofreads input text with suggested corrections, backed by an AI language model. This API exposes high-level functionality to help web developers perform real-time proofreading and offers two specific features: error correction , and error labeling (identifying the error type like spelling or grammar). Developers can use this API to proofread user messages in chat applications , help polish email drafting , catch errors during note-taking , or provide high-quality interactive proofreading feedback when writing documents.
+
+* [Explainer](https://github.com/webmachinelearning/proofreader-api/blob/main/README.md)
+* [Feedback](https://github.com/webmachinelearning/proofreader-api/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/03b14cb6-3ac8-4049-8bf1-b293109f1d05)
+
+
+
+<!-- ------------------------------ -->
+#### Prompt API
+
+Expires on Jun. 16, 2026.
+
+Prompt API allows interacting with an AI language model using text, image, and audio inputs. It supports various use cases, from generating image captions and performing visual searches to transcribing audio, classifying sound events, generating text following specific instructions, and extracting information or insights from text. It supports structured outputs which ensure that responses adhere to a predefined format, typically expressed as a JSON schema, to enhance response conformance and facilitate seamless integration with downstream applications that require standardized output formats.
+
+* [Explainer](https://github.com/webmachinelearning/prompt-api/blob/main/README.md)
+* [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b7d35247-b855-4b08-b237-89e7a5056117)
+
+
+
+<!-- ------------------------------ -->
+#### WebAssembly Custom Descriptors
+
+Expires on Jun. 16, 2026.
+
+Allows WebAssembly to store data associated with source-level types more efficiently in new &quot;custom descriptor&quot; objects. 
+
+* [Explainer](https://github.com/WebAssembly/custom-descriptors/blob/main/proposals/custom-descriptors/Overview.md)
+* [Feedback](https://github.com/WebAssembly/custom-descriptors/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/f1227421-7d96-4380-b588-cbe9806aa7a3)
+
+
+
+<!-- ------------------------------ -->
+#### UserMediaElement
+
+Expires on Jul. 14, 2026.
+
+The current web permission model for UserMedia relies on JavaScript-triggered prompts, giving the user agent no strong signal of user intent. This results in out-of-context prompts, user frustration, and difficult-to-recover-from denial states.
+
+We propose the &lt;usermedia&gt; element, a semantic HTML control with browser-controlled content and strict styling constraints. These constraints are fundamental to the security model, ensuring a very high level of confidence in the user&#39;s intent when making a permission decision at both the site and OS level.
+
+Crucially, the &lt;usermedia&gt; element evolves beyond simply managing permissions; it streamlines the entire journey by also directly providing UserMedia stream to the site. This often eliminates the need for separate JavaScript API calls, simplifying implementation and creating a more seamless user flow.
+
+By providing a clear, consistent, in-page control, this element solves significant user problems related to context blindness and &quot;permission regret,&quot; offering a simple recovery path from a previously denied state. The combination of a user-initiated element and a subsequent browser-controlled confirmation UI enhances intent capture, improves accessibility, and prevents manipulative patterns, providing a significantly better experience for both users and developers.
+
+* [Explainer](https://github.com/WICG/PEPC/blob/main/usermedia_element.md)
+* [Feedback](https://github.com/WICG/PEPC/issues/62#issuecomment-3210807676)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/ff216fe5-9eb9-4acb-aace-2f6a8789b95c)
+
+
+
+<!-- ------------------------------ -->
+#### Soft Navigation Heuristics
+
+Expires on Jul. 28, 2026.
+
+&quot;Soft navigations&quot; are JS-driven same-document navigations that are using the history API or the new Navigation API, triggered by a user gesture and modifies the DOM, modifying the previous content, as well as the URL displayed to the user. This OT would experiment with soft navigation heuristics, and will experimentally web-expose them, so that RUM providers and developers can collect them and report back of their usefulness when collecting performance metrics.
+
+* [Explainer](https://github.com/WICG/soft-navigations#soft-navigations)
+* [Feedback](https://github.com/WICG/soft-navigations/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/ec952482-49f0-4980-a451-13ea3f9a7220)
+
+
+
+<!-- ------------------------------ -->
+#### Enhanced Canvas TextMetrics
+
+Expires on Aug. 11, 2026.
+
+Expand the TextMetrics Canvas API to support selection rectangles, bounding box queries, and glyph cluster-based operations.
+
+This new functionality should enable complex text editing applications with accurate selection, caret positioning, and hit testing.  Additionally, cluster-based rendering facilitates sophisticated text effects such as independent character animations and styling.
+
+* [Explainer](https://github.com/Igalia/explainers/blob/main/canvas-formatted-text/text-metrics-additions.md)
+* [Feedback](https://github.com/Igalia/explainers/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/c4ab8844-e904-46c1-94b6-7e2b5c19bf3e)
+
+
+
+<!-- ------------------------------ -->
+#### WebNN
+
+Expires on Aug. 11, 2026.
+
+WebNN provides a high-level abstraction over the ML acceleration capabilities provided by the platform. The goal of this experiment is to understand how well real-world models abstract to the operations supported by WebNN and how well WebNN can map these operations to those supported by the hardware of real-world users.
+
+* [Explainer](https://webnn.io/en/learn/get-started/quickstart)
+* [Feedback](https://github.com/webmachinelearning/webnn/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/19857284-cf52-484b-8b09-8ca50ac9dccb)
+
+
+
+<!-- ------------------------------ -->
+#### focusgroup
+
+Expires on Aug. 11, 2026.
+
+focusgroup provides focus navigation among a set of focusable elements with the arrow keys.
+
+* [Explainer](https://open-ui.org/components/scoped-focusgroup.explainer)
+* [Feedback](https://github.com/openui/open-ui/issues/new?labels=focusgroup&amp;title=%5Bfocusgroup%5D%20)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/6d4b86e7-230c-4d23-ab2b-ee8d05f18702)
+
+
+
+<!-- ------------------------------ -->
+#### URL and eval hashes in CSP script-src
+
+Expires on Aug. 25, 2026.
+
+This feature introduces url- and eval- hashes to be used in script-src directives in Content Security Policy. It enables developers to write a strict CSP that only relies on hash and nonce based policies, without having to use permissive hostname based allowlists or unsafe-eval.
+
+
+* [Explainer](https://github.com/explainers-by-googlers/script-src-v2)
+* [Feedback](https://github.com/explainers-by-googlers/script-src-v2/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/6bd50a0d-6f30-425f-beba-034be41bb013)
+
+
+
+<!-- ------------------------------ -->
+#### WebAppInstallation
+
+Expires on Aug. 25, 2026.
+
+Allows websites to imperatively install other websites as web apps, via an install_url and optional manifest_id. 
+
+* [Explainer](https://aka.ms/webinstall)
+* [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=web-install-api.md)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/bcf7d28f-6bdf-45d8-9207-63c97a042407)
+
+
+
+<!-- ------------------------------ -->
+#### OpaqueRange
+
+Expires on Aug. 25, 2026.
+
+OpaqueRange lets developers create live ranges over text inside &lt;input&gt; and &lt;textarea&gt; elements that automatically update as the user edits. These ranges support geometry methods like getBoundingClientRect() and the CSS Custom Highlight API, enabling use cases like caret-positioned popups and inline spell-check highlighting directly on form controls without cloning elements or exposing internal DOM structure.
+
+* [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/OpaqueRange/explainer.md)
+* [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=opaque-range.md)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/5f4620e8-2969-4579-a5c6-304b8fae7200)
+
+
+
+<!-- ------------------------------ -->
+#### html-in-canvas
+
+Expires on Aug. 25, 2026.
+
+HTML-in-canvas enables customizing the rendering of html using canvas with three new primitives: an attribute to opt-in canvas elements (layoutsubtree), methods to draw child elements (2d: drawElementImage, webgl: texElementImage2D, webgpu: copyElementImageToTexture), and a paint event which fires to handle updates.
+
+* [Explainer](https://github.com/WICG/html-in-canvas)
+* [Feedback](https://github.com/WICG/html-in-canvas/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/a297467e-0030-4c4c-8739-48e130026c03)
+
+
+
+<!-- ------------------------------ -->
+#### Digital Credentials API - Issuance Support
+
+Expires on Sep. 8, 2026.
+
+This API enables triggering the issuance of user credentials from a credential issuer server to a digital wallet application. It is available on both Desktop and Android platforms and can be used, for instance, to trigger the provisioning of a new driver&#39;s license or verified academic degree from a government or university server to a user&#39;s digital wallet.
+
+* [Explainer](https://w3c-fedid.github.io/digital-credentials)
+* [Feedback](https://github.com/w3c-fedid/digital-credentials/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/89fbbd25-ce49-43b6-a206-dd0909394ed8)
+
+
+
+<!-- ------------------------------ -->
+#### PrerenderUntilScript
+
+Expires on Sep. 8, 2026.
+
+A new action for the Speculation Rules API, prerender_until_script. This action is designed to provide developers with an intermediate option between the existing prefetch and prerender actions.
+
+* [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerender-until-script.md)
+* [Feedback](https://github.com/WICG/nav-speculation/issues/305)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b7fcdb4e-b3ab-4bbe-ba5a-0d4e655ad690)
+
+
+
+<!-- ------------------------------ -->
+#### WebAudio Configurable Render Quantum
+
+Expires on Sep. 8, 2026.
+
+Makes AudioContext and OfflineAudioContext take an optional renderSizeHint, which allows users to ask for a particular render quantum size.
+
+* [Explainer](https://webaudio.github.io/web-audio-api/#dom-audiocontextoptions-rendersizehint)
+* [Feedback](https://github.com/WebAudio/web-audio-api/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/d5574838-d416-4242-81a8-7833c107b028)
+
+
+
+<!-- ------------------------------ -->
+#### PrerenderActivationByFormSubmission
+
+Expires on Sep. 8, 2026.
+
+Introduces a new field to the Speculation Rules API that allows prerender rules to be activated by form submissions.
+
+* [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerendering-form-submission.md)
+* [Feedback](https://github.com/WICG/nav-speculation/issues/322)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/63420781-6a9d-4b23-a827-69ebe66fb631)
+
+
+
+<!-- ------------------------------ -->
+#### CPU Performance API
+
+Expires on Sep. 8, 2026.
+
+The CPU Performance API exposes some information about how powerful the user device is. It targets web applications that will use this information to provide an improved user experience, possibly in combination with the Compute Pressure API, which provides information about the user device’s CPU pressure/utilization and allows applications to react to changes in CPU pressure.
+
+* [Explainer](https://github.com/WICG/cpu-performance)
+* [Feedback](https://github.com/WICG/cpu-performance/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/505dbb22-2d7f-4c91-9a2b-3913345a956e)
+
+
+
+<!-- ------------------------------ -->
+#### Connection Allowlists
+
+Expires on Sep. 8, 2026.
+
+Connection Allowlists is a feature designed to provide explicit control over external endpoints by restricting connections initiated via the Fetch API or other web platform APIs from a document or worker. The proposed implementation involves the distribution of an authorized endpoint list from the server through an HTTP response header. Prior to the establishment of any connection by the user agent on behalf of a page, the agent will evaluate the destination against this allowlist; connections to verified endpoints will be permitted, while those failing to match the entries in the list will be blocked. More details on the proposal can be found here: https://github.com/WICG/connection-allowlists 
+
+* [Explainer](https://github.com/WICG/connection-allowlists)
+* [Feedback](https://github.com/WICG/connection-allowlists/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/a20a4374-39fd-445f-9348-f6c8737a45de)
+
+
+
+<!-- ------------------------------ -->
+#### Prerendering cross-origin iframes
+
+Expires on Sep. 22, 2026.
+
+Prerenders cross-origin iframes with an opt-in response header. Browsers will now prerender all cross-origin frames if the top-level frame&#39;s HTTP response includes the Supports-Loading-Mode: prerender-cross-origin-frames.
+
+* [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerendering-cross-origin-iframes.md)
+* [Feedback](https://github.com/WICG/nav-speculation/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/46c24517-496a-4a6b-a4d3-604b08620d43)
+
+
+
+<!-- ------------------------------ -->
+#### Container Timing
+
+Expires on Oct. 6, 2026.
+
+The Container Timing API enables monitoring when annotated sections of the DOM are displayed on screen and have finished their initial paint. A developer will have the ability to mark subsections of the DOM with the &quot;containertiming&quot; attribute (similar to &quot;elementtiming&quot; for the Element Timing API) and receive performance entries when that section has been painted for the first time. This API will allow developers to measure the timing of various components in their pages.
+
+* [Explainer](https://github.com/WICG/container-timing/blob/main/ORIGIN_TRIAL.md)
+* [Feedback](https://github.com/WICG/container-timing/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/79fd2cd8-2283-4ed8-a472-4a8281a73d86)
+
+
+
+<!-- ------------------------------ -->
+#### Long Animation Frames - separate style and layout durations
+
+Expires on Oct. 6, 2026.
+
+Add `styleDuration`, `forcedStyleDuration`, `layoutDuration` and `forcedLayoutDuration` information to the Long Animation Frame API, enabling developers to distinguish style and layout times.
+
+That enables developers to get a deeper understanding of their CSS performance issues in the wild.
+
+* [Explainer](https://github.com/w3c/long-animation-frames/pull/30#issue-3828859369)
+* [Feedback](https://github.com/w3c/long-animation-frames/pull/30)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/349e23d8-799a-4ac2-b45a-ffb91e09b4ce)
+
+
+
+<!-- ------------------------------ -->
+#### Prompt API Sampling Parameters
+
+Expires on Oct. 6, 2026.
+
+Enable Prompt API per-session language model sampling parameters.
+
+Parameter tuning is useful for testing and use-case specific model behavior optimization. This trial will explore parameters and options that satisfy developer requirements and mitigate interoperability concerns that excluded topK and temperature from the initial Prompt API launch.
+
+* [Explainer](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#sampling-parameters)
+* [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/32d0cd0f-611d-411e-b48e-cfd8edfdbf73)
+
+
+
+<!-- ------------------------------ -->
+#### HTML Install Element
+
+Expires on Oct. 6, 2026.
+
+Allows websites to declaratively install other websites as web apps, via an install_url and optional manifest_id attributes of the HTML element.
+
+
+* [Explainer](https://github.com/MicrosoftEdge/Demos/blob/main/pwa-install-element/README.md)
+* [Feedback](https://github.com/WICG/install-element/issues/new?template=install-element-ot-feedback.md)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b2eb5c7f-7df0-4ad9-950e-2fbd2ebc08ec)
+
+
+
+<!-- ------------------------------ -->
+#### Declarative CSS Module Scripts
+
+Expires on Oct. 6, 2026.
+
+Declarative CSS Modules Scripts are an extension of the existing script-based CSS Module Scripts. They allow for developers to share declarative stylesheets with shadow roots, including declarative shadow roots. Developers can define inline style modules with &lt;style type=&quot;module&quot; specifier=&quot;foo&quot;&gt; and apply a declarative module to a declarative shadow DOM by referencing specifier or a URL, such as &lt;template shadowrootmode=&quot;open&quot; shadowrootadoptedstylesheets=&quot;foo&quot;&gt;.
+
+* [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md)
+* [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/DeclarativeShadowDOMStyleSharing)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/966b04dd-3da4-43f4-a6a0-66a785f129f4)
+
+
+
+<!-- ------------------------------ -->
+#### Autofill Event
+
+Expires on Nov. 3, 2026.
+
+Autofill is a key feature of the web that reduces friction for millions of users everyday. But it&#39;s not without its developer friction.
+
+This trial exposes the &quot;autofill&quot; event which will enable developers to get access to the fields/values about to be filled, change the form dynamically to accomodate that and ask the browser to retrigger autofill if needed.
+
+* [Explainer](https://github.com/WICG/autofill-event?tab=readme-ov-file#autofill-event)
+* [Feedback](https://github.com/WICG/autofill-event/issues/31)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/43534059-5696-4eaf-8bbd-eba4c4f86e88)
+
+
+
+
+<!-- ====================================================================== -->
+> [!NOTE]
+> Portions of this page are modifications based on work created and shared by Chromium.org and used according to terms described in the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0).

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -347,7 +347,7 @@ An open WebSocket connection is now closed when a page enters the back/forward c
 
 Previously, a page that had an active WebSocket connection couldn't be stored in the bfcache.  With this change, more pages benefit from instant backward and forward navigation.
 
-When the page enters the bfcache, your page receives a `close` event on each affected `WebSocket`.  Listen for the `pageshow` event, and then reconnect when `event.persisted` is `true`.
+When your page enters the bfcache, the page receives a `close` event on each affected `WebSocket`.  Listen for the `pageshow` event, and then reconnect when `event.persisted` is `true`.
 
 See also:
 * [WebSocket](https://developer.mozilla.org/docs/Web/API/WebSocket) at MDN.

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -5,11 +5,11 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
-ms.date: 
+ms.date: 06/02/2026
 ---
 # Microsoft Edge 149 web platform release notes (Jun. 2026)
-<!-- todo: update date: field to:
-ms.date: 
+<!-- todo: update ms.date: field to:
+ms.date: 06/04/2026
 per build report, must be < 30 days in future
 -->
 
@@ -27,7 +27,7 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [`image-rendering: crisp-edges`](#image-rendering-crisp-edges)
   * [`path-length` CSS property for SVG elements](#path-length-css-property-for-svg-elements)
   * [`path()`, `shape()`, `rect()`, and `xywh()` in `shape-outside`](#path-shape-rect-and-xywh-in-shape-outside)
-  * [Remove `border-color: gray` from the table user agent stylesheet](#remove-border-color-gray-from-the-table-user-agent-stylesheet)
+  * [Removed `border-color: gray` from user agent stylesheet for `<table>`](#removed-border-color-gray-from-user-agent-stylesheet-for-table)
   * [Scope system accent color to installed web apps](#scope-system-accent-color-to-installed-web-apps)
   * [User-action pseudo-classes top-layer boundary](#user-action-pseudo-classes-top-layer-boundary)
 * [Web APIs](#web-apis)
@@ -35,12 +35,12 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Intl.Locale variants](#intllocale-variants)
   * [`OpaqueRange` for form control text](#opaquerange-for-form-control-text)
   * [Migrate a PWA to a new origin](#migrate-a-pwa-to-a-new-origin)
-  * [Distinguish payment handler errors in Payment Request](#distinguish-payment-handler-errors-in-payment-request)
+  * [Distinguish payment handler errors in a payment request](#distinguish-payment-handler-errors-in-a-payment-request)
   * [Get notified when the `scrollBy` and `scrollTo` methods complete](#get-notified-when-the-scrollby-and-scrollto-methods-complete)
   * [`Request.isReloadNavigation` attribute](#requestisreloadnavigation-attribute)
   * [Service Worker router timing fields in Resource Timing and Navigation Timing APIs](#service-worker-router-timing-fields-in-resource-timing-and-navigation-timing-apis)
   * [`autocorrect="off"` on Windows touch keyboard](#autocorrectoff-on-windows-touch-keyboard)
-  * [Defer clipboard data reads with selective format reading](#defer-clipboard-data-reads-with-selective-format-reading)
+  * [Defer clipboard data reads until the format<!-- todo: the MIME type? --> is specified](#defer-clipboard-data-reads-until-the-format-is-specified)
   * [Close WebSocket connections on bfcache entry](#close-websocket-connections-on-bfcache-entry)
 * [Origin trials](#origin-trials)
   * [SharedArrayBuffers in non-isolated pages on Desktop platforms](#sharedarraybuffers-in-non-isolated-pages-on-desktop-platforms)
@@ -84,8 +84,8 @@ See [What's new in DevTools (Microsoft Edge 149)](../../devtools/whats-new/149.m
 ## WebView2
 
 See [Release notes for the WebView2 SDK](../../webview2/release-notes/index.md).
-<!-- todo: when exists, use instead:
-See [Release SDK 1.0.nnnn.nn, for Runtime nnn](../../webview2/release-notes/index.md#10nnnnnn) (Jun 2026) in _Release notes for the WebView2 SDK_.
+<!-- todo: when exists, use instead the 149 equiv. of:
+See [Release SDK 1.0.3912.50, for Runtime 147 (Apr. 13, 2026)](../../webview2/release-notes/index.md#release-sdk-10391250-for-runtime-147-apr-13-2026) in _Release notes for the WebView2 SDK_.
 -->
 
 
@@ -98,16 +98,17 @@ The following new Cascading Style Sheets (CSS) features are included in Microsof
 <!-- ------------------------------ -->
 #### CSS gap decorations
 
-Style the gaps in Grid and Flexbox container layouts, similar to `column-rule` in multicol layout.  Use gap decorations to visually separate items without resorting to workarounds such as pseudo-elements or extra wrapper elements.
+Style the gaps in Grid and Flexbox container layouts, similar to `column-rule` in multiple-column layout.  Use gap decorations to visually separate items without resorting to workarounds such as pseudo-elements or extra wrapper elements.
 
 See also:
-* [A new way to style gaps in CSS](https://developer.chrome.com/blog/gap-decorations).
+* [A new way to style gaps in CSS](https://developer.chrome.com/blog/gap-decorations)
+* [Multiple-column layout](https://developer.mozilla.org/docs/Learn_web_development/Core/CSS_layout/Multiple-column_Layout) at MDN.
 
 
 <!-- ------------------------------ -->
 #### Clip text overflow on user interaction
 
-When a user interacts with text that has `text-overflow: ellipsis` set (such as editing or caret navigation), the text temporarily switches from ellipsis to clip.  This allows the user to see and interact with the hidden overflow content.
+When a user interacts with text that has `text-overflow: ellipsis` set (such as during editing or caret navigation), the text temporarily switches from ellipsis to clip (in which the truncation can happen in the middle of a character).  This allows the user to see and interact with the hidden overflow content.
 
 This behavior applies to all editable and non-editable elements.  Form controls (`<textarea>`, `<input>`) already support this behavior.
 
@@ -120,7 +121,7 @@ See also:
 
 The `image-rendering` property now supports the `crisp-edges` value.
 
-Use `image-rendering: crisp-edges` to scale an image in a way that preserves contrast and edges without smoothing colors or introducing blur.
+Use `image-rendering: crisp-edges` to scale an image in a way that preserves contrast and edges, without smoothing colors or introducing blur.
 
 See also:
 * [image-rendering](https://developer.mozilla.org/docs/Web/CSS/image-rendering) at MDN.
@@ -129,9 +130,16 @@ See also:
 <!-- ------------------------------ -->
 #### `path-length` CSS property for SVG elements
 
-Use the new `path-length` CSS property to set the `pathLength` value on SVG geometry elements (including `<path>`, `<circle>`, `<rect>`, `<line>`, `<polyline>`, `<polygon>`, and `<ellipse>`).
+Use the new `path-length` CSS property to set the `pathLength` attribute value on SVG geometry elements, including:
+* `<path>`
+* `<circle>`
+* `<rect>`
+* `<line>`
+* `<polyline>`
+* `<polygon>`
+* `<ellipse>`
 
-The `path-length` CSS property allows you to manipulate an SVG's `pathLength` property via stylesheets, inline styles, and animations.
+The `path-length` CSS property allows you to manipulate an SVG's `pathLength` property<!-- todo: `pathLength` attribute value? --> via stylesheets, inline styles, and animations.
 
 CSS declarations override the SVG presentation attribute following standard CSS precedence rules.  The initial value is `none`.
 
@@ -149,10 +157,11 @@ See also:
 * [shape() CSS function](https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/shape) at MDN.
 * [rect() CSS function](https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/rect) at MDN.
 * [xywh() CSS function](https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/xywh) at MDN.
+* [float CSS property](https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/float) at MDN.
 
 
 <!-- ------------------------------ -->
-#### Remove `border-color: gray` from the table user agent stylesheet
+#### Removed `border-color: gray` from user agent stylesheet for `<table>`
 
 The erroneous `border-color: gray` rule has been removed from the browser's user agent stylesheet for the `<table>` element.  Table borders now correctly default to `currentColor`, matching the HTML specification and other browsers.
 
@@ -165,7 +174,7 @@ See also:
 
 The `accent-color: auto` CSS value for form controls now applies the operating system's accent color only within installed web app contexts.  On regular web pages, form controls use a browser-default accent color instead.
 
-This change aligns the behavior of `accent-color: auto` with the `AccentColor` and `AccentColorText` CSS system color keywords, which are also scoped to installed web app contexts to reduce fingerprinting.
+This change aligns the behavior of `accent-color: auto` with the `AccentColor` and `AccentColorText` CSS system color keywords, which are also scoped to installed web app contexts, to reduce fingerprinting.
 
 See also:
 * [accent-color](https://developer.mozilla.org/docs/Web/CSS/accent-color) at MDN.
@@ -187,12 +196,12 @@ For example, consider this HTML:
 <script>document.querySelector('[popover]').showPopover();</script>
 ```
 
-When the user hovers the `<button>` element, the `:hover` pseudo-class matches the `<button>` and the `<div popover>` elements, but doesn't match the `<main>` element, because the `<div popover>` is a top-layer element.
+When the user hovers over the `<button>` element, the `:hover` pseudo-class matches the `<button>` and the `<div popover>` elements, but doesn't match the `<main>` element, because the `<div popover>` is a top-layer element.
 
-Top-layer elements are visually rendered outside of their parent context, so changing parent styles when a top-layer element is hovered or activated is undesirable.
+Top-layer elements are visually rendered outside of their parent context, so changing parent styles when a top-layer element is hovered over or activated is undesirable.
 
 See also:
-* [User action pseudo-classes](https://www.w3.org/TR/selectors-4/#useraction-pseudos) in _Selectors Level 4_.
+* [User Action Pseudo-classes](https://www.w3.org/TR/selectors-4/#useraction-pseudos) in _Selectors Level 4_.
 * [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) at MDN.
 
 
@@ -205,7 +214,11 @@ The following new Web API features are included in Microsoft Edge.
 <!-- ------------------------------ -->
 #### Disable SVG filters on cross-origin iframes and plugins
 
-SVG filters are no longer applied to cross-origin or restricted iframes (such as sandboxed iframes) and embedded plugins (such as PDFs).  This prevents potential security issues from cross-origin content being processed through SVG filter effects.
+SVG filters are no longer applied to the following:
+* Cross-origin or restricted iframes (such as sandboxed iframes).
+* Embedded plugins (such as PDFs).
+
+This prevents potential security issues from cross-origin content being processed through SVG filter effects.
 
 See also:
 * [SVG filters](https://developer.mozilla.org/docs/Web/SVG/Guides/SVG_filters) at MDN.
@@ -215,7 +228,7 @@ See also:
 <!-- ------------------------------ -->
 #### Intl.Locale variants
 
-The `Intl.Locale` object now exposes a `variants` property. You can also pass a `variants` string in the options of the `Intl.Locale` constructor.
+The `Intl.Locale` object now exposes a `variants` property.  You <!-- todo: now? (is this part new?) --> can also pass a `variants` string in the options of the `Intl.Locale` constructor.
 
 The variants of a locale represent additional language preferences that are not covered by the language, region, and script fields of a language ID.
 
@@ -228,11 +241,16 @@ See also:
 
 Use `OpaqueRange` to represent a live span of text within a form control's value, such as a `<textarea>` or text-based `<input>`.
 
-`OpaqueRange` enables operations such as `getBoundingClientRect()`, `getClientRects()`, and integration with the CSS Custom Highlight API for inline suggestions, highlights, and anchored popovers.  It preserves encapsulation by exposing only value offsets while returning `null` for `startContainer` and `endContainer`.
+<!-- `OpaqueRange` enables the following for inline suggestions, highlights, and anchored popovers: -->
+`OpaqueRange` enables:
+* Operations such as `getBoundingClientRect()` and `getClientRects()`.
+* Integration with the CSS Custom Highlight API for inline suggestions, highlights, and anchored popovers.<!-- todo: does right half of list item also apply to previous list item?  compare orig sentence containing all -->
+
+`OpaqueRange` preserves encapsulation by exposing only value offsets, and returns `null` for `startContainer` and `endContainer`.
 
 See also:
 * [OpaqueRange](https://github.com/MicrosoftEdge/Demos/tree/main/opaque-range) at MicrosoftEdge/Demos.
-* [Try the OpaqueRange API. Stop using mirror divs to measure text positions in inputs!](https://www.youtube.com/watch?v=Sp9C68TZXiE).
+* [Try the OpaqueRange API. Stop using mirror divs to measure text positions in inputs!](https://www.youtube.com/watch?v=Sp9C68TZXiE) at YouTube.
 
 
 <!-- ------------------------------ -->
@@ -247,13 +265,14 @@ See also:
 
 
 <!-- ------------------------------ -->
-#### Distinguish payment handler errors in Payment Request
+#### Distinguish payment handler errors in a payment request
 
-Payment handlers accessed via the Payment Request API can now return distinct errors for "user cancelled" versus "internal payment app error".
+A payment handler that's accessed via the Payment Request API can now return distinct errors for "user cancelled" versus "internal payment app error".
 
-Use this distinction to build better flows for your users.  For example, retry or fall back to a different payment method when an internal error occurs, while properly stopping the flow if the user cancels.
+Use this distinction to build better flows for your users.  For example, when an internal error occurs, retry or fall back to a different payment method, while properly stopping the flow if the user cancels.
 
-If the promise passed to `PaymentRequestEvent.respondWith` is rejected with an `OperationError`, your `PaymentRequest.show()` promise receives an `OperationError`.  Otherwise, it receives an `AbortError` (user cancel).
+* If the promise that's passed to `PaymentRequestEvent.respondWith` is rejected with an `OperationError`, your `PaymentRequest.show()` promise receives an `OperationError`.
+* If the promise that's passed to `PaymentRequestEvent.respondWith` is rejected with a value other than `OperationError`, your `PaymentRequest.show()` promise receives an `AbortError` (user cancel).<!-- todo: is the first clause of this list item an accurate replacement for the orig. "Otherwise, it receives..."?  specify the "otherwise" case -->
 
 See also:
 * [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API) at MDN.
@@ -262,7 +281,7 @@ See also:
 <!-- ------------------------------ -->
 #### Get notified when the `scrollBy` and `scrollTo` methods complete
 
-Programmatic scrolling methods, such as `scrollBy` and `scrollTo`, now return `Promise` objects that resolve when the scroll completes.  Use these promises to run code after a smooth-scroll finishes, without relying on timers or scroll-event polling.
+Programmatic scrolling methods, such as `scrollBy` and `scrollTo`, now return a `Promise` object that resolves when the scroll completes.  Use this promise to run code after a smooth-scroll finishes, without relying on a timer or scroll-event polling.
 
 See also:
 * [Window: scrollBy() method](https://developer.mozilla.org/docs/Web/API/Window/scrollBy) at MDN.
@@ -272,9 +291,11 @@ See also:
 <!-- ------------------------------ -->
 #### `Request.isReloadNavigation` attribute
 
-The read-only boolean `isReloadNavigation` attribute is now available on the Fetch API's `Request` interface.  This attribute indicates whether the navigation request was initiated as a user-triggered reload, such as when the user clicks the refresh button, or when `location.reload()` or `history.go(0)` run.
+The `isReloadNavigation` attribute is now available on the Fetch API's `Request` interface.  This attribute indicates whether the navigation request was initiated as a user-triggered reload, such as when the user clicks the **Refresh** button, or when the `location.reload()` or `history.go(0)` method runs.
 
-Use this attribute in your Service Worker's `FetchEvent` handler to implement caching strategies such as bypassing the cache or enforcing a network-first strategy specifically during a reload.
+The `isReloadNavigation` attribute is a read-only boolean.
+
+Use this attribute in your Service Worker's `FetchEvent` handler to implement caching strategies, such as bypassing the cache or enforcing a network-first strategy specifically during a reload.
 
 See also:
 * [Request.isReloadNavigation](https://fetch.spec.whatwg.org/#dom-request-isreloadnavigation) in the Fetch Standard.
@@ -283,7 +304,11 @@ See also:
 <!-- ------------------------------ -->
 #### Service Worker router timing fields in Resource Timing and Navigation Timing APIs
 
-The `workerMatchedRouterSource` and `workerFinalRouterSource` attributes are now available on the Resource Timing and Navigation Timing APIs.  Use these attributes to identify which Service Worker Static Router rule was matched and the final source that was used for the request.
+The `workerMatchedRouterSource` and `workerFinalRouterSource` attributes are now available on the Resource Timing and Navigation Timing APIs.
+
+* Use the `workerMatchedRouterSource` attribute to identify which service worker static router rule was matched.
+
+* Use the `workerFinalRouterSource` attribute to identify the final source that was used for the request.
 
 See also:
 * [Service Worker API](https://developer.mozilla.org/docs/Web/API/Service_Worker_API) at MDN.
@@ -293,25 +318,28 @@ See also:
 <!-- ------------------------------ -->
 #### `autocorrect="off"` on Windows touch keyboard
 
-The `autocorrect` attribute now works correctly on the Windows touch keyboard.  Previously, the touch keyboard ignored the `autocorrect="off"` attribute value and always autocorrected words.
+The `autocorrect` attribute now works correctly on the Windows touch keyboard.  Previously, the touch keyboard ignored the `autocorrect="off"` attribute value, and always autocorrected words.
 
-Set `autocorrect="off"` on `<input>`, `<textarea>`, or `contenteditable` elements to prevent the touch keyboard from replacing typed text.
+To prevent the touch keyboard from replacing typed text, set the `autocorrect="off"` attribute value on:
+* An `<input>` element.
+* A `<textarea>` element.
+* Any element that has the `contenteditable` attribute set.
 
 See also:
 * [autocorrect](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocorrect) at MDN.
 
 
 <!-- ------------------------------ -->
-#### Defer clipboard data reads with selective format reading
+#### Defer clipboard data reads until the format<!-- todo: the MIME type? --> is specified
 
-The Async Clipboard API now defers reading clipboard data from the operating system until you call `getType()`.  When you call `navigator.clipboard.read()`, the browser returns `ClipboardItem` objects with available MIME types but without the underlying data.  The actual data is read only when you request a specific format.
+The Async Clipboard API now defers reading clipboard data from the operating system until you call `getType()`.  When you call `navigator.clipboard.read()`, the browser returns `ClipboardItem` objects<!-- todo: favor singular not plural --> with available MIME types<!-- todo: favor singular not plural -->, but without the underlying data.  The actual data is read only when you request a specific format.
 
 ```javascript
 const items = await navigator.clipboard.read(); // No data is read yet.
 const text = await items[0].getType('text/plain'); // Only the 'text/plain' data is read here.
 ```
 
-This reduces CPU usage and improves the perceived responsiveness of the API call.
+This reduces CPU usage, and improves the perceived responsiveness of the API call.
 
 See also:
 * [Clipboard API](https://developer.mozilla.org/docs/Web/API/Clipboard_API) at MDN.
@@ -320,11 +348,11 @@ See also:
 <!-- ------------------------------ -->
 #### Close WebSocket connections on bfcache entry
 
-Open WebSocket connections are now closed when a page enters the back/forward cache (bfcache), instead of preventing the page from being cached.
+An open WebSocket connection is now closed when a page enters the back/forward cache (bfcache), instead of preventing the page from being cached.
 
-Previously, a page with an active WebSocket connection couldn't be stored in the bfcache.  With this change, more pages benefit from instant backward and forward navigation.
+Previously, a page that had an active WebSocket connection couldn't be stored in the bfcache.  With this change, more pages benefit from instant backward and forward navigation.
 
-Your page receives a `close` event on each affected `WebSocket` when the page enters the bfcache.  Listen for the `pageshow` event, and then reconnect when `event.persisted` is `true`.
+When the page enters the bfcache, your page receives a `close` event on each affected `WebSocket`.  Listen for the `pageshow` event, and then reconnect when `event.persisted` is `true`.
 
 See also:
 * [WebSocket](https://developer.mozilla.org/docs/Web/API/WebSocket) at MDN.
@@ -346,7 +374,7 @@ For the full list of available origin trials, see [Microsoft Edge Origin Trials]
 
 Expires on May 19, 2026.
 
-Temporary extension for ungated use of SharedArrayBuffers in pages that are not cross-origin isolated.
+Temporary extension for ungated<!-- todo: clarify --> use of the `SharedArrayBuffer` objects in pages that aren't cross-origin isolated<!-- todo: clearer wording: isolated to prevent cross-origin -->.
 
 * [Explainer](https://developer.chrome.com/blog/enabling-shared-array-buffer/)
 * [Feedback](https://bugs.chromium.org/p/chromium/issues/entry?components=Internals%3ESandbox%3ESiteIsolation)
@@ -358,7 +386,7 @@ Temporary extension for ungated use of SharedArrayBuffers in pages that are not 
 
 Expires on May 19, 2026.
 
-The Incoming Call Notifications API extends the Notifications API to allow an installed PWA to send incoming call notifications.
+The Incoming Call Notifications API extends the Notifications API to allow an installed Progressive Web App (PWA) to send incoming call notifications.
 
 Incoming call notifications have a ringtone and buttons that are styled to indicate accepting or rejecting a call.
 
@@ -395,7 +423,6 @@ Use the Prompt API to prompt a small language model (SLM) that's built into Micr
 The Prompt API is an experimental web API.
 
 Use the Prompt API to:
-
 * Generate and analyze text.
 * Create application logic based on user input.
 * Discover innovative ways to integrate prompt-engineering capabilities into your web app.
@@ -445,13 +472,15 @@ Information about this origin trial:
 
 Expires on Jul. 28, 2026.
 
-Soft navigations are same-document navigations that are driven by JavaScript, when using the History API or the Navigation API. Soft navigations are triggered by a user gesture and modify the DOM and the displayed URL.
+Soft navigations are same-document navigations that are driven by JavaScript, when using the History API or the Navigation API.
 
-This origin trial exposes soft navigation heuristics so that you can collect performance metrics for single-page app navigations.
+Soft navigations are triggered by a user gesture.  A soft navigation modifies the DOM and the displayed URL.
+
+This origin trial exposes soft navigation heuristics so that you can collect performance metrics for navigations in a single-page app.
 
 * [Explainer](https://github.com/WICG/soft-navigations#soft-navigations)
 * [Feedback](https://github.com/WICG/soft-navigations/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/ec952482-49f0-4980-a451-13ea3f9a7220)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/ec952482-49f0-4980-a451-13ea3f9a7220)
 
 
 <!-- ------------------------------ -->
@@ -513,9 +542,9 @@ Information about this origin trial:
 
 Expires on Aug. 25, 2026.
 
-This feature introduces url- and eval- hashes to be used in `script-src` directives in Content Security Policy.
+This feature introduces url- hashes and eval- hashes to be used in `script-src` directives in Content Security Policy.
 
-This enables you to write a strict CSP that only relies on hash and nonce based policies, without having to use permissive hostname based allowlists or `unsafe-eval`.
+This enables you to write a strict CSP that only relies on hash-based and nonce-based policies, without having to use permissive hostname-based allowlists or `unsafe-eval`.
 
 * [Explainer](https://github.com/explainers-by-googlers/script-src-v2)
 * [Feedback](https://github.com/explainers-by-googlers/script-src-v2/issues)
@@ -547,7 +576,7 @@ HTML in canvas enables customizing the rendering of HTML using canvas with three
 
 * [Explainer](https://github.com/WICG/html-in-canvas)
 * [Feedback](https://github.com/WICG/html-in-canvas/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/a297467e-0030-4c4c-8739-48e130026c03)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/a297467e-0030-4c4c-8739-48e130026c03)
 
 
 <!-- ------------------------------ -->
@@ -557,8 +586,11 @@ Expires on Sep. 8, 2026.
 
 The Digital Credentials API enables triggering the issuance of user credentials from a credential issuer server to a digital wallet application.
 
-For example, use the Digital Credentials API to trigger the provisioning of a new driver's license, or a verified academic degree, from a government or university server to a user's digital wallet.
+For example, use the Digital Credentials API to:
+* Trigger the provisioning of a new driver's license from a government server to a user's digital wallet.
+* Trigger the provisioning of a<!-- todo: new? --> verified academic degree from a university server to a user's digital wallet.
 
+Information about this origin trial:
 * [Explainer](https://w3c-fedid.github.io/digital-credentials)
 * [Feedback](https://github.com/w3c-fedid/digital-credentials/issues)
 * [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/89fbbd25-ce49-43b6-a206-dd0909394ed8)
@@ -630,11 +662,15 @@ The Compute Pressure API provides information about the user device's CPU pressu
 
 Expires on Sep. 8, 2026.
 
-Restrict connections initiated via the Fetch API or other web platform APIs from a document or worker to an allowlist of endpoints.  Distribute the authorized endpoint list from the server through an HTTP response header.  The browser evaluates each connection destination against the allowlist before connecting; connections to unlisted endpoints are blocked.
+Connection allowlists restrict connections that are initiated via the Fetch API or other web platform APIs from a document or worker to an allowlist of endpoints.
+
+Distribute the authorized endpoint list from the server through an HTTP response header.
+
+The browser evaluates each connection destination against the allowlist before connecting; connections to unlisted endpoints are blocked.
 
 * [Explainer](https://github.com/WICG/connection-allowlists)
 * [Feedback](https://github.com/WICG/connection-allowlists/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/a20a4374-39fd-445f-9348-f6c8737a45de)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/a20a4374-39fd-445f-9348-f6c8737a45de)
 
 
 <!-- ------------------------------ -->
@@ -656,11 +692,13 @@ This origin trial prerenders cross-origin iframes by using an opt-in response he
 
 Expires on Oct. 6, 2026.
 
-Enable per-session language model sampling parameters in the Prompt API.  Use parameter tuning to test and optimize model behavior for your specific use case.  This trial explores parameters such as `topK` and `temperature` that satisfy developer requirements and mitigate interoperability concerns.
+These Prompt API sampling parameters<!-- todo: what are the parameters?  two are specified, implying more --> enable per-session language model sampling parameters in the Prompt API.  Use parameter tuning to test and optimize model behavior for your specific use case.
+
+This origin trial explores<!-- todo: reword "explores" --> parameters such as `topK` and `temperature` that satisfy developer requirements<!-- todo: alt wording for "satisfy developer requirements"? --> and mitigate interoperability concerns<!-- todo: and improve interoperability -->.
 
 * [Explainer](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#sampling-parameters)
 * [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/32d0cd0f-611d-411e-b48e-cfd8edfdbf73)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/32d0cd0f-611d-411e-b48e-cfd8edfdbf73)
 
 
 <!-- ------------------------------ -->
@@ -668,11 +706,13 @@ Enable per-session language model sampling parameters in the Prompt API.  Use pa
 
 Expires on Oct. 6, 2026.
 
-The Container Timing API monitors when annotated sections of the DOM are displayed on screen and have finished their initial paint.  Mark subsections of the DOM with the `containertiming` attribute (similar to `elementtiming` for the Element Timing API) to receive performance entries when that section has been painted for the first time.
+The Container Timing API monitors when an annotated <!-- todo: container --> section of the DOM is displayed on screen and has finished its initial paint.
+
+To receive performance entries when a <!-- todo: container --> section has been painted for the first time, mark each such subsection of the DOM with the `containertiming` attribute.  This is similar to `elementtiming` for the Element Timing API.
 
 * [Explainer](https://github.com/WICG/container-timing/blob/main/ORIGIN_TRIAL.md)
 * [Feedback](https://github.com/WICG/container-timing/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/79fd2cd8-2283-4ed8-a472-4a8281a73d86)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/79fd2cd8-2283-4ed8-a472-4a8281a73d86)
 
 
 <!-- ------------------------------ -->
@@ -680,11 +720,17 @@ The Container Timing API monitors when annotated sections of the DOM are display
 
 Expires on Oct. 6, 2026.
 
-Adds `styleDuration`, `forcedStyleDuration`, `layoutDuration`, and `forcedLayoutDuration` to the Long Animation Frame API.  Use these fields to distinguish style and layout times, giving you a deeper understanding of CSS performance issues in the field.
+This origin trial adds the following fields to the Long Animation Frame API:
+* `styleDuration`
+* `forcedStyleDuration`
+* `layoutDuration`
+* `forcedLayoutDuration`
+
+Use these fields<!-- todo: attributes? --> to distinguish style and layout times, to gain a deeper understanding of CSS performance issues for each field<!-- todo: issues for each aspect of layout? -->.
 
 * [Explainer](https://github.com/w3c/long-animation-frames/pull/30#issue-3828859369)
 * [Feedback](https://github.com/w3c/long-animation-frames/pull/30)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/349e23d8-799a-4ac2-b45a-ffb91e09b4ce)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/349e23d8-799a-4ac2-b45a-ffb91e09b4ce)
 
 
 <!-- ------------------------------ -->
@@ -696,7 +742,7 @@ Declaratively install other websites as web apps by using the `<install>` elemen
 
 * [Explainer](https://github.com/MicrosoftEdge/Demos/blob/main/pwa-install-element/README.md)
 * [Feedback](https://github.com/WICG/install-element/issues/new?template=install-element-ot-feedback.md)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b2eb5c7f-7df0-4ad9-950e-2fbd2ebc08ec)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/b2eb5c7f-7df0-4ad9-950e-2fbd2ebc08ec)
 
 
 <!-- ------------------------------ -->
@@ -704,11 +750,13 @@ Declaratively install other websites as web apps by using the `<install>` elemen
 
 Expires on Oct. 6, 2026.
 
-Declarative CSS Module Scripts extend the existing script-based CSS Module Scripts to share declarative stylesheets with shadow roots, including declarative shadow roots.  Define inline style modules with `<style type="module" specifier="foo">` and apply them to a declarative shadow DOM by referencing a specifier or URL, such as `<template shadowrootmode="open" shadowrootadoptedstylesheets="foo">`.
+Declarative CSS Module Scripts extend the existing script-based CSS Module Scripts to share declarative stylesheets with shadow roots, including declarative shadow roots.
+
+Define inline style modules with `<style type="module" specifier="foo">` and then apply them to a declarative shadow DOM by referencing a specifier or URL, such as `<template shadowrootmode="open" shadowrootadoptedstylesheets="foo">`.
 
 * [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md)
 * [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/DeclarativeShadowDOMStyleSharing)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/966b04dd-3da4-43f4-a6a0-66a785f129f4)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/966b04dd-3da4-43f4-a6a0-66a785f129f4)
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -1,13 +1,13 @@
 ---
-title: Microsoft Edge 149 web platform release notes (Jun 2026)
-description: Microsoft Edge 149 web platform release notes (Jun 2026)
+title: Microsoft Edge 149 web platform release notes (Jun. 2026)
+description: Microsoft Edge 149 web platform release notes (Jun. 2026)
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
 ms.date: 
 ---
-# Microsoft Edge 149 web platform release notes (Jun 2026)
+# Microsoft Edge 149 web platform release notes (Jun. 2026)
 <!-- todo: update date: field to:
 ms.date: 
 per build report, must be < 30 days in future
@@ -21,105 +21,55 @@ To stay up-to-date and get the latest web platform features, download a preview 
 
 * [Edge DevTools](#edge-devtools)
 * [WebView2](#webview2)
-* [CSS/SVG/Web API features](#csssvgweb-api-features)
-  
-  * [CSS Gap Decorations](#css-gap-decorations)
-  
-  * [Capability Elements &lt;usermedia&gt; MVP](#capability-elements-usermedia-mvp)
-  
-  * [Clip Text overflow on user interaction](#clip-text-overflow-on-user-interaction)
-  
-  * [Disable SVG filters on plugins and cross-origin/restricted iframes](#disable-svg-filters-on-plugins-and-cross-origin-restricted-iframes)
-  
-  * [Intl.Locale.prototype.variants](#intl-locale-prototype-variants)
-  
-  * [OpaqueRange](#opaquerange)
-  
-  * [PWA origin migration](#pwa-origin-migration)
-  
-  * [Payment Request: Allow payment handlers to report back internal errors](#payment-request-allow-payment-handlers-to-report-back-internal-errors)
-  
-  * [Programmatic scroll promises](#programmatic-scroll-promises)
-  
-  * [Remove explicit border color UA stylesheet rule for tables](#remove-explicit-border-color-ua-stylesheet-rule-for-tables)
-  
-  * [Resource Timing: Add spec-compliant Service Worker Router timing fields](#resource-timing-add-spec-compliant-service-worker-router-timing-fields)
-  
-  * [Respect autocorrect=&quot;off&quot; for Windows touch keyboard in TSF](#respect-autocorrect-off-for-windows-touch-keyboard-in-tsf)
-  
-  * [Selective Clipboard Format Read](#selective-clipboard-format-read)
-  
-  * [Support &#39;path-length&#39; as a CSS property.](#support-path-length-as-a-css-property)
-  
-  * [Support path() and shape() in shape-outside](#support-path-and-shape-in-shape-outside)
-  
-  * [Support rect() and xywh() in shape-outside](#support-rect-and-xywh-in-shape-outside)
-  
-  * [User action pseudo class top layer boundary](#user-action-pseudo-class-top-layer-boundary)
-  
-  * [Web app scope system accent color](#web-app-scope-system-accent-color)
-  
-  * [image-rendering: crisp-edges](#image-rendering-crisp-edges)
-  
-* [Deprecated or removed features](#deprecated-or-removed-features)
-  
-  
+* [CSS features](#css-features)
+  * [CSS gap decorations](#css-gap-decorations)
+  * [Clip text overflow on user interaction](#clip-text-overflow-on-user-interaction)
+  * [`image-rendering: crisp-edges`](#image-rendering-crisp-edges)
+  * [`path-length` CSS property for SVG elements](#path-length-css-property-for-svg-elements)
+  * [`path()`, `shape()`, `rect()`, and `xywh()` in `shape-outside`](#path-shape-rect-and-xywh-in-shape-outside)
+  * [Remove `border-color: gray` from the table UA stylesheet](#remove-border-color-gray-from-the-table-ua-stylesheet)
+  * [Scope system accent color to installed web apps](#scope-system-accent-color-to-installed-web-apps)
+  * [User-action pseudo-class top-layer boundary](#user-action-pseudo-class-top-layer-boundary)
+* [Web APIs](#web-apis)
+  * [Disable SVG filters on cross-origin iframes and plugins](#disable-svg-filters-on-cross-origin-iframes-and-plugins)
+  * [`Intl.Locale.prototype.variants`](#intllocaleprototypevariants)
+  * [`OpaqueRange` for form control text](#opaquerange-for-form-control-text)
+  * [Migrate a PWA to a new origin](#migrate-a-pwa-to-a-new-origin)
+  * [Distinguish payment handler errors in Payment Request](#distinguish-payment-handler-errors-in-payment-request)
+  * [Get notified when the `scrollBy` and `scrollTo` methods complete](#get-notified-when-the-scrollby-and-scrollto-methods-complete)
+  * [`Request.isReloadNavigation` attribute](#requestisreloadnavigation-attribute)
+  * [Service Worker Router timing fields in Resource Timing](#service-worker-router-timing-fields-in-resource-timing)
+  * [Honor `autocorrect="off"` on Windows touch keyboard](#honor-autocorrectoff-on-windows-touch-keyboard)
+  * [Defer clipboard data reads with selective format reading](#defer-clipboard-data-reads-with-selective-format-reading)
+  * [Close WebSocket connections on bfcache entry](#close-websocket-connections-on-bfcache-entry)
 * [Origin trials](#origin-trials)
-  
   * [SharedArrayBuffers in non-isolated pages on Desktop platforms](#sharedarraybuffers-in-non-isolated-pages-on-desktop-platforms)
-  
   * [Incoming Call Notifications](#incoming-call-notifications)
-  
   * [Proofreader API](#proofreader-api)
-  
   * [Prompt API](#prompt-api)
-  
   * [WebAssembly Custom Descriptors](#webassembly-custom-descriptors)
-  
-  * [UserMediaElement](#usermediaelement)
-  
+  * [`<usermedia>` HTML element](#usermedia-html-element)
   * [Soft Navigation Heuristics](#soft-navigation-heuristics)
-  
   * [Enhanced Canvas TextMetrics](#enhanced-canvas-textmetrics)
-  
   * [WebNN](#webnn)
-  
-  * [focusgroup](#focusgroup)
-  
+  * [`focusgroup` HTML attribute for keyboard navigation](#focusgroup-html-attribute-for-keyboard-navigation)
   * [URL and eval hashes in CSP script-src](#url-and-eval-hashes-in-csp-script-src)
-  
-  * [WebAppInstallation](#webappinstallation)
-  
+  * [Web Install API](#web-install-api)
   * [OpaqueRange](#opaquerange)
-  
-  * [html-in-canvas](#html-in-canvas)
-  
-  * [Digital Credentials API - Issuance Support](#digital-credentials-api-issuance-support)
-  
-  * [PrerenderUntilScript](#prerenderuntilscript)
-  
+  * [HTML-in-canvas](#html-in-canvas)
+  * [Digital Credentials API - Issuance Support](#digital-credentials-api---issuance-support)
+  * [`prerender_until_script` Speculation Rules API action](#prerender_until_script-speculation-rules-api-action)
   * [WebAudio Configurable Render Quantum](#webaudio-configurable-render-quantum)
-  
-  * [PrerenderActivationByFormSubmission](#prerenderactivationbyformsubmission)
-  
+  * [Prerender activation by form submission](#prerender-activation-by-form-submission)
   * [CPU Performance API](#cpu-performance-api)
-  
   * [Connection Allowlists](#connection-allowlists)
-  
   * [Prerendering cross-origin iframes](#prerendering-cross-origin-iframes)
-  
   * [Container Timing](#container-timing)
-  
-  * [Long Animation Frames - separate style and layout durations](#long-animation-frames-separate-style-and-layout-durations)
-  
+  * [Long Animation Frames - separate style and layout durations](#long-animation-frames---separate-style-and-layout-durations)
   * [Prompt API Sampling Parameters](#prompt-api-sampling-parameters)
-  
   * [HTML Install Element](#html-install-element)
-  
   * [Declarative CSS Module Scripts](#declarative-css-module-scripts)
-  
   * [Autofill Event](#autofill-event)
-  
 
 
 <!-- ====================================================================== -->
@@ -145,209 +95,91 @@ See [Release SDK 1.0.nnnn.nn, for Runtime nnn](../../webview2/release-notes/inde
 
 The following new Cascading Style Sheets (CSS) features are included in Microsoft Edge.
 
-## Web APIs
-
-The following new Web API features are included in Microsoft Edge.
-
-**TODO: MOVE THE BELOW FEATURES IN THE CORRECT H2 HEADINGS ABOVE.**
-
-
 
 <!-- ------------------------------ -->
-#### CSS Gap Decorations
+#### CSS gap decorations
 
-CSS Gap Decorations enables styling of gaps in container layouts like Grid and Flexbox, similar to ‘column-rule’ in multicol layout. This feature is highly requested by web authors who must use hacks to style the gaps in Grid and Flexbox layouts today.
+Style the gaps in Grid and Flexbox container layouts, similar to `column-rule` in multicol layout.  Use gap decorations to visually separate items without resorting to workarounds such as pseudo-elements or extra wrapper elements.
 
 See also:
-* []()
+* [A new way to style gaps in CSS](https://developer.chrome.com/blog/gap-decorations).
 
 
 <!-- ------------------------------ -->
-#### Capability Elements &lt;usermedia&gt; MVP
+#### Clip text overflow on user interaction
 
-Usermedia Capability Element, is a declarative, user-activated control for accessing the starting and interacting with media streams.
+When a user interacts with text that has `text-overflow: ellipsis` set (such as editing or caret navigation), the text temporarily switches from ellipsis to clip.  This allows the user to see and interact with the hidden overflow content.
 
-This addresses the long-standing problem of permission prompts being triggered directly from JavaScript without a strong signal of user intent. By embedding a browser-controlled element in the page, the user's click provides a clear, intentional signal. This enables a much better prompt UX and, crucially, provides a simple recovery path for users who have previously denied the permission.
-
-Note: This feature was previously developed and tested in an Origin Trial as the more generic <permission> element. Based on feedback from developers and other browser vendors, it has evolved into capability-specific elements to provide a more tailored and powerful developer experience.
+This behavior applies to all editable and non-editable elements.  Form controls (`<textarea>`, `<input>`) already support this behavior.
 
 See also:
-* []()
+* [text-overflow](https://developer.mozilla.org/docs/Web/CSS/text-overflow) at MDN.
 
 
 <!-- ------------------------------ -->
-#### Clip Text overflow on user interaction
+#### `image-rendering: crisp-edges`
 
-When a user interacts (editing or caret navigation) with text which has ‘text-overflow: ellipsis’ set, the text switches temporarily from ellipsis to clip allowing the user to see and interact with the hidden overflow content. This feature applies to all editable and non-editable elements. For form controls (textarea, input), the behavior is already supported.
+The `image-rendering` property now supports the `crisp-edges` value.
+
+Use `image-rendering: crisp-edges` to scale an image in a way that preserves contrast and edges without smoothing colors or introducing blur.
 
 See also:
-* []()
+* [image-rendering](https://developer.mozilla.org/docs/Web/CSS/image-rendering) at MDN.
 
 
 <!-- ------------------------------ -->
-#### Disable SVG filters on plugins and cross-origin/restricted iframes
+#### `path-length` CSS property for SVG elements
 
-This launch prevents SVG filters from being applied to cross-origin/restricted iframes (e.g., sandboxed ones) and embedded plugins (e.g., pdfs). When a frame/plugin would be painted with an SVG filter effect, the effect tree is traversed to find the highest ancestor without SVG filters, and that effect is then applied instead.
+Use the new `path-length` CSS property to set the `pathLength` value on SVG geometry elements (including `<path>`, `<circle>`, `<rect>`, `<line>`, `<polyline>`, `<polygon>`, and `<ellipse>`).
 
+The `path-length` CSS property allows you to manipulate an SVG's `pathLength` property via stylesheets, inline styles, and animations.
+
+CSS declarations override the SVG presentation attribute following standard CSS precedence rules.  The initial value is `none`.
 
 See also:
-* []()
+* [pathLength](https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/pathLength) at MDN.
 
 
 <!-- ------------------------------ -->
-#### Intl.Locale.prototype.variants
+#### `path()`, `shape()`, `rect()`, and `xywh()` in `shape-outside`
 
-Add Intl.Locale.prototype.variants as stated in 
-https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
-and also accept "variants" in option bag in Intl.Locale consturctor
-as in https://tc39.es/ecma402/#sec-updatelanguageid
-The changes to ECMA402 is merged in 
- https://github.com/tc39/ecma402/pull/960
-and the test code in test262 are merged in  in https://github.com/tc39/test262/pull/4474/
+You can now use the `path()`, `shape()`, `rect()`, and `xywh()` shape functions in the CSS `shape-outside` property to define float exclusion shapes.
 
 See also:
-* []()
+* [path() CSS function](https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/path) at MDN.
+* [shape() CSS function](https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/shape) at MDN.
+* [rect() CSS function](https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/rect) at MDN.
+* [xywh() CSS function](https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/xywh) at MDN.
 
 
 <!-- ------------------------------ -->
-#### OpaqueRange
+#### Remove `border-color: gray` from the table user agent stylesheet
 
-`OpaqueRange` represents a live span of text within a form control’s value, such as a `<textarea>` or text-based `<input>`, so developers can work with value text using range-like APIs.
-
-It enables operations such as `getBoundingClientRect()`, `getClientRects()`, and integration with the CSS Custom Highlight API for UI such as inline suggestions, highlights, and anchored popovers. It preserves encapsulation by exposing only value offsets while returning `null` for `startContainer` and `endContainer`, so DOM endpoints and internal structure are not exposed.
+The erroneous `border-color: gray` rule has been removed from the browser's user agent stylesheet for the `<table>` element.  Table borders now correctly default to `currentColor`, matching the HTML specification and other browsers.
 
 See also:
-* []()
+* [&lt;table&gt; HTML table element](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/table) at MDN.
 
 
 <!-- ------------------------------ -->
-#### PWA origin migration
+#### Scope system accent color to installed web apps
 
-When a user installs a Progressive Web App (PWA), its identity and security context are tightly bound to its web origin, for example, `app.example.com`. This presents a significant challenge for developers who need to change their PWA's origin due to rebranding, domain restructuring, or technical re-architecture. Currently, such a change forces users to manually uninstall the old app and reinstall the new one, leading to a disruptive experience and potential user loss. Chrome 149 introduces a mechanism for developers to seamlessly migrate an installed PWA to a new, same-site origin, preserving user trust and permissions.
+The `accent-color: auto` CSS value for form controls now applies the operating system's accent color only within installed web app contexts.  On regular web pages, form controls use a browser-default accent color instead.
 
-The [WebAppInstallForceList](https://chromeenterprise.google/policies/#WebAppInstallForceList) policy will block migration. Since enterprise policies around web applications are primarily based on URLs and origins, there is a risk that a migration would bypass certain policies an admin might have configured. No migration will be offered to the user when an app is force-installed by their enterprise administrator, and instead a banner will be shown explaining this to the user.
+This change aligns the behavior of `accent-color: auto` with the `AccentColor` and `AccentColorText` CSS system color keywords, which are also scoped to installed web app contexts to reduce fingerprinting.
 
 See also:
-* []()
+* [accent-color](https://developer.mozilla.org/docs/Web/CSS/accent-color) at MDN.
 
 
 <!-- ------------------------------ -->
-#### Payment Request: Allow payment handlers to report back internal errors
+#### User-action pseudo-classes top-layer boundary
 
-Enables payment handlers that are accessed via the Payment Request API to return distinct errors for "user cancelled" vs "internal payment app error". This allows web developers to build better flows for users, e.g. by retrying or falling back to a different flow when an internal app error occurs, whilst properly stopping the flow if the user wants to cancel.
+The `:hover`, `:active`, and `:focus-within` pseudo-classes now match on parent elements only up to the first top-layer element in the chain of parent elements.
 
-The Web-based Payment Handler API can indicate this difference based on what error they use to reject the promised passed to PaymentRequestEvent.respondWith. If the promise is rejected with an OperationError, then "internal app error" (OperationError) is returned to the merchant via the PaymentRequest.show(), otherwise "user cancel" (AbortError) is returned.
+For example, consider this HTML:
 
-Native app payment handler infrastructure is similarly updated, but is out of scope for web APIs.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Programmatic scroll promises
-
-Web developers currently have no way to know when a programmatic smooth-scroll has completed. This feature provides a solution to the problem: make the programmatic scroll methods return Promise objects that get resolved on scroll completion.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Remove explicit border color UA stylesheet rule for tables
-
-This change removes the erroneous `border-color: gray` CSS rule from the UA stylesheet for the `<table>` element.
-
-The spec does not contain this rule:
-
-https://html.spec.whatwg.org/multipage/rendering.html#tables-2
-
-and it causes the borders to incorrectly not default to currentColor. Neither Firefox nor Webkit have this `gray` border color rule in their UA stylesheet, leading to interop problems.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Resource Timing: Add spec-compliant Service Worker Router timing fields
-
-Adds the `workerMatchedRouterSource` and `workerFinalRouterSource` attributes to the Resource Timing and Navigation Timing APIs. These attributes allow developers to identify which Service Worker Static Router rule was matched and the final source used for the request.
-
-Note on Deprecation: This change focuses exclusively on adding the spec-compliant fields. We will be sending a separate Intent to Deprecate (I2D) for the existing non-compliant fields (`workerMatchedSourceType` and `workerFinalSourceType`) once we have gathered sufficient usage data from our UseCounters.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Respect autocorrect=&quot;off&quot; for Windows touch keyboard in TSF
-
-The HTML autocorrect attribute allows web authors to control whether autocorrection should be applied to user input in editable elements including <input>, <textarea>, and contenteditable hosts. On Windows, the touch keyboard ignores this attribute and always autocorrects words. For example, typing "truf" followed by space in an element with autocorrect="off" yields "true " instead of preserving "truf ". This feature makes Chrome's TSF integration detect and revert touch keyboard autocorrections when the focused editable element has autocorrect="off" set.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Selective Clipboard Format Read
-
-Enhances the Asynchronous Clipboard API by deferring actual clipboard data retrieval from the OS until the web application calls getType(). Instead of eagerly fetching all available formats at read() time, the browser now returns ClipboardItem objects with available MIME types but without the underlying data, and reads from the OS clipboard only when getType() is invoked.
-
-    const items = await navigator.clipboard.read(); // No data read yet
-    const text = await items.getType('text/plain'); // Only 'text/plain' data 
-                                                                                 read here
-
-This reduces CPU usage, improves the perceived responsiveness of the API call, and optimizes the browser's power consumption.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Support &#39;path-length&#39; as a CSS property.
-
-This change introduces a new CSS property, 'path-length', which maps to the existing SVG 'pathLength' presentation attribute. It applies to SVG geometry elements that support 'pathLength' (including <path>, <circle>, <rect>, <line>, <polyline>, <polygon>, and <ellipse>).
-
-Exposing 'pathLength' as a CSS property allows authors to specify it via stylesheets, inline styles, and animations, enabling it to participate in normal CSS cascading, specificity, transitions, and animations. The property affects all computations that depend on the total path length, including stroke dash rendering and text positioning along a <textPath>.
-
-CSS declarations override the presentation attribute following standard CSS precedence rules. The initial value of 'path-length' is 'none', which represents the absence of an author-supplied path length and is distinct from an explicit numeric value such as '0'.
-
-Existing attribute-only behavior is preserved when the feature is disabled.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Support path() and shape() in shape-outside
-
-Adds support for the path() and shape() shape functions in the CSS shape-outside property. These functions allow developers to define float exclusion shapes using rectangle coordinates.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### Support rect() and xywh() in shape-outside
-
-Adds support for the rect() and xywh() basic shape functions in the CSS shape-outside property. These functions allow developers to define float exclusion shapes using rectangle coordinates, aligning Chrome with Firefox and Safari which already support this feature.
-
-See also:
-* []()
-
-
-<!-- ------------------------------ -->
-#### User action pseudo class top layer boundary
-
-This feature represents the behavior described in this section of the CSS spec:
-
-https://www.w3.org/TR/selectors-4/#useraction-pseudos
-
-which says that :hover, :active, and :focus-within match on the parents of elements, but only up to the first top layer element in the parent chain. The change for Chromium is that last "up to the top layer" part of this behavior.
-
-Concretely, this means that for this structure:
-
-```
+```html
 <main>
   <div popover>
     <button></button>
@@ -356,45 +188,148 @@ Concretely, this means that for this structure:
 <script>document.querySelector('[popover]').showPopover();</script>
 ```
 
-if the user hovers the `<button>`, then the `:hover` pseudo class will match the `<button>`, and the popover, but will not match the `<main>` element.
+When the user hovers the `<button>` element, the `:hover` pseudo-class matches the `<button>` and the `<div popover>` elements, but doesn't match the `<main>` element, because the `<div popover>` is a top-layer element.
 
-The rationale behind this change is that typically top layer elements are rendered "elsewhere", in a location that is disconnected from the parent element visually. So it typically does not make sense to change the styles of the parent element when the top layer element is hovered or activated, for example.
-
-The customizable-<select> implementation shipped in Chromium has this logic hard-coded for the specific case of the select `::picker()` popover. That special case logic will be removed when this feature ships.
+Top-layer elements are visually rendered outside of their parent context, so changing parent styles when a top-layer element is hovered or activated is undesirable.
 
 See also:
-* []()
+* [User action pseudo-classes](https://www.w3.org/TR/selectors-4/#useraction-pseudos) in _Selectors Level 4_.
+* [Popover API](https://developer.mozilla.org/docs/Web/API/Popover_API) at MDN.
+
+
+<!-- ====================================================================== -->
+## Web APIs
+
+The following new Web API features are included in Microsoft Edge.
 
 
 <!-- ------------------------------ -->
-#### Web app scope system accent color
+#### Disable SVG filters on cross-origin iframes and plugins
 
-Currently, if the `accent-color` property for form controls are set to `auto`, they adopt the system accent color set by the user in their operating system. This happens in all contexts whether on the web or in an installed web application. Current feature state: https://chromestatus.com/feature/6548224737017856
-
-AccentColor and AccentColorText CSS keywords, which also adopt the system accent color, pose a significant fingerprinting vector if exposed widely on the web. As such, they're currently planned to only be available in installed web app contexts. We want system accent color exposure to match across all vectors, so we should scope `accent-color: auto` to only be available in installed web app contexts as well. This introduces more consistent developer and user expectations for system colors and aligns with fingerprinting restrictions for AccentColor[Text].
+SVG filters are no longer applied to cross-origin or restricted iframes (such as sandboxed iframes) and embedded plugins (such as PDFs).  This prevents potential security issues from cross-origin content being processed through SVG filter effects.
 
 See also:
-* []()
+* [SVG filters](https://developer.mozilla.org/docs/Web/SVG/Guides/SVG_filters) at MDN.
+* [&lt;iframe&gt; HTML inline frame element](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/iframe) at MDN.
 
 
 <!-- ------------------------------ -->
-#### image-rendering: crisp-edges
+#### Intl.Locale variants
 
-"image-rendering: crisp-edges" indicates that image should be scaled in a way that preserves contrast and edges, and which avoids smoothing colors or introducing blur to the image in the process
+The `Intl.Locale` object now exposes a `variants` property. You can also pass a `variants` string in the options of the `Intl.Locale` constructor.
 
-Note: spec wise this is technically different than 'pixelated'. In actual implementations it is not. Spec wise 'pixelated' = use any process the UA wants to make the result look pixelated. nearest-neighbor is acceptable. 'crisp-edges' = use any process you want that preserves contrast, edges, and avoids blending colors, nearest-neighbor is acceptable. Both Firefox and Safari use treat both as synonym and use nearest-neighbor for both.
+The variants of a locale represent additional language preferences that are not covered by the language, region, and script fields of a language ID.
 
 See also:
-* []()
+* [Intl.Locale](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale) at MDN.
 
 
 <!-- ------------------------------ -->
-#### Deprecated or removed features
+#### `OpaqueRange` for form control text
 
-**TODO: CHECK THE FEATURES LISTED BELOW AND ADD THEM TO THE SITE-COMPAT-IMPACTING-CHANGES ARTICLE.**
+Use `OpaqueRange` to represent a live span of text within a form control's value, such as a `<textarea>` or text-based `<input>`.
+
+`OpaqueRange` enables operations such as `getBoundingClientRect()`, `getClientRects()`, and integration with the CSS Custom Highlight API for inline suggestions, highlights, and anchored popovers.  It preserves encapsulation by exposing only value offsets while returning `null` for `startContainer` and `endContainer`.
+
+See also:
+* [OpaqueRange](https://github.com/MicrosoftEdge/Demos/tree/main/opaque-range) at MicrosoftEdge/Demos.
+* [Try the OpaqueRange API. Stop using mirror divs to measure text positions in inputs!](https://www.youtube.com/watch?v=Sp9C68TZXiE).
 
 
+<!-- ------------------------------ -->
+#### Migrate a PWA to a new origin
 
+You can now seamlessly migrate an installed Progressive Web App (PWA) to a new, same-site origin, preserving user trust and permissions.
+
+When a user installs a PWA, its identity is bound to its web origin (for example, `app.example.com`).  Previously, changing the origin forced users to manually uninstall and reinstall the app.  This feature eliminates that disruption.
+
+See also:
+* [Progressive web apps](https://developer.mozilla.org/docs/Web/Progressive_web_apps) at MDN.
+
+
+<!-- ------------------------------ -->
+#### Distinguish payment handler errors in Payment Request
+
+Payment handlers accessed via the Payment Request API can now return distinct errors for "user cancelled" versus "internal payment app error".
+
+Use this distinction to build better flows for your users.  For example, retry or fall back to a different payment method when an internal error occurs, while properly stopping the flow if the user cancels.
+
+If the promise passed to `PaymentRequestEvent.respondWith` is rejected with an `OperationError`, your `PaymentRequest.show()` promise receives an `OperationError`.  Otherwise, it receives an `AbortError` (user cancel).
+
+See also:
+* [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API) at MDN.
+
+
+<!-- ------------------------------ -->
+#### Get notified when the `scrollBy` and `scrollTo` methods complete
+
+Programmatic scrolling methods, such as `scrollBy` and `scrollTo`, now return `Promise` objects that resolve when the scroll completes.  Use these promises to run code after a smooth-scroll finishes, without relying on timers or scroll-event polling.
+
+See also:
+* [Window: scrollBy() method](https://developer.mozilla.org/docs/Web/API/Window/scrollBy) at MDN.
+* [Window: scrollTo() method](https://developer.mozilla.org/docs/Web/API/Window/scrollTo) at MDN.
+
+
+<!-- ------------------------------ -->
+#### `Request.isReloadNavigation` attribute
+
+The read-only boolean `isReloadNavigation` attribute is now available on the Fetch API's `Request` interface.  This attribute indicates whether the navigation request was initiated as a user-triggered reload, such as when the user clicks the refresh button, or when `location.reload()` or `history.go(0)` run.
+
+Use this attribute in your Service Worker's `FetchEvent` handler to implement caching strategies such as bypassing the cache or enforcing a network-first strategy specifically during a reload.
+
+See also:
+* [Request.isReloadNavigation](https://fetch.spec.whatwg.org/#dom-request-isreloadnavigation) in the Fetch Standard.
+
+
+<!-- ------------------------------ -->
+#### Service Worker router timing fields in Resource Timing and Navigation Timing APIs
+
+The `workerMatchedRouterSource` and `workerFinalRouterSource` attributes are now available on the Resource Timing and Navigation Timing APIs.  Use these attributes to identify which Service Worker Static Router rule was matched and the final source that was used for the request.
+
+See also:
+* [Service Worker API](https://developer.mozilla.org/docs/Web/API/Service_Worker_API) at MDN.
+* [Use the Service Worker Static Routing API to bypass the service worker for specific paths](https://developer.chrome.com/blog/service-worker-static-routing).
+
+
+<!-- ------------------------------ -->
+#### `autocorrect="off"` on Windows touch keyboard
+
+The `autocorrect` attribute now works correctly on the Windows touch keyboard.  Previously, the touch keyboard ignored the `autocorrect="off"` attribute value and always autocorrected words.
+
+Set `autocorrect="off"` on `<input>`, `<textarea>`, or `contenteditable` elements to prevent the touch keyboard from replacing typed text.
+
+See also:
+* [autocorrect](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/autocorrect) at MDN.
+
+
+<!-- ------------------------------ -->
+#### Defer clipboard data reads with selective format reading
+
+The Async Clipboard API now defers reading clipboard data from the operating system until you call `getType()`.  When you call `navigator.clipboard.read()`, the browser returns `ClipboardItem` objects with available MIME types but without the underlying data.  The actual data is read only when you request a specific format.
+
+```javascript
+const items = await navigator.clipboard.read(); // No data is read yet.
+const text = await items[0].getType('text/plain'); // Only the 'text/plain' data is read here.
+```
+
+This reduces CPU usage and improves the perceived responsiveness of the API call.
+
+See also:
+* [Clipboard API](https://developer.mozilla.org/docs/Web/API/Clipboard_API) at MDN.
+
+
+<!-- ------------------------------ -->
+#### Close WebSocket connections on bfcache entry
+
+Open WebSocket connections are now closed when a page enters the back/forward cache (bfcache), instead of preventing the page from being cached.
+
+Previously, a page with an active WebSocket connection couldn't be stored in the bfcache.  With this change, more pages benefit from instant backward and forward navigation.
+
+Your page receives a `close` event on each affected `WebSocket` when the page enters the bfcache.  Listen for the `pageshow` event, and then reconnect when `event.persisted` is `true`.
+
+See also:
+* [WebSocket](https://developer.mozilla.org/docs/Web/API/WebSocket) at MDN.
+* [Working with the bfcache](https://developer.mozilla.org/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications#working_with_the_bfcache) at MDN.
 
 
 <!-- ====================================================================== -->
@@ -407,7 +342,6 @@ Origin trials let you try experimental APIs on your own live website for a limit
 For the full list of available origin trials, see [Microsoft Edge Origin Trials](https://developer.microsoft.com/microsoft-edge/origin-trials/).
 
 
-
 <!-- ------------------------------ -->
 #### SharedArrayBuffers in non-isolated pages on Desktop platforms
 
@@ -417,8 +351,7 @@ Temporary extension for ungated use of SharedArrayBuffers in pages that are not 
 
 * [Explainer](https://developer.chrome.com/blog/enabling-shared-array-buffer/)
 * [Feedback](https://bugs.chromium.org/p/chromium/issues/entry?components=Internals%3ESandbox%3ESiteIsolation)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/5745776f-9ff4-47fd-81f2-beaf6c2c50c6)
-
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/5745776f-9ff4-47fd-81f2-beaf6c2c50c6)
 
 
 <!-- ------------------------------ -->
@@ -426,12 +359,15 @@ Temporary extension for ungated use of SharedArrayBuffers in pages that are not 
 
 Expires on May 19, 2026.
 
-Extend the Notifications API to allow installed PWA&#39;s to send incoming call notifications - i.e., notifications with call-styled buttons and a ringtone. This extension will help VoIP web apps to create more engaging experiences by making it easier for users to easily recognize a calling notification and answer it. Besides that, this feature will help bridge the gap between native and web implementations of apps that have them both.
+The Incoming Call Notifications API extends the Notifications API to allow an installed PWA to send incoming call notifications.
+
+Incoming call notifications have a ringtone and buttons that are styled to indicate accepting or rejecting a call.
+
+This helps web apps create more engaging experiences by making it easier for users to recognize a calling notification and answer it.
 
 * [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Notifications/notifications_actions_customization.md)
 * [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/699bfcb9-7bf2-414b-8158-af775f52ac03)
-
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/699bfcb9-7bf2-414b-8158-af775f52ac03)
 
 
 <!-- ------------------------------ -->
@@ -439,25 +375,39 @@ Extend the Notifications API to allow installed PWA&#39;s to send incoming call 
 
 Expires on May 19, 2026.
 
-The Proofreader API is a JavaScript API that proofreads input text with suggested corrections, backed by an AI language model. This API exposes high-level functionality to help web developers perform real-time proofreading and offers two specific features: error correction , and error labeling (identifying the error type like spelling or grammar). Developers can use this API to proofread user messages in chat applications , help polish email drafting , catch errors during note-taking , or provide high-quality interactive proofreading feedback when writing documents.
+The Proofreader API corrects grammar, spelling, and punctuation errors in text.
+
+The Proofreader API uses a small language model (SLM) that's built into Microsoft Edge, from your website's JavaScript code, or from your browser extension's JavaScript code.
+
+See also [Correct grammar and spelling with the Proofreader API](../proofreader-api.md).
 
 * [Explainer](https://github.com/webmachinelearning/proofreader-api/blob/main/README.md)
 * [Feedback](https://github.com/webmachinelearning/proofreader-api/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/03b14cb6-3ac8-4049-8bf1-b293109f1d05)
-
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/03b14cb6-3ac8-4049-8bf1-b293109f1d05)
 
 
 <!-- ------------------------------ -->
 #### Prompt API
 
-Expires on Jun. 16, 2026.
+Expires on Jun. 16, 2026
 
-Prompt API allows interacting with an AI language model using text, image, and audio inputs. It supports various use cases, from generating image captions and performing visual searches to transcribing audio, classifying sound events, generating text following specific instructions, and extracting information or insights from text. It supports structured outputs which ensure that responses adhere to a predefined format, typically expressed as a JSON schema, to enhance response conformance and facilitate seamless integration with downstream applications that require standardized output formats.
+Use the Prompt API to prompt a small language model (SLM) that's built into Microsoft Edge, from your website's JavaScript code, or from your browser extension's JavaScript code.
 
+The Prompt API is an experimental web API.
+
+Use the Prompt API to:
+
+* Generate and analyze text.
+* Create application logic based on user input.
+* Discover innovative ways to integrate prompt-engineering capabilities into your web app.
+
+See also:
+* [Prompt API](#prompt-api), above.
+
+Information about this origin trial:
 * [Explainer](https://github.com/webmachinelearning/prompt-api/blob/main/README.md)
 * [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b7d35247-b855-4b08-b237-89e7a5056117)
-
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/b7d35247-b855-4b08-b237-89e7a5056117)
 
 
 <!-- ------------------------------ -->
@@ -465,31 +415,30 @@ Prompt API allows interacting with an AI language model using text, image, and a
 
 Expires on Jun. 16, 2026.
 
-Allows WebAssembly to store data associated with source-level types more efficiently in new &quot;custom descriptor&quot; objects. 
+WebAssembly Custom Descriptors allows WebAssembly to store data associated with source-level types more efficiently in custom descriptor objects.
 
 * [Explainer](https://github.com/WebAssembly/custom-descriptors/blob/main/proposals/custom-descriptors/Overview.md)
 * [Feedback](https://github.com/WebAssembly/custom-descriptors/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/f1227421-7d96-4380-b588-cbe9806aa7a3)
 
 
-
 <!-- ------------------------------ -->
-#### UserMediaElement
+#### `<usermedia>` HTML element
 
 Expires on Jul. 14, 2026.
 
-The current web permission model for UserMedia relies on JavaScript-triggered prompts, giving the user agent no strong signal of user intent. This results in out-of-context prompts, user frustration, and difficult-to-recover-from denial states.
+The `<usermedia>` element is a browser-controlled HTML element for requesting camera or microphone access.
 
-We propose the &lt;usermedia&gt; element, a semantic HTML control with browser-controlled content and strict styling constraints. These constraints are fundamental to the security model, ensuring a very high level of confidence in the user&#39;s intent when making a permission decision at both the site and OS level.
+Using a semantic HTML element instead of JavaScript:
+* Provides better clarity to users about the permission request.
+* Improves accessibility.
+* Prevents manipulative UI patterns.
+* Streamlines the workflow, by directly providing the media stream to your application without separate API calls.
 
-Crucially, the &lt;usermedia&gt; element evolves beyond simply managing permissions; it streamlines the entire journey by also directly providing UserMedia stream to the site. This often eliminates the need for separate JavaScript API calls, simplifying implementation and creating a more seamless user flow.
-
-By providing a clear, consistent, in-page control, this element solves significant user problems related to context blindness and &quot;permission regret,&quot; offering a simple recovery path from a previously denied state. The combination of a user-initiated element and a subsequent browser-controlled confirmation UI enhances intent capture, improves accessibility, and prevents manipulative patterns, providing a significantly better experience for both users and developers.
-
+Information about this origin trial:
 * [Explainer](https://github.com/WICG/PEPC/blob/main/usermedia_element.md)
 * [Feedback](https://github.com/WICG/PEPC/issues/62#issuecomment-3210807676)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/ff216fe5-9eb9-4acb-aace-2f6a8789b95c)
-
 
 
 <!-- ------------------------------ -->
@@ -497,12 +446,11 @@ By providing a clear, consistent, in-page control, this element solves significa
 
 Expires on Jul. 28, 2026.
 
-&quot;Soft navigations&quot; are JS-driven same-document navigations that are using the history API or the new Navigation API, triggered by a user gesture and modifies the DOM, modifying the previous content, as well as the URL displayed to the user. This OT would experiment with soft navigation heuristics, and will experimentally web-expose them, so that RUM providers and developers can collect them and report back of their usefulness when collecting performance metrics.
+Soft navigations are JavaScript-driven same-document navigations that use the History API or the Navigation API, are triggered by a user gesture, and modify the DOM and the displayed URL.  This origin trial exposes soft navigation heuristics so that you can collect performance metrics for single-page app navigations.
 
 * [Explainer](https://github.com/WICG/soft-navigations#soft-navigations)
 * [Feedback](https://github.com/WICG/soft-navigations/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/ec952482-49f0-4980-a451-13ea3f9a7220)
-
 
 
 <!-- ------------------------------ -->
@@ -510,14 +458,13 @@ Expires on Jul. 28, 2026.
 
 Expires on Aug. 11, 2026.
 
-Expand the TextMetrics Canvas API to support selection rectangles, bounding box queries, and glyph cluster-based operations.
+The Enhanced Canvas TextMetrics origin trial expands the TextMetrics Canvas API to support selection rectangles, bounding-box queries, and glyph cluster-based operations.
 
-This new functionality should enable complex text editing applications with accurate selection, caret positioning, and hit testing.  Additionally, cluster-based rendering facilitates sophisticated text effects such as independent character animations and styling.
+This enables complex text-editing applications to have accurate selection, caret positioning, and hit-testing.  Cluster-based rendering also facilitates sophisticated text effects, such as independent character animations and styling.
 
 * [Explainer](https://github.com/Igalia/explainers/blob/main/canvas-formatted-text/text-metrics-additions.md)
 * [Feedback](https://github.com/Igalia/explainers/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/c4ab8844-e904-46c1-94b6-7e2b5c19bf3e)
-
 
 
 <!-- ------------------------------ -->
@@ -525,25 +472,23 @@ This new functionality should enable complex text editing applications with accu
 
 Expires on Aug. 11, 2026.
 
-WebNN provides a high-level abstraction over the ML acceleration capabilities provided by the platform. The goal of this experiment is to understand how well real-world models abstract to the operations supported by WebNN and how well WebNN can map these operations to those supported by the hardware of real-world users.
+Use the WebNN API to build and execute machine-learning models directly in your web app.  WebNN provides a high-level abstraction over the platform's ML acceleration capabilities.
 
 * [Explainer](https://webnn.io/en/learn/get-started/quickstart)
 * [Feedback](https://github.com/webmachinelearning/webnn/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/19857284-cf52-484b-8b09-8ca50ac9dccb)
 
 
-
 <!-- ------------------------------ -->
-#### focusgroup
+#### `focusgroup` HTML attribute for keyboard navigation
 
 Expires on Aug. 11, 2026.
 
-focusgroup provides focus navigation among a set of focusable elements with the arrow keys.
+Use the `focusgroup` attribute to provide arrow-key navigation among a set of focusable elements, without custom JavaScript.
 
 * [Explainer](https://open-ui.org/components/scoped-focusgroup.explainer)
 * [Feedback](https://github.com/openui/open-ui/issues/new?labels=focusgroup&amp;title=%5Bfocusgroup%5D%20)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/6d4b86e7-230c-4d23-ab2b-ee8d05f18702)
-
 
 
 <!-- ------------------------------ -->
@@ -551,26 +496,23 @@ focusgroup provides focus navigation among a set of focusable elements with the 
 
 Expires on Aug. 25, 2026.
 
-This feature introduces url- and eval- hashes to be used in script-src directives in Content Security Policy. It enables developers to write a strict CSP that only relies on hash and nonce based policies, without having to use permissive hostname based allowlists or unsafe-eval.
-
+Use URL and eval hashes in `script-src` directives in Content Security Policy.  This enables you to write a strict CSP that relies only on hash- and nonce-based policies, without permissive hostname-based allowlists or `unsafe-eval`.
 
 * [Explainer](https://github.com/explainers-by-googlers/script-src-v2)
 * [Feedback](https://github.com/explainers-by-googlers/script-src-v2/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/6bd50a0d-6f30-425f-beba-034be41bb013)
 
 
-
 <!-- ------------------------------ -->
-#### WebAppInstallation
+#### Web Install API
 
 Expires on Aug. 25, 2026.
 
-Allows websites to imperatively install other websites as web apps, via an install_url and optional manifest_id. 
+The Web Install API allows a website to install another website as a web app on the user's device, by using `navigator.install()`.
 
 * [Explainer](https://aka.ms/webinstall)
 * [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=web-install-api.md)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/bcf7d28f-6bdf-45d8-9207-63c97a042407)
-
 
 
 <!-- ------------------------------ -->
@@ -578,25 +520,23 @@ Allows websites to imperatively install other websites as web apps, via an insta
 
 Expires on Aug. 25, 2026.
 
-OpaqueRange lets developers create live ranges over text inside &lt;input&gt; and &lt;textarea&gt; elements that automatically update as the user edits. These ranges support geometry methods like getBoundingClientRect() and the CSS Custom Highlight API, enabling use cases like caret-positioned popups and inline spell-check highlighting directly on form controls without cloning elements or exposing internal DOM structure.
+Use `OpaqueRange` to represent a live span of text within a form control's value.  See [OpaqueRange for form control text](#opaquerange-for-form-control-text), above.
 
-* [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/OpaqueRange/explainer.md)
-* [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=opaque-range.md)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/5f4620e8-2969-4579-a5c6-304b8fae7200)
-
+* [Explainer]()
+* [Feedback]()
+* [Register]()
 
 
 <!-- ------------------------------ -->
-#### html-in-canvas
+#### HTML in canvas
 
 Expires on Aug. 25, 2026.
 
-HTML-in-canvas enables customizing the rendering of html using canvas with three new primitives: an attribute to opt-in canvas elements (layoutsubtree), methods to draw child elements (2d: drawElementImage, webgl: texElementImage2D, webgpu: copyElementImageToTexture), and a paint event which fires to handle updates.
+HTML in canvas enables customizing the rendering of HTML using canvas with three new primitives: a `layoutsubtree` attribute to opt in canvas elements, methods to draw child elements (`drawElementImage` for 2D, `texElementImage2D` for WebGL, `copyElementImageToTexture` for WebGPU), and a `paint` event that fires to handle updates.
 
 * [Explainer](https://github.com/WICG/html-in-canvas)
 * [Feedback](https://github.com/WICG/html-in-canvas/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/a297467e-0030-4c4c-8739-48e130026c03)
-
 
 
 <!-- ------------------------------ -->
@@ -604,25 +544,23 @@ HTML-in-canvas enables customizing the rendering of html using canvas with three
 
 Expires on Sep. 8, 2026.
 
-This API enables triggering the issuance of user credentials from a credential issuer server to a digital wallet application. It is available on both Desktop and Android platforms and can be used, for instance, to trigger the provisioning of a new driver&#39;s license or verified academic degree from a government or university server to a user&#39;s digital wallet.
+Use this API to trigger the issuance of user credentials from a credential issuer server to a digital wallet application.  For example, use this API to provision a new driver's license or verified academic degree from a government or university server to a user's digital wallet.
 
 * [Explainer](https://w3c-fedid.github.io/digital-credentials)
 * [Feedback](https://github.com/w3c-fedid/digital-credentials/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/89fbbd25-ce49-43b6-a206-dd0909394ed8)
 
 
-
 <!-- ------------------------------ -->
-#### PrerenderUntilScript
+#### `prerender_until_script` Speculation Rules API action
 
 Expires on Sep. 8, 2026.
 
-A new action for the Speculation Rules API, prerender_until_script. This action is designed to provide developers with an intermediate option between the existing prefetch and prerender actions.
+A new action for the Speculation Rules API that provides an intermediate option between the existing `prefetch` and `prerender` actions.
 
 * [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerender-until-script.md)
 * [Feedback](https://github.com/WICG/nav-speculation/issues/305)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b7fcdb4e-b3ab-4bbe-ba5a-0d4e655ad690)
-
 
 
 <!-- ------------------------------ -->
@@ -630,25 +568,23 @@ A new action for the Speculation Rules API, prerender_until_script. This action 
 
 Expires on Sep. 8, 2026.
 
-Makes AudioContext and OfflineAudioContext take an optional renderSizeHint, which allows users to ask for a particular render quantum size.
+Pass an optional `renderSizeHint` to `AudioContext` and `OfflineAudioContext` to request a particular render quantum size.
 
 * [Explainer](https://webaudio.github.io/web-audio-api/#dom-audiocontextoptions-rendersizehint)
 * [Feedback](https://github.com/WebAudio/web-audio-api/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/d5574838-d416-4242-81a8-7833c107b028)
 
 
-
 <!-- ------------------------------ -->
-#### PrerenderActivationByFormSubmission
+#### Prerender activation by form submission
 
 Expires on Sep. 8, 2026.
 
-Introduces a new field to the Speculation Rules API that allows prerender rules to be activated by form submissions.
+A new field in the Speculation Rules API that allows prerender rules to be activated by form submissions.
 
 * [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerendering-form-submission.md)
 * [Feedback](https://github.com/WICG/nav-speculation/issues/322)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/63420781-6a9d-4b23-a827-69ebe66fb631)
-
 
 
 <!-- ------------------------------ -->
@@ -656,12 +592,11 @@ Introduces a new field to the Speculation Rules API that allows prerender rules 
 
 Expires on Sep. 8, 2026.
 
-The CPU Performance API exposes some information about how powerful the user device is. It targets web applications that will use this information to provide an improved user experience, possibly in combination with the Compute Pressure API, which provides information about the user device’s CPU pressure/utilization and allows applications to react to changes in CPU pressure.
+The CPU Performance API exposes information about the user's device capabilities.  Use this information to provide an improved user experience, possibly in combination with the Compute Pressure API.
 
 * [Explainer](https://github.com/WICG/cpu-performance)
 * [Feedback](https://github.com/WICG/cpu-performance/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/505dbb22-2d7f-4c91-9a2b-3913345a956e)
-
 
 
 <!-- ------------------------------ -->
@@ -669,12 +604,11 @@ The CPU Performance API exposes some information about how powerful the user dev
 
 Expires on Sep. 8, 2026.
 
-Connection Allowlists is a feature designed to provide explicit control over external endpoints by restricting connections initiated via the Fetch API or other web platform APIs from a document or worker. The proposed implementation involves the distribution of an authorized endpoint list from the server through an HTTP response header. Prior to the establishment of any connection by the user agent on behalf of a page, the agent will evaluate the destination against this allowlist; connections to verified endpoints will be permitted, while those failing to match the entries in the list will be blocked. More details on the proposal can be found here: https://github.com/WICG/connection-allowlists 
+Restrict connections initiated from a document or worker to an allowlist of endpoints.  Distribute the authorized endpoint list from the server through an HTTP response header.  The browser evaluates each connection destination against the allowlist before connecting.
 
 * [Explainer](https://github.com/WICG/connection-allowlists)
 * [Feedback](https://github.com/WICG/connection-allowlists/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/a20a4374-39fd-445f-9348-f6c8737a45de)
-
 
 
 <!-- ------------------------------ -->
@@ -682,12 +616,11 @@ Connection Allowlists is a feature designed to provide explicit control over ext
 
 Expires on Sep. 22, 2026.
 
-Prerenders cross-origin iframes with an opt-in response header. Browsers will now prerender all cross-origin frames if the top-level frame&#39;s HTTP response includes the Supports-Loading-Mode: prerender-cross-origin-frames.
+Prerender all cross-origin frames when the top-level frame's HTTP response includes the `Supports-Loading-Mode: prerender-cross-origin-frames` header.
 
 * [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerendering-cross-origin-iframes.md)
 * [Feedback](https://github.com/WICG/nav-speculation/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/46c24517-496a-4a6b-a4d3-604b08620d43)
-
 
 
 <!-- ------------------------------ -->
@@ -695,12 +628,11 @@ Prerenders cross-origin iframes with an opt-in response header. Browsers will no
 
 Expires on Oct. 6, 2026.
 
-The Container Timing API enables monitoring when annotated sections of the DOM are displayed on screen and have finished their initial paint. A developer will have the ability to mark subsections of the DOM with the &quot;containertiming&quot; attribute (similar to &quot;elementtiming&quot; for the Element Timing API) and receive performance entries when that section has been painted for the first time. This API will allow developers to measure the timing of various components in their pages.
+The Container Timing API monitors when annotated sections of the DOM are displayed on screen and have finished their initial paint.  Mark subsections of the DOM with the `containertiming` attribute to receive performance entries when that section has been painted for the first time.
 
 * [Explainer](https://github.com/WICG/container-timing/blob/main/ORIGIN_TRIAL.md)
 * [Feedback](https://github.com/WICG/container-timing/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/79fd2cd8-2283-4ed8-a472-4a8281a73d86)
-
 
 
 <!-- ------------------------------ -->
@@ -708,14 +640,11 @@ The Container Timing API enables monitoring when annotated sections of the DOM a
 
 Expires on Oct. 6, 2026.
 
-Add `styleDuration`, `forcedStyleDuration`, `layoutDuration` and `forcedLayoutDuration` information to the Long Animation Frame API, enabling developers to distinguish style and layout times.
-
-That enables developers to get a deeper understanding of their CSS performance issues in the wild.
+Adds `styleDuration`, `forcedStyleDuration`, `layoutDuration`, and `forcedLayoutDuration` to the Long Animation Frame API.  Use these fields to distinguish style and layout times, giving you a deeper understanding of CSS performance issues in the field.
 
 * [Explainer](https://github.com/w3c/long-animation-frames/pull/30#issue-3828859369)
 * [Feedback](https://github.com/w3c/long-animation-frames/pull/30)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/349e23d8-799a-4ac2-b45a-ffb91e09b4ce)
-
 
 
 <!-- ------------------------------ -->
@@ -723,14 +652,11 @@ That enables developers to get a deeper understanding of their CSS performance i
 
 Expires on Oct. 6, 2026.
 
-Enable Prompt API per-session language model sampling parameters.
-
-Parameter tuning is useful for testing and use-case specific model behavior optimization. This trial will explore parameters and options that satisfy developer requirements and mitigate interoperability concerns that excluded topK and temperature from the initial Prompt API launch.
+Enable per-session language model sampling parameters in the Prompt API.  Use parameter tuning to test and optimize model behavior for your specific use case.
 
 * [Explainer](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#sampling-parameters)
 * [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/32d0cd0f-611d-411e-b48e-cfd8edfdbf73)
-
 
 
 <!-- ------------------------------ -->
@@ -738,13 +664,11 @@ Parameter tuning is useful for testing and use-case specific model behavior opti
 
 Expires on Oct. 6, 2026.
 
-Allows websites to declaratively install other websites as web apps, via an install_url and optional manifest_id attributes of the HTML element.
-
+Declaratively install other websites as web apps by using the `install_url` and optional `manifest_id` attributes of the HTML Install Element.
 
 * [Explainer](https://github.com/MicrosoftEdge/Demos/blob/main/pwa-install-element/README.md)
 * [Feedback](https://github.com/WICG/install-element/issues/new?template=install-element-ot-feedback.md)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b2eb5c7f-7df0-4ad9-950e-2fbd2ebc08ec)
-
 
 
 <!-- ------------------------------ -->
@@ -752,12 +676,11 @@ Allows websites to declaratively install other websites as web apps, via an inst
 
 Expires on Oct. 6, 2026.
 
-Declarative CSS Modules Scripts are an extension of the existing script-based CSS Module Scripts. They allow for developers to share declarative stylesheets with shadow roots, including declarative shadow roots. Developers can define inline style modules with &lt;style type=&quot;module&quot; specifier=&quot;foo&quot;&gt; and apply a declarative module to a declarative shadow DOM by referencing specifier or a URL, such as &lt;template shadowrootmode=&quot;open&quot; shadowrootadoptedstylesheets=&quot;foo&quot;&gt;.
+Share declarative stylesheets with shadow roots, including declarative shadow roots.  Define inline style modules with `<style type="module" specifier="foo">` and apply them to a declarative shadow DOM by referencing a specifier or URL, such as `<template shadowrootmode="open" shadowrootadoptedstylesheets="foo">`.
 
 * [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md)
 * [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/DeclarativeShadowDOMStyleSharing)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/966b04dd-3da4-43f4-a6a0-66a785f129f4)
-
 
 
 <!-- ------------------------------ -->
@@ -765,15 +688,11 @@ Declarative CSS Modules Scripts are an extension of the existing script-based CS
 
 Expires on Nov. 3, 2026.
 
-Autofill is a key feature of the web that reduces friction for millions of users everyday. But it&#39;s not without its developer friction.
-
-This trial exposes the &quot;autofill&quot; event which will enable developers to get access to the fields/values about to be filled, change the form dynamically to accomodate that and ask the browser to retrigger autofill if needed.
+The `autofill` event fires before the browser fills form fields, giving you access to the fields and values about to be filled.  Use this event to dynamically adjust your form to accommodate autofill, and to ask the browser to retrigger autofill if needed.
 
 * [Explainer](https://github.com/WICG/autofill-event?tab=readme-ov-file#autofill-event)
 * [Feedback](https://github.com/WICG/autofill-event/issues/31)
 * [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/43534059-5696-4eaf-8bbd-eba4c4f86e88)
-
-
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -402,7 +402,7 @@ Use the Prompt API to:
 * Discover innovative ways to integrate prompt-engineering capabilities into your web app.
 
 See also:
-* [Prompt API](#prompt-api), above.
+* [Prompt a built-in language model with the Prompt API](../prompt-api.md).
 
 Information about this origin trial:
 * [Explainer](https://github.com/webmachinelearning/prompt-api/blob/main/README.md)

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -62,7 +62,7 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Prompt API sampling parameters](#prompt-api-sampling-parameters)
   * [Container Timing](#container-timing)
   * [Separate style and layout durations in the Long Animation Frame API](#separate-style-and-layout-durations-in-the-long-animation-frame-api)
-  * [HTML Install Element](#html-install-element)
+  * [HTML `<install>` element](#html-install-element)
   * [Declarative CSS Module Scripts](#declarative-css-module-scripts)
   * [Autofill Event](#autofill-event)
 
@@ -422,8 +422,7 @@ Use the Prompt API to:
 * Create application logic based on user input.
 * Discover innovative ways to integrate prompt-engineering capabilities into your web app.
 
-See also:
-* [Prompt a built-in language model with the Prompt API](../prompt-api.md).
+See also [Prompt a built-in language model with the Prompt API](../prompt-api.md).
 
 Information about this origin trial:
 * [Explainer](https://github.com/webmachinelearning/prompt-api/blob/main/README.md)
@@ -467,11 +466,11 @@ Information about this origin trial:
 
 Expires on Jul. 28, 2026.
 
+This origin trial exposes soft-navigation heuristics so that you can collect performance metrics for navigations in a single-page app.
+
 A _soft navigation_ is a same-document navigation that's driven by JavaScript, when using the History API or the Navigation API.
 
 Soft navigations are triggered by a user gesture.  A soft navigation modifies the DOM and the displayed URL.
-
-This origin trial exposes soft-navigation heuristics so that you can collect performance metrics for navigations in a single-page app.
 
 * [Explainer](https://github.com/WICG/soft-navigations#soft-navigations)
 * [Feedback](https://github.com/WICG/soft-navigations/issues)
@@ -569,6 +568,7 @@ HTML in canvas enables customizing the rendering of HTML using canvas with three
 * Methods to draw child elements: `drawElementImage` for 2D, `texElementImage2D` for WebGL, and `copyElementImageToTexture` for WebGPU.
 * The `paint` event that fires to handle updates.
 
+Information about this origin trial:
 * [Explainer](https://github.com/WICG/html-in-canvas)
 * [Feedback](https://github.com/WICG/html-in-canvas/issues)
 * [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/a297467e-0030-4c4c-8739-48e130026c03)
@@ -729,7 +729,7 @@ Use these properties to distinguish style and layout times, to gain a deeper und
 
 
 <!-- ------------------------------ -->
-#### HTML Install Element
+#### HTML `<install>` element
 
 Expires on Oct. 6, 2026.
 

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -40,7 +40,7 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [`Request.isReloadNavigation` attribute](#requestisreloadnavigation-attribute)
   * [Service Worker router timing fields in Resource Timing and Navigation Timing APIs](#service-worker-router-timing-fields-in-resource-timing-and-navigation-timing-apis)
   * [`autocorrect="off"` on Windows touch keyboard](#autocorrectoff-on-windows-touch-keyboard)
-  * [Defer clipboard data reads until the format<!-- todo: the MIME type? --> is specified](#defer-clipboard-data-reads-until-the-format-is-specified)
+  * [Defer clipboard data reads until the MIME type is specified](#defer-clipboard-data-reads-until-the-mime-type-is-specified)
   * [Close WebSocket connections on bfcache entry](#close-websocket-connections-on-bfcache-entry)
 * [Origin trials](#origin-trials)
   * [SharedArrayBuffers in non-isolated pages on Desktop platforms](#sharedarraybuffers-in-non-isolated-pages-on-desktop-platforms)
@@ -63,7 +63,7 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [CPU Performance API](#cpu-performance-api)
   * [Connection allowlists](#connection-allowlists)
   * [Prerendering cross-origin iframes](#prerendering-cross-origin-iframes)
-  * [Prompt API Sampling Parameters](#prompt-api-sampling-parameters)
+  * [Prompt API sampling parameters](#prompt-api-sampling-parameters)
   * [Container Timing](#container-timing)
   * [Separate style and layout durations in the Long Animation Frame API](#separate-style-and-layout-durations-in-the-long-animation-frame-api)
   * [HTML Install Element](#html-install-element)
@@ -139,7 +139,7 @@ Use the new `path-length` CSS property to set the `pathLength` attribute value o
 * `<polygon>`
 * `<ellipse>`
 
-The `path-length` CSS property allows you to manipulate an SVG's `pathLength` property<!-- todo: `pathLength` attribute value? --> via stylesheets, inline styles, and animations.
+The `path-length` CSS property allows you to manipulate an SVG's `pathLength` attribute value via stylesheets, inline styles, and animations.
 
 CSS declarations override the SVG presentation attribute following standard CSS precedence rules.  The initial value is `none`.
 
@@ -228,7 +228,7 @@ See also:
 <!-- ------------------------------ -->
 #### Intl.Locale variants
 
-The `Intl.Locale` object now exposes a `variants` property.  You <!-- todo: now? (is this part new?) --> can also pass a `variants` string in the options of the `Intl.Locale` constructor.
+The `Intl.Locale` object now exposes a `variants` property.  You can also now pass a `variants` string in the options of the `Intl.Locale` constructor.
 
 The variants of a locale represent additional language preferences that are not covered by the language, region, and script fields of a language ID.
 
@@ -241,10 +241,9 @@ See also:
 
 Use `OpaqueRange` to represent a live span of text within a form control's value, such as a `<textarea>` or text-based `<input>`.
 
-<!-- `OpaqueRange` enables the following for inline suggestions, highlights, and anchored popovers: -->
-`OpaqueRange` enables:
+`OpaqueRange` enables the following for inline suggestions, highlights, and anchored popovers:
 * Operations such as `getBoundingClientRect()` and `getClientRects()`.
-* Integration with the CSS Custom Highlight API for inline suggestions, highlights, and anchored popovers.<!-- todo: does right half of list item also apply to previous list item?  compare orig sentence containing all -->
+* Integration with the CSS Custom Highlight API .
 
 `OpaqueRange` preserves encapsulation by exposing only value offsets, and returns `null` for `startContainer` and `endContainer`.
 
@@ -272,7 +271,7 @@ A payment handler that's accessed via the Payment Request API can now return dis
 Use this distinction to build better flows for your users.  For example, when an internal error occurs, retry or fall back to a different payment method, while properly stopping the flow if the user cancels.
 
 * If the promise that's passed to `PaymentRequestEvent.respondWith` is rejected with an `OperationError`, your `PaymentRequest.show()` promise receives an `OperationError`.
-* If the promise that's passed to `PaymentRequestEvent.respondWith` is rejected with a value other than `OperationError`, your `PaymentRequest.show()` promise receives an `AbortError` (user cancel).<!-- todo: is the first clause of this list item an accurate replacement for the orig. "Otherwise, it receives..."?  specify the "otherwise" case -->
+* If the promise that's passed to `PaymentRequestEvent.respondWith` is rejected with a value other than `OperationError`, your `PaymentRequest.show()` promise receives an `AbortError` (user cancel).
 
 See also:
 * [Payment Request API](https://developer.mozilla.org/docs/Web/API/Payment_Request_API) at MDN.
@@ -330,9 +329,9 @@ See also:
 
 
 <!-- ------------------------------ -->
-#### Defer clipboard data reads until the format<!-- todo: the MIME type? --> is specified
+#### Defer clipboard data reads until the MIME type is specified
 
-The Async Clipboard API now defers reading clipboard data from the operating system until you call `getType()`.  When you call `navigator.clipboard.read()`, the browser returns `ClipboardItem` objects<!-- todo: favor singular not plural --> with available MIME types<!-- todo: favor singular not plural -->, but without the underlying data.  The actual data is read only when you request a specific format.
+The Async Clipboard API now defers reading clipboard data from the operating system until you call `getType()`.  When you call `navigator.clipboard.read()`, the browser returns an array of `ClipboardItem` objects, each with their available MIME types, but without the underlying data.  The actual data is read only when you request a specific format.
 
 ```javascript
 const items = await navigator.clipboard.read(); // No data is read yet.
@@ -374,7 +373,7 @@ For the full list of available origin trials, see [Microsoft Edge Origin Trials]
 
 Expires on May 19, 2026.
 
-Temporary extension for ungated<!-- todo: clarify --> use of the `SharedArrayBuffer` objects in pages that aren't cross-origin isolated<!-- todo: clearer wording: isolated to prevent cross-origin -->.
+This origin trial allows you to use `SharedArrayBuffer` objects in pages that aren't _cross-origin isolated_. A cross-origin isolated page is a page that's not be able to load cross-origin content unless the resource explicitly allows it via a Cross-Origin-Resource-Policy header or CORS headers.
 
 * [Explainer](https://developer.chrome.com/blog/enabling-shared-array-buffer/)
 * [Feedback](https://bugs.chromium.org/p/chromium/issues/entry?components=Internals%3ESandbox%3ESiteIsolation)
@@ -472,11 +471,11 @@ Information about this origin trial:
 
 Expires on Jul. 28, 2026.
 
-Soft navigations are same-document navigations that are driven by JavaScript, when using the History API or the Navigation API.
+A _soft navigation_ is a same-document navigation that's driven by JavaScript, when using the History API or the Navigation API.
 
 Soft navigations are triggered by a user gesture.  A soft navigation modifies the DOM and the displayed URL.
 
-This origin trial exposes soft navigation heuristics so that you can collect performance metrics for navigations in a single-page app.
+This origin trial exposes soft-navigation heuristics so that you can collect performance metrics for navigations in a single-page app.
 
 * [Explainer](https://github.com/WICG/soft-navigations#soft-navigations)
 * [Feedback](https://github.com/WICG/soft-navigations/issues)
@@ -588,7 +587,7 @@ The Digital Credentials API enables triggering the issuance of user credentials 
 
 For example, use the Digital Credentials API to:
 * Trigger the provisioning of a new driver's license from a government server to a user's digital wallet.
-* Trigger the provisioning of a<!-- todo: new? --> verified academic degree from a university server to a user's digital wallet.
+* Trigger the provisioning of a new verified academic degree from a university server to a user's digital wallet.
 
 Information about this origin trial:
 * [Explainer](https://w3c-fedid.github.io/digital-credentials)
@@ -688,13 +687,13 @@ This origin trial prerenders cross-origin iframes by using an opt-in response he
 
 
 <!-- ------------------------------ -->
-#### Prompt API Sampling Parameters
+#### Prompt API sampling parameters
 
 Expires on Oct. 6, 2026.
 
-These Prompt API sampling parameters<!-- todo: what are the parameters?  two are specified, implying more --> enable per-session language model sampling parameters in the Prompt API.  Use parameter tuning to test and optimize model behavior for your specific use case.
+The Prompt API `topK` and `temperature` sampling parameters let you optimize model behavior for your specific use case.
 
-This origin trial explores<!-- todo: reword "explores" --> parameters such as `topK` and `temperature` that satisfy developer requirements<!-- todo: alt wording for "satisfy developer requirements"? --> and mitigate interoperability concerns<!-- todo: and improve interoperability -->.
+The Prompt API sampling parameters apply per language model session.
 
 * [Explainer](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#sampling-parameters)
 * [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
@@ -706,9 +705,9 @@ This origin trial explores<!-- todo: reword "explores" --> parameters such as `t
 
 Expires on Oct. 6, 2026.
 
-The Container Timing API monitors when an annotated <!-- todo: container --> section of the DOM is displayed on screen and has finished its initial paint.
+The Container Timing API monitors when an annotated container of the DOM is displayed on screen and has finished its initial paint.
 
-To receive performance entries when a <!-- todo: container --> section has been painted for the first time, mark each such subsection of the DOM with the `containertiming` attribute.  This is similar to `elementtiming` for the Element Timing API.
+To receive performance entries when a container has been painted for the first time, mark each such subsection of the DOM with the `containertiming` attribute.  This is similar to `elementtiming` for the Element Timing API.
 
 * [Explainer](https://github.com/WICG/container-timing/blob/main/ORIGIN_TRIAL.md)
 * [Feedback](https://github.com/WICG/container-timing/issues)
@@ -720,13 +719,13 @@ To receive performance entries when a <!-- todo: container --> section has been 
 
 Expires on Oct. 6, 2026.
 
-This origin trial adds the following fields to the Long Animation Frame API:
+This origin trial adds the following properties to the Long Animation Frame API:
 * `styleDuration`
 * `forcedStyleDuration`
 * `layoutDuration`
 * `forcedLayoutDuration`
 
-Use these fields<!-- todo: attributes? --> to distinguish style and layout times, to gain a deeper understanding of CSS performance issues for each field<!-- todo: issues for each aspect of layout? -->.
+Use these properties to distinguish style and layout times, to gain a deeper understanding of CSS performance issues for each aspect of layout.
 
 * [Explainer](https://github.com/w3c/long-animation-frames/pull/30#issue-3828859369)
 * [Feedback](https://github.com/w3c/long-animation-frames/pull/30)

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -27,19 +27,19 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [`image-rendering: crisp-edges`](#image-rendering-crisp-edges)
   * [`path-length` CSS property for SVG elements](#path-length-css-property-for-svg-elements)
   * [`path()`, `shape()`, `rect()`, and `xywh()` in `shape-outside`](#path-shape-rect-and-xywh-in-shape-outside)
-  * [Remove `border-color: gray` from the table UA stylesheet](#remove-border-color-gray-from-the-table-ua-stylesheet)
+  * [Remove `border-color: gray` from the table user agent stylesheet](#remove-border-color-gray-from-the-table-user-agent-stylesheet)
   * [Scope system accent color to installed web apps](#scope-system-accent-color-to-installed-web-apps)
-  * [User-action pseudo-class top-layer boundary](#user-action-pseudo-class-top-layer-boundary)
+  * [User-action pseudo-classes top-layer boundary](#user-action-pseudo-classes-top-layer-boundary)
 * [Web APIs](#web-apis)
   * [Disable SVG filters on cross-origin iframes and plugins](#disable-svg-filters-on-cross-origin-iframes-and-plugins)
-  * [`Intl.Locale.prototype.variants`](#intllocaleprototypevariants)
+  * [Intl.Locale variants](#intllocale-variants)
   * [`OpaqueRange` for form control text](#opaquerange-for-form-control-text)
   * [Migrate a PWA to a new origin](#migrate-a-pwa-to-a-new-origin)
   * [Distinguish payment handler errors in Payment Request](#distinguish-payment-handler-errors-in-payment-request)
   * [Get notified when the `scrollBy` and `scrollTo` methods complete](#get-notified-when-the-scrollby-and-scrollto-methods-complete)
   * [`Request.isReloadNavigation` attribute](#requestisreloadnavigation-attribute)
-  * [Service Worker Router timing fields in Resource Timing](#service-worker-router-timing-fields-in-resource-timing)
-  * [Honor `autocorrect="off"` on Windows touch keyboard](#honor-autocorrectoff-on-windows-touch-keyboard)
+  * [Service Worker router timing fields in Resource Timing and Navigation Timing APIs](#service-worker-router-timing-fields-in-resource-timing-and-navigation-timing-apis)
+  * [`autocorrect="off"` on Windows touch keyboard](#autocorrectoff-on-windows-touch-keyboard)
   * [Defer clipboard data reads with selective format reading](#defer-clipboard-data-reads-with-selective-format-reading)
   * [Close WebSocket connections on bfcache entry](#close-websocket-connections-on-bfcache-entry)
 * [Origin trials](#origin-trials)
@@ -47,26 +47,25 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Incoming Call Notifications](#incoming-call-notifications)
   * [Proofreader API](#proofreader-api)
   * [Prompt API](#prompt-api)
-  * [WebAssembly Custom Descriptors](#webassembly-custom-descriptors)
+  * [WebAssembly custom descriptors](#webassembly-custom-descriptors)
   * [`<usermedia>` HTML element](#usermedia-html-element)
-  * [Soft Navigation Heuristics](#soft-navigation-heuristics)
+  * [Soft navigation heuristics](#soft-navigation-heuristics)
   * [Enhanced Canvas TextMetrics](#enhanced-canvas-textmetrics)
   * [WebNN](#webnn)
   * [`focusgroup` HTML attribute for keyboard navigation](#focusgroup-html-attribute-for-keyboard-navigation)
   * [URL and eval hashes in CSP script-src](#url-and-eval-hashes-in-csp-script-src)
   * [Web Install API](#web-install-api)
-  * [OpaqueRange](#opaquerange)
-  * [HTML-in-canvas](#html-in-canvas)
+  * [HTML in canvas](#html-in-canvas)
   * [Digital Credentials API - Issuance Support](#digital-credentials-api---issuance-support)
   * [`prerender_until_script` Speculation Rules API action](#prerender_until_script-speculation-rules-api-action)
   * [WebAudio Configurable Render Quantum](#webaudio-configurable-render-quantum)
   * [Prerender activation by form submission](#prerender-activation-by-form-submission)
   * [CPU Performance API](#cpu-performance-api)
-  * [Connection Allowlists](#connection-allowlists)
+  * [Connection allowlists](#connection-allowlists)
   * [Prerendering cross-origin iframes](#prerendering-cross-origin-iframes)
-  * [Container Timing](#container-timing)
-  * [Long Animation Frames - separate style and layout durations](#long-animation-frames---separate-style-and-layout-durations)
   * [Prompt API Sampling Parameters](#prompt-api-sampling-parameters)
+  * [Container Timing](#container-timing)
+  * [Separate style and layout durations in the Long Animation Frame API](#separate-style-and-layout-durations-in-the-long-animation-frame-api)
   * [HTML Install Element](#html-install-element)
   * [Declarative CSS Module Scripts](#declarative-css-module-scripts)
   * [Autofill Event](#autofill-event)
@@ -411,15 +410,15 @@ Information about this origin trial:
 
 
 <!-- ------------------------------ -->
-#### WebAssembly Custom Descriptors
+#### WebAssembly custom descriptors
 
 Expires on Jun. 16, 2026.
 
-WebAssembly Custom Descriptors allows WebAssembly to store data associated with source-level types more efficiently in custom descriptor objects.
+WebAssembly custom descriptors allow WebAssembly to store data that's associated with source-level types more efficiently, in custom descriptor objects.
 
 * [Explainer](https://github.com/WebAssembly/custom-descriptors/blob/main/proposals/custom-descriptors/Overview.md)
 * [Feedback](https://github.com/WebAssembly/custom-descriptors/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/f1227421-7d96-4380-b588-cbe9806aa7a3)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/f1227421-7d96-4380-b588-cbe9806aa7a3)
 
 
 <!-- ------------------------------ -->
@@ -427,26 +426,28 @@ WebAssembly Custom Descriptors allows WebAssembly to store data associated with 
 
 Expires on Jul. 14, 2026.
 
-The `<usermedia>` element is a browser-controlled HTML element for requesting camera or microphone access.
+The `<usermedia>` HTML element is a browser-controlled element for requesting camera or microphone access.
 
 Using a semantic HTML element instead of JavaScript:
 * Provides better clarity to users about the permission request.
 * Improves accessibility.
 * Prevents manipulative UI patterns.
-* Streamlines the workflow, by directly providing the media stream to your application without separate API calls.
+* Streamlines the workflow, by directly providing the media stream to your application.  This eliminates the need for separate API calls.
 
 Information about this origin trial:
 * [Explainer](https://github.com/WICG/PEPC/blob/main/usermedia_element.md)
 * [Feedback](https://github.com/WICG/PEPC/issues/62#issuecomment-3210807676)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/ff216fe5-9eb9-4acb-aace-2f6a8789b95c)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/ff216fe5-9eb9-4acb-aace-2f6a8789b95c)
 
 
 <!-- ------------------------------ -->
-#### Soft Navigation Heuristics
+#### Soft navigation heuristics
 
 Expires on Jul. 28, 2026.
 
-Soft navigations are JavaScript-driven same-document navigations that use the History API or the Navigation API, are triggered by a user gesture, and modify the DOM and the displayed URL.  This origin trial exposes soft navigation heuristics so that you can collect performance metrics for single-page app navigations.
+Soft navigations are same-document navigations that are driven by JavaScript, when using the History API or the Navigation API. Soft navigations are triggered by a user gesture and modify the DOM and the displayed URL.
+
+This origin trial exposes soft navigation heuristics so that you can collect performance metrics for single-page app navigations.
 
 * [Explainer](https://github.com/WICG/soft-navigations#soft-navigations)
 * [Feedback](https://github.com/WICG/soft-navigations/issues)
@@ -458,13 +459,21 @@ Soft navigations are JavaScript-driven same-document navigations that use the Hi
 
 Expires on Aug. 11, 2026.
 
-The Enhanced Canvas TextMetrics origin trial expands the TextMetrics Canvas API to support selection rectangles, bounding-box queries, and glyph cluster-based operations.
+The Enhanced Canvas TextMetrics origin trial expands the TextMetrics Canvas API to support:
+* Selection rectangles.
+* Bounding-box queries.
+* Operations based on a glyph cluster.
 
-This enables complex text-editing applications to have accurate selection, caret positioning, and hit-testing.  Cluster-based rendering also facilitates sophisticated text effects, such as independent character animations and styling.
+This new functionality enables complex text-editing applications to have accurate selection, caret positioning, and hit-testing.
 
+Also, cluster-based rendering facilitates sophisticated text effects, such as:
+* Independent character animations.
+* Independent character styling.
+
+Information about this origin trial:
 * [Explainer](https://github.com/Igalia/explainers/blob/main/canvas-formatted-text/text-metrics-additions.md)
 * [Feedback](https://github.com/Igalia/explainers/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/c4ab8844-e904-46c1-94b6-7e2b5c19bf3e)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/c4ab8844-e904-46c1-94b6-7e2b5c19bf3e)
 
 
 <!-- ------------------------------ -->
@@ -472,11 +481,13 @@ This enables complex text-editing applications to have accurate selection, caret
 
 Expires on Aug. 11, 2026.
 
-Use the WebNN API to build and execute machine-learning models directly in your web app.  WebNN provides a high-level abstraction over the platform's ML acceleration capabilities.
+Use the WebNN API to build and execute machine-learning models directly in your web app.
+
+Use hardware-accelerated neural networks by creating computational graphs that efficiently map to platform capabilities and device hardware.
 
 * [Explainer](https://webnn.io/en/learn/get-started/quickstart)
 * [Feedback](https://github.com/webmachinelearning/webnn/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/19857284-cf52-484b-8b09-8ca50ac9dccb)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/19857284-cf52-484b-8b09-8ca50ac9dccb)
 
 
 <!-- ------------------------------ -->
@@ -484,11 +495,17 @@ Use the WebNN API to build and execute machine-learning models directly in your 
 
 Expires on Aug. 11, 2026.
 
-Use the `focusgroup` attribute to provide arrow-key navigation among a set of focusable elements, without custom JavaScript.
+Standardize keyboard navigation for composite widgets such as toolbars, tabs, menus, and radio groups, by using the `focusgroup` HTML attribute.
 
+The `focusgroup` attribute automatically handles the following, without requiring custom JavaScript code:
+* The _roving tabindex_ behavior.
+* Navigation via arrow keys.
+* Focus memory; restores the last-focused element when re-entering the focusgroup.
+
+Information about this origin trial:
 * [Explainer](https://open-ui.org/components/scoped-focusgroup.explainer)
 * [Feedback](https://github.com/openui/open-ui/issues/new?labels=focusgroup&amp;title=%5Bfocusgroup%5D%20)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/6d4b86e7-230c-4d23-ab2b-ee8d05f18702)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/6d4b86e7-230c-4d23-ab2b-ee8d05f18702)
 
 
 <!-- ------------------------------ -->
@@ -496,11 +513,13 @@ Use the `focusgroup` attribute to provide arrow-key navigation among a set of fo
 
 Expires on Aug. 25, 2026.
 
-Use URL and eval hashes in `script-src` directives in Content Security Policy.  This enables you to write a strict CSP that relies only on hash- and nonce-based policies, without permissive hostname-based allowlists or `unsafe-eval`.
+This feature introduces url- and eval- hashes to be used in `script-src` directives in Content Security Policy.
+
+This enables you to write a strict CSP that only relies on hash and nonce based policies, without having to use permissive hostname based allowlists or `unsafe-eval`.
 
 * [Explainer](https://github.com/explainers-by-googlers/script-src-v2)
 * [Feedback](https://github.com/explainers-by-googlers/script-src-v2/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/6bd50a0d-6f30-425f-beba-034be41bb013)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/6bd50a0d-6f30-425f-beba-034be41bb013)
 
 
 <!-- ------------------------------ -->
@@ -512,19 +531,7 @@ The Web Install API allows a website to install another website as a web app on 
 
 * [Explainer](https://aka.ms/webinstall)
 * [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/new?template=web-install-api.md)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/bcf7d28f-6bdf-45d8-9207-63c97a042407)
-
-
-<!-- ------------------------------ -->
-#### OpaqueRange
-
-Expires on Aug. 25, 2026.
-
-Use `OpaqueRange` to represent a live span of text within a form control's value.  See [OpaqueRange for form control text](#opaquerange-for-form-control-text), above.
-
-* [Explainer]()
-* [Feedback]()
-* [Register]()
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/bcf7d28f-6bdf-45d8-9207-63c97a042407)
 
 
 <!-- ------------------------------ -->
@@ -532,7 +539,11 @@ Use `OpaqueRange` to represent a live span of text within a form control's value
 
 Expires on Aug. 25, 2026.
 
-HTML in canvas enables customizing the rendering of HTML using canvas with three new primitives: a `layoutsubtree` attribute to opt in canvas elements, methods to draw child elements (`drawElementImage` for 2D, `texElementImage2D` for WebGL, `copyElementImageToTexture` for WebGPU), and a `paint` event that fires to handle updates.
+HTML in canvas enables customizing the rendering of HTML using canvas with three new primitives:
+
+* The `layoutsubtree` attribute to opt-in canvas elements.
+* Methods to draw child elements: `drawElementImage` for 2D, `texElementImage2D` for WebGL, and `copyElementImageToTexture` for WebGPU.
+* The `paint` event that fires to handle updates.
 
 * [Explainer](https://github.com/WICG/html-in-canvas)
 * [Feedback](https://github.com/WICG/html-in-canvas/issues)
@@ -544,11 +555,13 @@ HTML in canvas enables customizing the rendering of HTML using canvas with three
 
 Expires on Sep. 8, 2026.
 
-Use this API to trigger the issuance of user credentials from a credential issuer server to a digital wallet application.  For example, use this API to provision a new driver's license or verified academic degree from a government or university server to a user's digital wallet.
+The Digital Credentials API enables triggering the issuance of user credentials from a credential issuer server to a digital wallet application.
+
+For example, use the Digital Credentials API to trigger the provisioning of a new driver's license, or a verified academic degree, from a government or university server to a user's digital wallet.
 
 * [Explainer](https://w3c-fedid.github.io/digital-credentials)
 * [Feedback](https://github.com/w3c-fedid/digital-credentials/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/89fbbd25-ce49-43b6-a206-dd0909394ed8)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/89fbbd25-ce49-43b6-a206-dd0909394ed8)
 
 
 <!-- ------------------------------ -->
@@ -556,11 +569,13 @@ Use this API to trigger the issuance of user credentials from a credential issue
 
 Expires on Sep. 8, 2026.
 
-A new action for the Speculation Rules API that provides an intermediate option between the existing `prefetch` and `prerender` actions.
+`prerender_until_script` is a new action for the Speculation Rules API.  This new action provides a middle option in between the `prefetch` and the `prerender` actions.
+
+Use the `prerender_until_script` action when you want the browser to prerender a page, but stop and switch back to prefetching after a specific script starts executing.
 
 * [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerender-until-script.md)
 * [Feedback](https://github.com/WICG/nav-speculation/issues/305)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/b7fcdb4e-b3ab-4bbe-ba5a-0d4e655ad690)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/b7fcdb4e-b3ab-4bbe-ba5a-0d4e655ad690)
 
 
 <!-- ------------------------------ -->
@@ -568,11 +583,18 @@ A new action for the Speculation Rules API that provides an intermediate option 
 
 Expires on Sep. 8, 2026.
 
-Pass an optional `renderSizeHint` to `AudioContext` and `OfflineAudioContext` to request a particular render quantum size.
+By default, WebAudio processes audio in fixed blocks of 128 sample-frames (a render quantum).  When your app's audio processing block size doesn't match this default, development becomes complex and processing becomes less efficient.
 
+Use the WebAudio Configurable Render Quantum origin trial to specify a `renderSizeHint` option when creating an `AudioContext` or `OfflineAudioContext`, to request a particular render quantum size.
+
+* Pass an integer, to request a specific size.
+* Pass `"default"` (or omit the option), to use the default of 128 frames.
+* Pass `"hardware"`, to let the browser pick an optimal size for the current configuration.
+
+Information about this origin trial:
 * [Explainer](https://webaudio.github.io/web-audio-api/#dom-audiocontextoptions-rendersizehint)
 * [Feedback](https://github.com/WebAudio/web-audio-api/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/d5574838-d416-4242-81a8-7833c107b028)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/d5574838-d416-4242-81a8-7833c107b028)
 
 
 <!-- ------------------------------ -->
@@ -580,11 +602,11 @@ Pass an optional `renderSizeHint` to `AudioContext` and `OfflineAudioContext` to
 
 Expires on Sep. 8, 2026.
 
-A new field in the Speculation Rules API that allows prerender rules to be activated by form submissions.
+This origin trial adds a new field to the Speculation Rules API, to allow prerender rules to be activated by form submissions.
 
 * [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerendering-form-submission.md)
 * [Feedback](https://github.com/WICG/nav-speculation/issues/322)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/63420781-6a9d-4b23-a827-69ebe66fb631)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/63420781-6a9d-4b23-a827-69ebe66fb631)
 
 
 <!-- ------------------------------ -->
@@ -592,19 +614,23 @@ A new field in the Speculation Rules API that allows prerender rules to be activ
 
 Expires on Sep. 8, 2026.
 
-The CPU Performance API exposes information about the user's device capabilities.  Use this information to provide an improved user experience, possibly in combination with the Compute Pressure API.
+The CPU Performance API exposes information about how powerful the user's device is.
+
+This API targets web applications that use this information to provide an improved user experience, possibly in combination with the Compute Pressure API.
+
+The Compute Pressure API provides information about the user device's CPU pressure and utilization, and allows the app to react to changes in CPU pressure.
 
 * [Explainer](https://github.com/WICG/cpu-performance)
 * [Feedback](https://github.com/WICG/cpu-performance/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/505dbb22-2d7f-4c91-9a2b-3913345a956e)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/505dbb22-2d7f-4c91-9a2b-3913345a956e)
 
 
 <!-- ------------------------------ -->
-#### Connection Allowlists
+#### Connection allowlists
 
 Expires on Sep. 8, 2026.
 
-Restrict connections initiated from a document or worker to an allowlist of endpoints.  Distribute the authorized endpoint list from the server through an HTTP response header.  The browser evaluates each connection destination against the allowlist before connecting.
+Restrict connections initiated via the Fetch API or other web platform APIs from a document or worker to an allowlist of endpoints.  Distribute the authorized endpoint list from the server through an HTTP response header.  The browser evaluates each connection destination against the allowlist before connecting; connections to unlisted endpoints are blocked.
 
 * [Explainer](https://github.com/WICG/connection-allowlists)
 * [Feedback](https://github.com/WICG/connection-allowlists/issues)
@@ -616,11 +642,25 @@ Restrict connections initiated from a document or worker to an allowlist of endp
 
 Expires on Sep. 22, 2026.
 
-Prerender all cross-origin frames when the top-level frame's HTTP response includes the `Supports-Loading-Mode: prerender-cross-origin-frames` header.
+By default, navigational prerendering delays the loading of all cross-origin iframes until the prerendered page is activated.  When cross-origin iframes are critical to your application, this delay can negate many of the benefits of prerendering.
+
+This origin trial prerenders cross-origin iframes by using an opt-in response header.  The browser prerenders all cross-origin frames if the top-level frame's HTTP response includes the `Supports-Loading-Mode: prerender-cross-origin-frames` header.
 
 * [Explainer](https://github.com/WICG/nav-speculation/blob/main/prerendering-cross-origin-iframes.md)
 * [Feedback](https://github.com/WICG/nav-speculation/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/46c24517-496a-4a6b-a4d3-604b08620d43)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/46c24517-496a-4a6b-a4d3-604b08620d43)
+
+
+<!-- ------------------------------ -->
+#### Prompt API Sampling Parameters
+
+Expires on Oct. 6, 2026.
+
+Enable per-session language model sampling parameters in the Prompt API.  Use parameter tuning to test and optimize model behavior for your specific use case.  This trial explores parameters such as `topK` and `temperature` that satisfy developer requirements and mitigate interoperability concerns.
+
+* [Explainer](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#sampling-parameters)
+* [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
+* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/32d0cd0f-611d-411e-b48e-cfd8edfdbf73)
 
 
 <!-- ------------------------------ -->
@@ -628,7 +668,7 @@ Prerender all cross-origin frames when the top-level frame's HTTP response inclu
 
 Expires on Oct. 6, 2026.
 
-The Container Timing API monitors when annotated sections of the DOM are displayed on screen and have finished their initial paint.  Mark subsections of the DOM with the `containertiming` attribute to receive performance entries when that section has been painted for the first time.
+The Container Timing API monitors when annotated sections of the DOM are displayed on screen and have finished their initial paint.  Mark subsections of the DOM with the `containertiming` attribute (similar to `elementtiming` for the Element Timing API) to receive performance entries when that section has been painted for the first time.
 
 * [Explainer](https://github.com/WICG/container-timing/blob/main/ORIGIN_TRIAL.md)
 * [Feedback](https://github.com/WICG/container-timing/issues)
@@ -636,7 +676,7 @@ The Container Timing API monitors when annotated sections of the DOM are display
 
 
 <!-- ------------------------------ -->
-#### Long Animation Frames - separate style and layout durations
+#### Separate style and layout durations in the Long Animation Frame API
 
 Expires on Oct. 6, 2026.
 
@@ -648,23 +688,11 @@ Adds `styleDuration`, `forcedStyleDuration`, `layoutDuration`, and `forcedLayout
 
 
 <!-- ------------------------------ -->
-#### Prompt API Sampling Parameters
-
-Expires on Oct. 6, 2026.
-
-Enable per-session language model sampling parameters in the Prompt API.  Use parameter tuning to test and optimize model behavior for your specific use case.
-
-* [Explainer](https://github.com/webmachinelearning/prompt-api?tab=readme-ov-file#sampling-parameters)
-* [Feedback](https://github.com/webmachinelearning/prompt-api/issues)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/32d0cd0f-611d-411e-b48e-cfd8edfdbf73)
-
-
-<!-- ------------------------------ -->
 #### HTML Install Element
 
 Expires on Oct. 6, 2026.
 
-Declaratively install other websites as web apps by using the `install_url` and optional `manifest_id` attributes of the HTML Install Element.
+Declaratively install other websites as web apps by using the `<install>` element, and optional `install_url` and `manifest_id` attributes.
 
 * [Explainer](https://github.com/MicrosoftEdge/Demos/blob/main/pwa-install-element/README.md)
 * [Feedback](https://github.com/WICG/install-element/issues/new?template=install-element-ot-feedback.md)
@@ -676,7 +704,7 @@ Declaratively install other websites as web apps by using the `install_url` and 
 
 Expires on Oct. 6, 2026.
 
-Share declarative stylesheets with shadow roots, including declarative shadow roots.  Define inline style modules with `<style type="module" specifier="foo">` and apply them to a declarative shadow DOM by referencing a specifier or URL, such as `<template shadowrootmode="open" shadowrootadoptedstylesheets="foo">`.
+Declarative CSS Module Scripts extend the existing script-based CSS Module Scripts to share declarative stylesheets with shadow roots, including declarative shadow roots.  Define inline style modules with `<style type="module" specifier="foo">` and apply them to a declarative shadow DOM by referencing a specifier or URL, such as `<template shadowrootmode="open" shadowrootadoptedstylesheets="foo">`.
 
 * [Explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/ShadowDOM/explainer.md)
 * [Feedback](https://github.com/MicrosoftEdge/MSEdgeExplainers/labels/DeclarativeShadowDOMStyleSharing)
@@ -688,11 +716,13 @@ Share declarative stylesheets with shadow roots, including declarative shadow ro
 
 Expires on Nov. 3, 2026.
 
-The `autofill` event fires before the browser fills form fields, giving you access to the fields and values about to be filled.  Use this event to dynamically adjust your form to accommodate autofill, and to ask the browser to retrigger autofill if needed.
+Use the new `autofill` event to detect when browser autofill updates form controls.
+
+This makes it easier to adapt custom UI, validation, or dependent form logic after autofill completes.
 
 * [Explainer](https://github.com/WICG/autofill-event?tab=readme-ov-file#autofill-event)
 * [Feedback](https://github.com/WICG/autofill-event/issues/31)
-* [Register](https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/43534059-5696-4eaf-8bbd-eba4c4f86e88)
+* [Register](https://developer.microsoft.com/microsoft-edge/origin-trials/trials/43534059-5696-4eaf-8bbd-eba4c4f86e88)
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/web-platform/release-notes/149.md
+++ b/microsoft-edge/web-platform/release-notes/149.md
@@ -5,13 +5,9 @@ author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: conceptual
 ms.service: microsoft-edge
-ms.date: 06/02/2026
+ms.date: 06/04/2026
 ---
 # Microsoft Edge 149 web platform release notes (Jun. 2026)
-<!-- todo: update ms.date: field to:
-ms.date: 06/04/2026
-per build report, must be < 30 days in future
--->
 
 The following are the new web platform features and updates in Microsoft Edge 149, which releases on Jun. 4, 2026.
 
@@ -243,7 +239,7 @@ Use `OpaqueRange` to represent a live span of text within a form control's value
 
 `OpaqueRange` enables the following for inline suggestions, highlights, and anchored popovers:
 * Operations such as `getBoundingClientRect()` and `getClientRects()`.
-* Integration with the CSS Custom Highlight API .
+* Integration with the CSS Custom Highlight API.
 
 `OpaqueRange` preserves encapsulation by exposing only value offsets, and returns `null` for `startContainer` and `endContainer`.
 
@@ -373,7 +369,7 @@ For the full list of available origin trials, see [Microsoft Edge Origin Trials]
 
 Expires on May 19, 2026.
 
-This origin trial allows you to use `SharedArrayBuffer` objects in pages that aren't _cross-origin isolated_. A cross-origin isolated page is a page that's not be able to load cross-origin content unless the resource explicitly allows it via a Cross-Origin-Resource-Policy header or CORS headers.
+This origin trial allows you to use `SharedArrayBuffer` objects in pages that aren't cross-origin isolated.  A _cross-origin isolated_ page is a page that's not be able to load cross-origin content unless the resource explicitly allows it via a Cross-Origin-Resource-Policy header or CORS headers.
 
 * [Explainer](https://developer.chrome.com/blog/enabling-shared-array-buffer/)
 * [Feedback](https://bugs.chromium.org/p/chromium/issues/entry?components=Internals%3ESandbox%3ESiteIsolation)


### PR DESCRIPTION
Related PRs:
* #3789
* #3786 

Rendered article sections for review:

* **Microsoft Edge 149 web platform release notes (Jun. 2026)**
   * `/web-platform/release-notes/149.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/149?branch=pr-en-us-3786
   * External preview: 
   * Planned live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/149
   * New article.

* **Microsoft Edge 148 web platform release notes (May 2026)**
   * `/web-platform/release-notes/148.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/148?branch=pr-en-us-3786
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/148
   * Removed sections:
      * **Reuse `no-store` images when same `src` is reassigned**
      * **WebSocket disconnection on bfcache entry**

* **Microsoft Edge 147 web platform release notes (Apr. 2026)**
   * `/web-platform/release-notes/147.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/147?branch=pr-en-us-3786
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/147
   * Linked to specific page **What's new in DevTools (Microsoft Edge 147)**.

* TOC
   * `toc.yml`
   * Added 149.
   * Archived 139.

AB#62083369
