### PR TITLE
Add "Detect language & translate text" in RelNotes 148

### DIFF
--- a/microsoft-edge/web-platform/release-notes/148.md
+++ b/microsoft-edge/web-platform/release-notes/148.md
@@ -454,7 +454,7 @@ Use the Prompt API to:
 * Discover innovative ways to integrate prompt-engineering capabilities into your web app.
 
 See also:
-* [Prompt API](#prompt-api), above.
+* [Prompt a built-in language model with the Prompt API](../prompt-api.md).
 
 Information about this origin trial:
 * [Explainer](https://github.com/webmachinelearning/prompt-api/blob/main/README.md)

--- a/microsoft-edge/web-platform/release-notes/148.md
+++ b/microsoft-edge/web-platform/release-notes/148.md
@@ -311,11 +311,11 @@ See also:
 
 The Language Detector API detects the language of text, and the Translator API translates text between different languages.
 
-Both APIs run on-device, providing reduced cost, network independence, and improved privacy compared to cloud-based solutions.  The APIs use machine learning models that are built into Microsoft Edge, and can be used from JavaScript code in your website or browser extension.
+Both APIs run on-device, providing reduced cost, network independence, and improved privacy, compared to cloud-based solutions.  The APIs use machine learning models that are built into Microsoft Edge, and can be used from JavaScript code in your website or browser extension.
 
 See also:
-* [Detect languages with the Language Detector API](../languagedetector-api.md).
-* [Translate text with the Translator API](../translator-api.md).
+* [Detect languages with the Language Detector API](../languagedetector-api.md)
+* [Translate text with the Translator API](../translator-api.md)
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/web-platform/release-notes/148.md
+++ b/microsoft-edge/web-platform/release-notes/148.md
@@ -32,8 +32,8 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Manifest localization](#manifest-localization)
   * [Support for avar2 in OpenType font format](#support-for-avar2-in-opentype-font-format)
   * [Pointer event suppression on drag start](#pointer-event-suppression-on-drag-start)
-  * [Prompt API](#prompt-api)
   * [Reuse `no-store` images when same `src` is reassigned](#reuse-no-store-images-when-same-src-is-reassigned)
+  * [Detect language and translate text](#detect-language-and-translate-text)
   * [Web Authentication Immediate UI mode](#web-authentication-immediate-ui-mode)
   * [WebGPU `linear_indexing` feature](#webgpu-linear_indexing-feature)
   * [WebSocket disconnection on bfcache entry](#websocket-disconnection-on-bfcache-entry)
@@ -42,7 +42,7 @@ To stay up-to-date and get the latest web platform features, download a preview 
   * [Writer API](#writer-api)
   * [Rewriter API](#rewriter-api)
   * [Proofreader API](#proofreader-api)
-  * [Prompt API](#prompt-api-1)
+  * [Prompt API](#prompt-api)
   * [WebGPU Compatibility Mode](#webgpu-compatibility-mode)
   * [Extended lifetime for Shared Workers](#extended-lifetime-for-shared-workers)
   * [SharedArrayBuffers in non-isolated pages on Desktop platforms](#sharedarraybuffers-in-non-isolated-pages-on-desktop-platforms)
@@ -293,32 +293,6 @@ See also:
 
 
 <!-- ------------------------------ -->
-#### Prompt API
-
-The Prompt API provides direct access to a browser-provided on-device AI language model.  The API design offers fine-grained control for progressively enhancing sites with model interactions tailored to individualized use cases.
-
-The Prompt API complements task-based language model APIs (such as the Summarizer API), and varied APIs and frameworks for generalized on-device inference using developer-supplied ML models.
-
-The initial implementation supports:
-* Text inputs.
-* Image inputs.
-* Audio inputs.
-* Response constraints that ensure that the generated text conforms with predefined regex and JSON schema formats.
-
-Use the Prompt API for:
-* Generating image captions.
-* Performing visual searches.
-* Transcribing audio.
-* Classifying sound events.
-* Generating text by following specific instructions.
-* Extracting information or insights from multimodal source material.
-
-See also:
-* [Prompt a built-in language model with the Prompt API](../prompt-api.md)
-* [Origin trials > Prompt API](#prompt-api-1), below.
-
-
-<!-- ------------------------------ -->
 #### Reuse `no-store` images when same `src` is reassigned
 
 When you reassign the same `src` value to an `<img>` element, the browser now reuses the already-decoded image from the document, even if the image was served with `Cache-Control: no-store`.  This avoids an unnecessary network re-fetch and improves performance.
@@ -330,6 +304,18 @@ This web interoperability fix aligns Microsoft Edge with Firefox and Safari.
 See also:
 * [\<img\>: The Image Embed element](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/img) at MDN.
 * [Cache-Control header](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Cache-Control) at MDN.
+
+
+<!-- ------------------------------ -->
+#### Detect language and translate text
+
+The Language Detector API detects the language of text, and the Translator API translates text between different languages.
+
+Both APIs run on-device, providing reduced cost, network independence, and improved privacy compared to cloud-based solutions.  The APIs use machine learning models that are built into Microsoft Edge, and can be used from JavaScript code in your website or browser extension.
+
+See also:
+* [Detect languages with the Language Detector API](../languagedetector-api.md).
+* [Translate text with the Translator API](../translator-api.md).
 
 
 <!-- ------------------------------ -->


### PR DESCRIPTION
Rendered article sections for review:

* **Microsoft Edge 148 web platform release notes (May 2026)**
   * `/web-platform/release-notes/148.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/148?branch=pr-en-us-3787#detect-language-and-translate-text
   * External preview: 
   * Planned live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/148#detect-language-and-translate-text
   * Removed one of the **Prompt API** sections.
   * Added section: **Detect language and translate text**

AB#62126665
