### PR TITLE
Summarizer API no longer in Preview

### DIFF
--- a/microsoft-edge/web-platform/release-notes/138.md
+++ b/microsoft-edge/web-platform/release-notes/138.md
@@ -148,18 +148,18 @@ See also:
 <!-- ---------- -->
 ###### Prompt and Writing Assistance API developer previews
 
-The Prompt API is now available as developer previews in Edge Canary and Dev channels.
+The Prompt API is now available as a developer preview in Edge Canary and Dev channels.
 
 The following Writing Assistance APIs are now available as developer previews in Edge Canary and Dev channels:
 * Writer API
 * Rewriter API
 
+Starting with Microsoft Edge 138, the following Writing Assistance API shipped normally; it's available to all developers, and is no longer a developer preview:
+* Summarizer API
+
 These APIs give you access to a powerful small language model, Phi-4-mini, that is built into the Edge browser.
 
 Use these APIs to try out prompt engineering, summarize and modify content, or generate text.
-
-The following Writing Assistance API shipped normally; it's available to all developers:
-* Summarizer API
 
 See also:
 * [Prompt a built-in language model with the Prompt API](../prompt-api.md)

--- a/microsoft-edge/web-platform/release-notes/138.md
+++ b/microsoft-edge/web-platform/release-notes/138.md
@@ -148,11 +148,18 @@ See also:
 <!-- ---------- -->
 ###### Prompt and Writing Assistance API developer previews
 
-The Prompt API and Writing Assistance APIs are now available as developer previews in Edge Canary and Dev channels.
+The Prompt API is now available as developer previews in Edge Canary and Dev channels.
+
+The following Writing Assistance APIs are now available as developer previews in Edge Canary and Dev channels:
+* Writer API
+* Rewriter API
 
 These APIs give you access to a powerful small language model, Phi-4-mini, that is built into the Edge browser.
 
 Use these APIs to try out prompt engineering, summarize and modify content, or generate text.
+
+The following Writing Assistance API shipped normally; it's available to all developers:
+* Summarizer API
 
 See also:
 * [Prompt a built-in language model with the Prompt API](../prompt-api.md)

--- a/microsoft-edge/web-platform/writing-assistance-apis.md
+++ b/microsoft-edge/web-platform/writing-assistance-apis.md
@@ -48,7 +48,9 @@ For introductory information about the Summarizer API, Writer API, and Rewriter 
 <!-- ====================================================================== -->
 ## Availability of the Writing Assistance APIs
 
-The Summarizer, Writer, and Rewriter APIs are available as a developer preview in Microsoft Edge Canary or Dev channels, starting with version 138.0.3309.2.
+The Writer API and the Rewriter APIs are available as a developer preview in Microsoft Edge Canary or Dev channels, starting with version 138.0.3309.2.
+
+The Summarizer API has been enabled by default since Microsoft Edge 138.
 
 The Writing Assistance APIs are optimized for tasks specific to generating, modifying, and summarizing text content.  To learn more about an alternative for more custom prompt engineering scenarios that may not be served by these APIs, see [Prompt a built-in language model with the Prompt API](./prompt-api.md).
 
@@ -119,7 +121,7 @@ An initial download of the model will be required the first time a website calls
 <!-- ====================================================================== -->
 ## Enable the Writing Assistance APIs
 
-To use any of the Writing Assistance APIs in Microsoft Edge:
+To use the Writer API or the Rewriter API in Microsoft Edge:
 
 1. Make sure you're using the latest version of Microsoft Edge Canary or Dev (version 138.0.3309.2 or newer).  See [Become a Microsoft Edge Insider](https://www.microsoft.com/edge/download/insider).
 
@@ -127,11 +129,12 @@ To use any of the Writing Assistance APIs in Microsoft Edge:
 
 1. In the search box, at the top of the page:
 
-   * To enable the Summarizer API, enter **Summarization API for Phi mini**.
    * To enable the Writer API, enter **Writer API for Phi mini**.
    * To enable the Rewriter API, enter **Rewriter API for Phi mini**.
 
    The page is filtered to show the matching flag.
+
+   (Starting with Microsoft Edge 138, the Summarizer API is enabled by default.  Prior to Microsoft Edge 138, to enable the Summarizer API, you had to enable the Summarizer API by entering **Summarization API for Phi mini** here.)
 
 1. Select **Enabled** next to the flag for the API you want to enable:
 


### PR DESCRIPTION
Rendered article sections for review:

* **Microsoft Edge 138 web platform release notes (Jun. 2025)** > **Prompt and Writing Assistance API developer previews**
   * `/web-platform/release-notes/138.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/release-notes/138?branch=pr-en-us-3804#prompt-and-writing-assistance-api-developer-previews
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/release-notes/138#prompt-and-writing-assistance-api-developer-previews
   * Separated discussion of Summarizer API (not Preview) from discussion of the other Writing Assistance APIs: Writer API & Rewriter API (in Preview).

* **Summarize, write, and rewrite text with the Writing Assistance APIs** > **Availability of the Writing Assistance APIs**, & **Enable the Writing Assistance APIs**
   * `/web-platform/writing-assistance-apis.md`
   * Internal preview: 
      * https://review.learn.microsoft.com/microsoft-edge/web-platform/writing-assistance-apis?branch=pr-en-us-3804#availability-of-the-writing-assistance-apis
      * https://review.learn.microsoft.com/microsoft-edge/web-platform/writing-assistance-apis?branch=pr-en-us-3804#enable-the-writing-assistance-apis
   * External preview: 
   * Before/live: 
      * https://learn.microsoft.com/microsoft-edge/web-platform/writing-assistance-apis#availability-of-the-writing-assistance-apis
      * https://learn.microsoft.com/microsoft-edge/web-platform/writing-assistance-apis##enable-the-writing-assistance-apis
   * Separated discussion of Summarizer API (not Preview) from discussion of the other Writing Assistance APIs: Writer API & Rewriter API (in Preview).

AB#62327601
