### PR TITLE
Add msAbydosForWindowlessWV2 feature flag

### DIFF
--- a/microsoft-edge/develop-web-microsoft-edge.md
+++ b/microsoft-edge/develop-web-microsoft-edge.md
@@ -177,9 +177,9 @@ The following sections are tips for using the Microsoft Learn website.
 <!-- ====================================================================== -->
 ## View end-user docs about Microsoft Edge
 
-Microsoft Edge Developer docs are at the Microsoft Learn website.  Microsoft Edge end-user docs are at the following, other websites:
+Microsoft Edge Developer docs are at the present, Microsoft Learn website (learn.microsoft.com).  Microsoft Edge end-user docs are at the following, other websites:
 
-* [Microsoft Edge help & learning](https://support.microsoft.com/microsoft-edge) - Support.microsoft.com.
+* [Microsoft Edge help & learning](https://support.microsoft.com/microsoft-edge) - support.microsoft.com.
 * [Do More with Edge](https://www.microsoft.com/edge/learning-center/) - Learning center at Microsoft.com.
 
 See also:

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -124,7 +124,8 @@ If the flag takes a value other than true|false, give an example. -->
 | `long-animation-frame-timing` |  Provides detailed timing for long animation frames, which are frames exceeding the standard 16.67ms duration (60fps).  This helps during debugging and performance analysis, to identify and optimize performance bottlenecks for animation-heavy applications. |
 | `msAbydos` | Enables the "handwriting-to-text" experience. |
 | `msAbydosGestureSupport` | Allows users to use gestures (such as the scratchout gesture) to delete text by using a pen.  Valid only if the `msAbydos` flag is enabled. |
-| `msAbydosHandwritingAttr` | Whether the "handwriting-to-text" experience is enabled for input elements at the DOM level.  Valid only if the `msAbydos` flag is enabled. |
+| `msAbydosHandwritingAttr` | Whether the "handwriting-to-text" experience is enabled for input elements at the DOM level.  Valid only if the `msAbydos` flag is enabled.|
+| `msAbydosForWindowlessWV2` | Enables ShellHandwriting (Windows Shell Handwriting) functionality in Window to Visual hosting mode.  See also [Windowed vs. Visual hosting of WebView2](./windowed-vs-visual-hosting.md). |
 | `msAllowAmbientAuthInPrivateWebView2` | This flag is to be used along with the `msSingleSignOnForInPrivateWebView2` browser flag, to enable single sign-on (SSO) with default credential flow or ambient authentication flow. |
 | `msEdgeDesignerDriverFix` | Enables getting content and automatically showing the Designer feature.  The Designer feature is not supported in WebView2. |
 | `msEdgeDesignerUI` | Enables the Designer Shoreline App.  The Designer Shoreline App is not supported in WebView2. |

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 02/02/2026
+ms.date: 05/21/2026
 ---
 # WebView2 browser flags
 <!-- lexicon:
@@ -124,8 +124,8 @@ If the flag takes a value other than true|false, give an example. -->
 | `long-animation-frame-timing` |  Provides detailed timing for long animation frames, which are frames exceeding the standard 16.67ms duration (60fps).  This helps during debugging and performance analysis, to identify and optimize performance bottlenecks for animation-heavy applications. |
 | `msAbydos` | Enables the "handwriting-to-text" experience. |
 | `msAbydosGestureSupport` | Allows users to use gestures (such as the scratchout gesture) to delete text by using a pen.  Valid only if the `msAbydos` flag is enabled. |
-| `msAbydosHandwritingAttr` | Whether the "handwriting-to-text" experience is enabled for input elements at the DOM level.  Valid only if the `msAbydos` flag is enabled.|
-| `msAbydosForWindowlessWV2` | Enables ShellHandwriting (Windows Shell Handwriting) functionality in Window to Visual hosting mode.  See also [Windowed vs. Visual hosting of WebView2](./windowed-vs-visual-hosting.md). |
+| `msAbydosHandwritingAttr` | Whether the "handwriting-to-text" experience is enabled for input elements at the DOM level.  Valid only if the `msAbydos` flag is enabled. |
+| `msAbydosForWindowlessWV2` | Enables ShellHandwriting (Windows Shell Handwriting) functionality in Window to Visual hosting mode.  Valid only if the `msAbydos` flag is enabled.  See also [Windowed vs. Visual hosting of WebView2](./windowed-vs-visual-hosting.md). |
 | `msAllowAmbientAuthInPrivateWebView2` | This flag is to be used along with the `msSingleSignOnForInPrivateWebView2` browser flag, to enable single sign-on (SSO) with default credential flow or ambient authentication flow. |
 | `msEdgeDesignerDriverFix` | Enables getting content and automatically showing the Designer feature.  The Designer feature is not supported in WebView2. |
 | `msEdgeDesignerUI` | Enables the Designer Shoreline App.  The Designer Shoreline App is not supported in WebView2. |

--- a/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
+++ b/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
@@ -72,21 +72,21 @@ For a list of APIs that can be used when configuring WebView2 for Windowed hosti
 
 
 <!-- ====================================================================== -->
-## Window to Visual hosting: For a similar experience as Windowed hosting, with added benefits and tradeoff
+## Window to Visual hosting: For a similar experience as Windowed hosting, with added benefits
 
-_Window-to-Visual hosting_ means that the WebView2 content is outputted to a Visual that is hosted in an HWND, rather than outputting content to a window directly or to a Visual directly.  By hosting content in an HWND, Window to Visual hosting is easy to use, in the same ways as Windowed hosting.  But by displaying content by using a Visual, Window-to-Visual hosting avoids some DPI and input issues that can result when using Windowed hosting.
+_Window to Visual hosting_ means that the WebView2 content is outputted to a Visual that is hosted in an HWND, rather than outputting content to a window directly or to a Visual directly.  By hosting content in an HWND, Window to Visual hosting is easy to use, in the same ways as Windowed hosting.  But by displaying content by using a Visual, Window to Visual hosting avoids some DPI and input issues that can result when using Windowed hosting.
+
+In Window to Visual hosting and Visual hosting, a _Visual_ is a basic graphical unit that can be used to compose graphical experiences on Windows. The Windows graphics APIs that expose this functionality and are relevant to WebView2 are `DirectComposition` and `Windows.UI.Composition`. The "Visual" in "Visual hosting" can be any one of `IDCompositionVisual`, `IDCompositionTarget`, or `Windows.UI.Composition.Visual`, which are Visuals that are exposed through the `DirectComposition` and `Windows.UI.Composition` APIs.  (Window to Visual hosting uses `IDCompositionVisual` specifically.)  See:
+* [Basic concepts](/windows/win32/directcomp/basic-concepts) in the Windows App Development > DirectComposition docs.
+* [Composition visual](/windows/uwp/composition/composition-visual-tree) in the Windows App Development > UWP docs.
 
 Window to Visual hosting doesn't require you to use the WebView2 Visual hosting APIs.
 
 To enable Window to Visual hosting, the environment variable `COREWEBVIEW2_FORCED_HOSTING_MODE` must be set to the value `COREWEBVIEW2_HOSTING_MODE_WINDOW_TO_VISUAL` before initializing your WebView2.
 
-In Window-to-Visual hosting and Visual hosting, a _Visual_ is a basic graphical unit that can be used to compose graphical experiences on Windows. The Windows graphics APIs that expose this functionality and are relevant to WebView2 are `DirectComposition` and `Windows.UI.Composition`. The "Visual" in "Visual hosting" can be any one of `IDCompositionVisual`, `IDCompositionTarget`, or `Windows.UI.Composition.Visual`, which are Visuals that are exposed through the `DirectComposition` and `Windows.UI.Composition` APIs.  (Window to Visual hosting uses `IDCompositionVisual` specifically.)  See:
-* [Basic concepts](/windows/win32/directcomp/basic-concepts) in the Windows App Development > DirectComposition docs.
-* [Composition visual](/windows/uwp/composition/composition-visual-tree) in the Windows App Development > UWP docs.
-
 
 <!-- ------------------------------ -->
-#### Advantages
+#### Capabilities and benefits of Window to Visual hosting
 
 * Different apps that share a WebView2 user data folder can have different DPI awareness.
 
@@ -96,16 +96,10 @@ In Window-to-Visual hosting and Visual hosting, a _Visual_ is a basic graphical 
 
 * When hosting a WebView2 in a VSTO Add-in, changing monitor scale won't potentially cause the app to hang. See [VSTO Add-ins](/visualstudio/vsto/office-solutions-development-overview-vsto#vsto-add-ins) in _Office solutions development overview (VSTO)_.
 
-
-<!-- ------------------------------ -->
-#### Disadvantages
-
-Enabling Window to Visual hosting mode removes support for Windows Shell Handwriting within the WebView2.
-<!-- todo: true, given new flag msAbydosForWindowlessWV2? -->
-
-See also:
-* [Ink input](/windows/win32/input_ink/input-ink-portal) - Windows App Development > User Interaction.
-* [shellhandwriting.h header](/windows/win32/api/shellhandwriting/) - Win32 API.
+* Window to Visual hosting mode supports Windows Shell Handwriting within the WebView2, by setting the `msAbydosForWindowlessWV2` flag.  See also:
+   * [WebView2 browser flags](./webview-features-flags.md)
+   * [Ink input](/windows/win32/input_ink/input-ink-portal) - Windows App Development > User Interaction.
+   * [shellhandwriting.h header](/windows/win32/api/shellhandwriting/) - Win32 API.
 
 
 <!-- ------------------------------ -->

--- a/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
+++ b/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
@@ -24,7 +24,7 @@ The different approaches for hosting the WebView2 control in your app are simila
 | Approach | Description | Optimized for |
 |---|---|---|
 | Windowed hosting | The WebView2 control takes input from the operating system (OS).  The OS sends the input to the WebView2. | Displaying web content quickly and easily, without having to include features for inputs, outputs, and accessibility. |
-| Window to Visual hosting | A combination of Windowed and Visual hosting. Similar to Windowed hosting except that WebView2 content is output to a Visual that is hosted in a window rather having content output to the window directly. | A developer experience nearly identical to Windowed hosting, but with improved DPI/scaling handling and the caveat that the Windows Shell Handwriting experience is unsupported. |
+| Window to Visual hosting | A combination of Windowed and Visual hosting. Similar to Windowed hosting except that WebView2 content is output to a Visual that is hosted in a window rather having content output to the window directly. | A developer experience nearly identical to Windowed hosting, but with improved DPI/scaling handling. |
 | Visual hosting | Your host app takes spatial input (such as mouse or touch input) from the user.  Your app sends this input to the WebView2 control. | More granular control over control composition.  The app needs to do specific handling of window management and rendering APIs. |
 
 These approaches have different requirements, constraints, and benefits.
@@ -80,13 +80,13 @@ In Window to Visual hosting and Visual hosting, a _Visual_ is a basic graphical 
 * [Basic concepts](/windows/win32/directcomp/basic-concepts) in the Windows App Development > DirectComposition docs.
 * [Composition visual](/windows/uwp/composition/composition-visual-tree) in the Windows App Development > UWP docs.
 
-Window to Visual hosting doesn't require you to use the WebView2 Visual hosting APIs.
-
 To enable Window to Visual hosting, the environment variable `COREWEBVIEW2_FORCED_HOSTING_MODE` must be set to the value `COREWEBVIEW2_HOSTING_MODE_WINDOW_TO_VISUAL` before initializing your WebView2.
 
 
 <!-- ------------------------------ -->
 #### Capabilities and benefits of Window to Visual hosting
+
+* Window to Visual hosting doesn't require you to use the WebView2 Visual hosting APIs.
 
 * Different apps that share a WebView2 user data folder can have different DPI awareness.
 
@@ -176,6 +176,7 @@ See also:
 <!-- all links in article, except api ref docs -->
 
 * [Overview of WebView2 APIs](./overview-features-apis.md)
+* [WebView2 browser flags](./webview-features-flags.md) - covers `msAbydosForWindowlessWV2`.
 <!-- omit:
 * [Enhance UI with the Visual layer (Windows App SDK/WinUI 3)](https://learn.microsoft.com/windows/apps/windows-app-sdk/composition) - Windows App Development. -->
 

--- a/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
+++ b/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting.md
@@ -101,6 +101,7 @@ In Window-to-Visual hosting and Visual hosting, a _Visual_ is a basic graphical 
 #### Disadvantages
 
 Enabling Window to Visual hosting mode removes support for Windows Shell Handwriting within the WebView2.
+<!-- todo: true, given new flag msAbydosForWindowlessWV2? -->
 
 See also:
 * [Ink input](/windows/win32/input_ink/input-ink-portal) - Windows App Development > User Interaction.


### PR DESCRIPTION
Rendered article sections for review:

* **WebView2 browser flags** > **Available WebView2 browser flags**
   * `/webview2/concepts/webview-features-flags.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags?branch=pr-en-us-3807#available-webview2-browser-flags
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags#available-webview2-browser-flags
   * Added row for `msAbydosForWindowlessWV2` feature flag, to enable Windows Shell Handwriting functionality in Window-to-Visual hosting mode (WebView2).

* **Windowed vs. Visual hosting of WebView2** > **Window to Visual hosting: For a similar experience as Windowed hosting, with added benefits and tradeoff** > **Disadvantages**
   * `/webview2/concepts/windowed-vs-visual-hosting.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting?branch=pr-en-us-3807#disadvantages-1
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting#disadvantages-1
     Became:
   https://learn.microsoft.com/microsoft-edge/webview2/concepts/windowed-vs-visual-hosting#capabilities-and-benefits-of-window-to-visual-hosting
   * Updated statement "Enabling Window to Visual hosting mode removes support for Windows Shell Handwriting within the WebView2."

* **Develop for the web with Microsoft Edge** > **View end-user docs about Microsoft Edge**
   * `/develop-web-microsoft-edge.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/develop-web-microsoft-edge?branch=pr-en-us-3807#view-end-user-docs-about-microsoft-edge
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/develop-web-microsoft-edge#view-end-user-docs-about-microsoft-edge
   * Clarified that LMC is the present website.

AB#62436812
