### PR TITLE
RelNotes for WebView2 SDK 150 (Jul. 2026)

### DIFF
--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -36,7 +36,7 @@
           # /web-platform/release-notes/index.md - add new relnotes page, remove earliest relnotes page
         - name: Microsoft Edge 151
           href: ./web-platform/release-notes/151.md
-          displayName: Microsoft Edge 151 web platform release notes (Aug. 2026)  # page title
+          displayName: Microsoft Edge 151 web platform release notes (Jul. 2026)  # page title
 
         - name: Microsoft Edge 150
           href: ./web-platform/release-notes/150.md

--- a/microsoft-edge/web-platform/release-notes/138.md
+++ b/microsoft-edge/web-platform/release-notes/138.md
@@ -57,7 +57,7 @@ See [What's new in DevTools (Microsoft Edge 138)](../../devtools/whats-new/2025/
 <!-- ====================================================================== -->
 ## WebView2
 
-See [Release SDK 1.0.3351.48, for Runtime 138 (Jul. 1, 2025)](../../webview2/release-notes/index.md#release-sdk-10335148-for-runtime-138-jul-1-2025) in _Release notes for the WebView2 SDK_.
+See [Release SDK 1.0.3351.48, for Runtime 138 (Jul. 1, 2025)](../../webview2/release-notes/archive.md#release-sdk-10335148-for-runtime-138-jul-1-2025) in _Archived release notes for the WebView2 SDK_.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/archive.md
+++ b/microsoft-edge/webview2/release-notes/archive.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: devtools
-ms.date: 06/11/2026
+ms.date: 07/06/2026
 ---
 # Archived release notes for the WebView2 SDK
 <!--
@@ -21,6 +21,120 @@ if change h2 headings pattern, enter work item: update links in announcements
 <!-- todo: update links in announcements -->
 
 The following features and bug fixes are in the WebView2 Release SDK and Prerelease SDK, for SDKs over one year old.
+
+
+<!-- ====================================================================== -->
+## Release SDK 1.0.3351.48, for Runtime 138 (Jul. 1, 2025)
+
+Release Date: Jul. 1, 2025
+
+[NuGet package for WebView2 SDK 1.0.3351.48](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.3351.48)
+
+For full API compatibility, this Release version of the WebView2 SDK requires WebView2 Runtime version 138.0.3351.48 or later.
+
+
+<!-- ------------------------------ -->
+#### Promotions to Phase 3 (Stable in Release)
+
+The following APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, and are now included in this Release SDK.
+
+
+<!-- ---------- -->
+###### Allow input event messages to pass through the browser window
+
+The `CoreWebView2ControllerOptions` class now has an `AllowHostInputProcessing` property, which allows user input event messages (keyboard, mouse, touch, or pen) to pass through the browser window, to be received by an app process window.
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* `CoreWebView2ControllerOptions` Class:
+   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.allowhostinputprocessing?view=webview2-dotnet-1.0.3351.48&preserve-view=true)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* `CoreWebView2ControllerOptions` Class:
+   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.3351.48&preserve-view=true#allowhostinputprocessing)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2ControllerOptions4](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3351.48&preserve-view=true)
+   * [ICoreWebView2ControllerOptions4::get_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3351.48&preserve-view=true#get_allowhostinputprocessing)
+   * [ICoreWebView2ControllerOptions4::put_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3351.48&preserve-view=true#put_allowhostinputprocessing)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Bug fixes
+
+
+<!-- ---------- -->
+###### Runtime-only
+
+* Fixed a blackbox issue on dialogs in visual hosting.
+
+<!-- end of Release SDK 1.0.3351.48, for Runtime 138 (Jul. 1, 2025) -->
+
+
+<!-- ====================================================================== -->
+## Prerelease SDK 1.0.3344-prerelease, for Runtime 138 (Jun. 3, 2025)
+
+Release Date: Jun. 3, 2025
+
+[NuGet package for WebView2 SDK 1.0.3344-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.3344-prerelease)
+
+For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 138.0.3344.0 or later.
+
+
+<!-- ------------------------------ -->
+#### Experimental APIs (Phase 1: Experimental in Prerelease)
+
+No Experimental APIs have been added in this Prerelease SDK.
+
+
+<!-- ------------------------------ -->
+#### Promotions to Phase 2 (Stable in Prerelease)
+
+The following APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, and are included in this Prerelease SDK.
+
+
+<!-- ---------- -->
+###### Allow input event messages to pass through the browser window
+
+The `CoreWebView2ControllerOptions` class now has an `AllowHostInputProcessing` property, which allows user input event messages (keyboard, mouse, touch, or pen) to pass through the browser window, to be received by an app process window.
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* `CoreWebView2ControllerOptions` Class:
+   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.allowhostinputprocessing?view=webview2-dotnet-1.0.3344-prerelease&preserve-view=true)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* `CoreWebView2ControllerOptions` Class:
+   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.3344-prerelease&preserve-view=true#allowhostinputprocessing)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2ControllerOptions4](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3344-prerelease&preserve-view=true)
+   * [ICoreWebView2ControllerOptions4::get_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3344-prerelease&preserve-view=true#get_allowhostinputprocessing)
+   * [ICoreWebView2ControllerOptions4::put_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3344-prerelease&preserve-view=true#put_allowhostinputprocessing)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Bug fixes
+
+
+<!-- ---------- -->
+###### Runtime-only
+
+* Fixed a bug where a mouse event doesn't fire after a touch event.
+* Disabled Web capture on the WebView2 control.
+* Fixed the **Downloads** dialog.
+* Fixed an issue with downloads in the default browser frame.  ([Issue #5196](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5196))
+* Fixed the margins in the printed PDF.
+
+<!-- end of Prerelease SDK 1.0.3344-prerelease, for Runtime 138 (Jun. 3, 2025) -->
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/archive.md
+++ b/microsoft-edge/webview2/release-notes/archive.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: devtools
-ms.date: 07/06/2026
+ms.date: 07/07/2026
 ---
 # Archived release notes for the WebView2 SDK
 <!--

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -29,7 +29,7 @@ The following new features and bug fixes are in the WebView2 Release SDK and Pre
 
 
 <!-- ====================================================================== -->
-## Prerelease SDK 1.0.4126-prerelease, for Runtime 150 (Jul. 6, 2026)
+## Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 6, 2026)
 
 Release Date: Jul. 6, 2026
 
@@ -128,7 +128,7 @@ This Prerelease SDK includes the following bug fixes.
 * Fixed a regression in the `AddScriptToExecuteOnDocumentCreated` API.
 * Implemented `OnRendererResponsive` for hang outcome tracking.
 
-<!-- end of Prerelease SDK 1.0.4126-prerelease, for Runtime 150 (Jul. 6, 2026) -->
+<!-- end of Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 6, 2026) -->
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 06/11/2026
+ms.date: 07/06/2026
 ---
 # Release notes for the WebView2 SDK
 <!--
@@ -26,6 +26,180 @@ todo: update links in announcements, since the Prerelease headings & Release hea
 -->
 
 The following new features and bug fixes are in the WebView2 Release SDK and Prerelease SDK, for SDKs during the past year.
+
+
+<!-- ====================================================================== -->
+## Prerelease SDK 1.0.nnnn-prerelease, for Runtime 151 (Jul. 6, 2026)
+
+Release Date: Mmm. dd, yyyy
+
+[NuGet package for WebView2 SDK 1.0.####-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.####-prerelease)
+
+For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version ###.0.####.0 or later.
+
+
+<!-- ------------------------------ -->
+#### Breaking changes
+<!-- omit section if empty; usually empty -->
+
+
+<!-- ---------- -->
+###### heading
+
+
+<!-- ------------------------------ -->
+#### General changes
+<!-- omit section if empty; usually empty -->
+
+
+<!-- ---------- -->
+###### heading
+
+
+<!-- ------------------------------ -->
+#### Experimental APIs (Phase 1: Experimental in Prerelease)
+
+No Experimental APIs have been added in this Prerelease SDK.
+The following APIs are in Phase 1: Experimental in Prerelease, and have been added in this Prerelease SDK.
+
+
+<!-- ---------- -->
+###### heading
+
+description
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+##### [Win32/C++](#tab/win32cpp)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Promotions to Phase 2 (Stable in Prerelease)
+
+No APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, in this Prerelease SDK.
+The following APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, and are included in this Prerelease SDK.
+The following APIs skipped Phase 1: Experimental in Prerelease, and have been directly added to Phase 2: Stable in Prerelease, and are included in this Prerelease SDK.
+
+
+<!-- ---------- -->
+###### heading
+
+description
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+##### [Win32/C++](#tab/win32cpp)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Bug fixes
+
+There are no bug fixes in this Prerelease SDK.
+This Prerelease SDK includes the following bug fixes.
+
+
+<!-- ---------- -->
+###### Runtime and SDK
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### Runtime-only
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### SDK-only
+
+* Fixed behavior.  ([Issue #]())
+
+<!-- end of Prerelease SDK 1.0.nnnn-prerelease, for Runtime 151 (Jul. 6, 2026) -->
+
+
+<!-- ====================================================================== -->
+## Release SDK 1.0.nnnn.nn, for Runtime 150 (Jul. 6, 2026)
+
+Release Date: Mmm. dd, yyyy
+
+[NuGet package for WebView2 SDK 1.0.####.##](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.####.##)
+
+For full API compatibility, this Release version of the WebView2 SDK requires WebView2 Runtime version ###.0.####.## or later.
+
+
+<!-- ------------------------------ -->
+#### Breaking changes
+<!-- omit section if empty; usually empty -->
+
+
+<!-- ---------- -->
+###### heading
+
+
+<!-- ------------------------------ -->
+#### General changes
+<!-- omit section if empty; usually empty -->
+
+
+<!-- ---------- -->
+###### heading
+
+
+<!-- ------------------------------ -->
+#### Promotions to Phase 3 (Stable in Release)
+
+No additional APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, in this Release SDK.
+The following APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, and are now included in this Release SDK.
+
+
+<!-- ---------- -->
+###### heading
+
+description
+
+##### [.NET/C#](#tab/dotnetcsharp)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+##### [Win32/C++](#tab/win32cpp)
+
+---
+
+
+<!-- ------------------------------ -->
+#### Bug fixes
+
+There are no bug fixes in this Release SDK.
+This Release SDK includes the following bug fixes.
+
+
+<!-- ---------- -->
+###### Runtime and SDK
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### Runtime-only
+
+* Fixed behavior.  ([Issue #]())
+
+
+<!-- ---------- -->
+###### SDK-only
+
+* Fixed behavior.  ([Issue #]())
+
+<!-- end of Release SDK 1.0.nnnn.nn, for Runtime 150 (Jul. 6, 2026) -->
 
 
 <!-- ====================================================================== -->
@@ -2829,120 +3003,6 @@ We're actively investigating these issues, and we encourage you to report any pr
 * Fixed a crash in Devtools on Windows Server and Windows 10.
 
 <!-- end of Release SDK 1.0.3405.78, for Runtime 139 (Aug. 11, 2025) -->
-
-
-<!-- ====================================================================== -->
-## Release SDK 1.0.3351.48, for Runtime 138 (Jul. 1, 2025)
-
-Release Date: Jul. 1, 2025
-
-[NuGet package for WebView2 SDK 1.0.3351.48](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.3351.48)
-
-For full API compatibility, this Release version of the WebView2 SDK requires WebView2 Runtime version 138.0.3351.48 or later.
-
-
-<!-- ------------------------------ -->
-#### Promotions to Phase 3 (Stable in Release)
-
-The following APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, and are now included in this Release SDK.
-
-
-<!-- ---------- -->
-###### Allow input event messages to pass through the browser window
-
-The `CoreWebView2ControllerOptions` class now has an `AllowHostInputProcessing` property, which allows user input event messages (keyboard, mouse, touch, or pen) to pass through the browser window, to be received by an app process window.
-
-##### [.NET/C#](#tab/dotnetcsharp)
-
-* `CoreWebView2ControllerOptions` Class:
-   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.allowhostinputprocessing?view=webview2-dotnet-1.0.3351.48&preserve-view=true)
-
-##### [WinRT/C#](#tab/winrtcsharp)
-
-* `CoreWebView2ControllerOptions` Class:
-   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.3351.48&preserve-view=true#allowhostinputprocessing)
-
-##### [Win32/C++](#tab/win32cpp)
-
-* [ICoreWebView2ControllerOptions4](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3351.48&preserve-view=true)
-   * [ICoreWebView2ControllerOptions4::get_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3351.48&preserve-view=true#get_allowhostinputprocessing)
-   * [ICoreWebView2ControllerOptions4::put_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3351.48&preserve-view=true#put_allowhostinputprocessing)
-
----
-
-
-<!-- ------------------------------ -->
-#### Bug fixes
-
-
-<!-- ---------- -->
-###### Runtime-only
-
-* Fixed a blackbox issue on dialogs in visual hosting.
-
-<!-- end of Release SDK 1.0.3351.48, for Runtime 138 (Jul. 1, 2025) -->
-
-
-<!-- ====================================================================== -->
-## Prerelease SDK 1.0.3344-prerelease, for Runtime 138 (Jun. 3, 2025)
-
-Release Date: Jun. 3, 2025
-
-[NuGet package for WebView2 SDK 1.0.3344-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.3344-prerelease)
-
-For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 138.0.3344.0 or later.
-
-
-<!-- ------------------------------ -->
-#### Experimental APIs (Phase 1: Experimental in Prerelease)
-
-No Experimental APIs have been added in this Prerelease SDK.
-
-
-<!-- ------------------------------ -->
-#### Promotions to Phase 2 (Stable in Prerelease)
-
-The following APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, and are included in this Prerelease SDK.
-
-
-<!-- ---------- -->
-###### Allow input event messages to pass through the browser window
-
-The `CoreWebView2ControllerOptions` class now has an `AllowHostInputProcessing` property, which allows user input event messages (keyboard, mouse, touch, or pen) to pass through the browser window, to be received by an app process window.
-
-##### [.NET/C#](#tab/dotnetcsharp)
-
-* `CoreWebView2ControllerOptions` Class:
-   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/dotnet/api/microsoft.web.webview2.core.corewebview2controlleroptions.allowhostinputprocessing?view=webview2-dotnet-1.0.3344-prerelease&preserve-view=true)
-
-##### [WinRT/C#](#tab/winrtcsharp)
-
-* `CoreWebView2ControllerOptions` Class:
-   * [CoreWebView2ControllerOptions.AllowHostInputProcessing Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controlleroptions?view=webview2-winrt-1.0.3344-prerelease&preserve-view=true#allowhostinputprocessing)
-
-##### [Win32/C++](#tab/win32cpp)
-
-* [ICoreWebView2ControllerOptions4](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3344-prerelease&preserve-view=true)
-   * [ICoreWebView2ControllerOptions4::get_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3344-prerelease&preserve-view=true#get_allowhostinputprocessing)
-   * [ICoreWebView2ControllerOptions4::put_AllowHostInputProcessing](/microsoft-edge/webview2/reference/win32/icorewebview2controlleroptions4?view=webview2-1.0.3344-prerelease&preserve-view=true#put_allowhostinputprocessing)
-
----
-
-
-<!-- ------------------------------ -->
-#### Bug fixes
-
-
-<!-- ---------- -->
-###### Runtime-only
-
-* Fixed a bug where a mouse event doesn't fire after a touch event.
-* Disabled Web capture on the WebView2 control.
-* Fixed the **Downloads** dialog.
-* Fixed an issue with downloads in the default browser frame.  ([Issue #5196](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5196))
-* Fixed the margins in the printed PDF.
-
-<!-- end of Prerelease SDK 1.0.3344-prerelease, for Runtime 138 (Jun. 3, 2025) -->
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -29,50 +29,72 @@ The following new features and bug fixes are in the WebView2 Release SDK and Pre
 
 
 <!-- ====================================================================== -->
-## Prerelease SDK 1.0.nnnn-prerelease, for Runtime 151 (Jul. 6, 2026)
+## Prerelease SDK 1.0.4126-prerelease, for Runtime 150 (Jul. 6, 2026)
 
-Release Date: Mmm. dd, yyyy
+Release Date: July 06, 2026
 
-[NuGet package for WebView2 SDK 1.0.####-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.####-prerelease)
+[NuGet package for WebView2 SDK 1.0.4126-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4126-prerelease)
 
-For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version ###.0.####.0 or later.
+For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 151.0.4126.0 or higher.
 
-
-<!-- ------------------------------ -->
-#### Breaking changes
-<!-- omit section if empty; usually empty -->
-
-
-<!-- ---------- -->
-###### heading
-
-
-<!-- ------------------------------ -->
-#### General changes
-<!-- omit section if empty; usually empty -->
-
-
-<!-- ---------- -->
-###### heading
 
 
 <!-- ------------------------------ -->
 #### Experimental APIs (Phase 1: Experimental in Prerelease)
 
-No Experimental APIs have been added in this Prerelease SDK.
 The following APIs are in Phase 1: Experimental in Prerelease, and have been added in this Prerelease SDK.
 
 
 <!-- ---------- -->
-###### heading
+###### CoreWebView2CrashReport
 
-description
+<!-- description need to updated -->
+
+description 
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
+* [CoreWebView2CrashReport Class](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.BucketId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.bucketid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.CrashReportId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.crashreportid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.ExceptionCode Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.exceptioncode?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.FaultingModuleName Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmodulename?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.FaultingModuleVersion Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmoduleversion?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.FaultOffset Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultoffset?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.ReportTime Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.reporttime?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+
+* [CoreWebView2OriginFeature.ReputationChecking Enum Value](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeature?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+<!-- todo : yet to confirm the enum as CoreWebView2OriginFeature is allready seen in the experimental -->
+* [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs.crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+
 ##### [WinRT/C#](#tab/winrtcsharp)
 
+* [CoreWebView2CrashReport Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2CrashReport.BucketId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#bucketid)
+* [CoreWebView2CrashReport.CrashReportId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreportid)
+* [CoreWebView2CrashReport.ExceptionCode Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#exceptioncode)
+* [CoreWebView2CrashReport.FaultingModuleName Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmodulename)
+* [CoreWebView2CrashReport.FaultingModuleVersion Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmoduleversion)
+* [CoreWebView2CrashReport.FaultOffset Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultoffset)
+* [CoreWebView2CrashReport.ReportTime Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#reporttime)
+* [CoreWebView2ProcessFailedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
+* [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreport)
+
+
 ##### [Win32/C++](#tab/win32cpp)
+
+  * `COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING`
+* [ICoreWebView2ExperimentalCrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true)
+  * [ICoreWebView2ExperimentalCrashReport::get_BucketId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_bucketid)
+  * [ICoreWebView2ExperimentalCrashReport::get_CrashReportId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreportid)
+  * [ICoreWebView2ExperimentalCrashReport::get_ExceptionCode](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_exceptioncode)
+  * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleName](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmodulename)
+  * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleVersion](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmoduleversion)
+  * [ICoreWebView2ExperimentalCrashReport::get_FaultOffset](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultoffset)
+  * [ICoreWebView2ExperimentalCrashReport::get_ReportTime](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_reporttime)
+* [ICoreWebView2ExperimentalProcessFailedEventArgs2](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true)
+  * [ICoreWebView2ExperimentalProcessFailedEventArgs2::get_CrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreport)
+
 
 ---
 
@@ -81,123 +103,65 @@ description
 #### Promotions to Phase 2 (Stable in Prerelease)
 
 No APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, in this Prerelease SDK.
-The following APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, and are included in this Prerelease SDK.
-The following APIs skipped Phase 1: Experimental in Prerelease, and have been directly added to Phase 2: Stable in Prerelease, and are included in this Prerelease SDK.
-
-
-<!-- ---------- -->
-###### heading
-
-description
-
-##### [.NET/C#](#tab/dotnetcsharp)
-
-##### [WinRT/C#](#tab/winrtcsharp)
-
-##### [Win32/C++](#tab/win32cpp)
-
----
 
 
 <!-- ------------------------------ -->
 #### Bug fixes
 
-There are no bug fixes in this Prerelease SDK.
 This Prerelease SDK includes the following bug fixes.
-
-
-<!-- ---------- -->
-###### Runtime and SDK
-
-* Fixed behavior.  ([Issue #]())
 
 
 <!-- ---------- -->
 ###### Runtime-only
 
-* Fixed behavior.  ([Issue #]())
+* Added fix for reentrancy for frame deletion 
+* Fixed object wrapper access related UAF 
+* Stamp browser-authoritative origin on Host pipe to fix WebMessageReceivedEventArgs.Source spoof 
+* Restricting access to singleton host pipe in deprecated webview2 
+* Removed origin parameter from the methods accessing native object 
+* Harden WebView2 virtual-host kDeny enforcement against renderer spoofing and NTFS-junction escapes.  
+* Fix window to Visual UIA tree 
+* Fixed regression in AddScriptToExecuteOnDocumentCreated API.
+* Implement OnRendererResponsive for hang outcome tracking 
 
 
-<!-- ---------- -->
-###### SDK-only
 
-* Fixed behavior.  ([Issue #]())
 
-<!-- end of Prerelease SDK 1.0.nnnn-prerelease, for Runtime 151 (Jul. 6, 2026) -->
+<!-- end of Prerelease SDK 1.0.4126-prerelease, for Runtime 150 (Jul. 6, 2026) -->
 
 
 <!-- ====================================================================== -->
-## Release SDK 1.0.nnnn.nn, for Runtime 150 (Jul. 6, 2026)
+## Release SDK 1.0.4078.44, for Runtime 150 (Jul. 6, 2026)
 
-Release Date: Mmm. dd, yyyy
+Release Date: July 06, 2026
 
-[NuGet package for WebView2 SDK 1.0.####.##](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.####.##)
+[NuGet package for WebView2 SDK 1.0.4078.44](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4078.44)
 
-For full API compatibility, this Release version of the WebView2 SDK requires WebView2 Runtime version ###.0.####.## or later.
-
-
-<!-- ------------------------------ -->
-#### Breaking changes
-<!-- omit section if empty; usually empty -->
-
-
-<!-- ---------- -->
-###### heading
-
-
-<!-- ------------------------------ -->
-#### General changes
-<!-- omit section if empty; usually empty -->
-
-
-<!-- ---------- -->
-###### heading
+For full API compatibility, this Release version of the WebView2 SDK requires WebView2 Runtime version 150.0.4078.44 or higher.
 
 
 <!-- ------------------------------ -->
 #### Promotions to Phase 3 (Stable in Release)
 
 No additional APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, in this Release SDK.
-The following APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, and are now included in this Release SDK.
-
-
-<!-- ---------- -->
-###### heading
-
-description
-
-##### [.NET/C#](#tab/dotnetcsharp)
-
-##### [WinRT/C#](#tab/winrtcsharp)
-
-##### [Win32/C++](#tab/win32cpp)
-
----
 
 
 <!-- ------------------------------ -->
 #### Bug fixes
 
-There are no bug fixes in this Release SDK.
 This Release SDK includes the following bug fixes.
-
-
-<!-- ---------- -->
-###### Runtime and SDK
-
-* Fixed behavior.  ([Issue #]())
-
 
 <!-- ---------- -->
 ###### Runtime-only
 
-* Fixed behavior.  ([Issue #]())
+* Added fix for reentrancy for frame deletion
+* Fixed object wrapper access related UAF
+* Stamp browser-authoritative origin on Host pipe to fix WebMessageReceivedEventArgs.Source spoof
+* Restricting access to singleton host pipe in deprecated webview2
+* Removed origin parameter from the methods accessing native object
+* Harden WebView2 virtual-host kDeny enforcement against renderer spoofing and NTFS-junction escapes. 
+* Fix window to Visual UIA tree
 
-
-<!-- ---------- -->
-###### SDK-only
-
-* Fixed behavior.  ([Issue #]())
 
 <!-- end of Release SDK 1.0.nnnn.nn, for Runtime 150 (Jul. 6, 2026) -->
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -11,7 +11,7 @@ ms.date: 07/06/2026
 # Release notes for the WebView2 SDK
 <!--
 https://learn.microsoft.com/microsoft-edge/webview2/release-notes/
-https://aka.ms/webviewrelease 
+https://aka.ms/webviewrelease
 -->
 
 <!-- maintenance:
@@ -31,12 +31,11 @@ The following new features and bug fixes are in the WebView2 Release SDK and Pre
 <!-- ====================================================================== -->
 ## Prerelease SDK 1.0.4126-prerelease, for Runtime 150 (Jul. 6, 2026)
 
-Release Date: July 06, 2026
+Release Date: Jul. 6, 2026
 
 [NuGet package for WebView2 SDK 1.0.4126-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4126-prerelease)
 
 For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 151.0.4126.0 or higher.
-
 
 
 <!-- ------------------------------ -->
@@ -48,53 +47,58 @@ The following APIs are in Phase 1: Experimental in Prerelease, and have been add
 <!-- ---------- -->
 ###### CoreWebView2CrashReport
 
-<!-- description need to updated -->
-
-description 
+Provides a crash report.  todo: real description
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
 * [CoreWebView2CrashReport Class](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.BucketId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.bucketid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.CrashReportId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.crashreportid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.ExceptionCode Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.exceptioncode?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.FaultingModuleName Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmodulename?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.FaultingModuleVersion Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmoduleversion?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.FaultOffset Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultoffset?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.ReportTime Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.reporttime?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.BucketId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.bucketid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.CrashReportId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.crashreportid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.ExceptionCode Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.exceptioncode?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.FaultingModuleName Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmodulename?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.FaultingModuleVersion Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmoduleversion?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.FaultOffset Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultoffset?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.ReportTime Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.reporttime?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
 
-* [CoreWebView2OriginFeature.ReputationChecking Enum Value](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeature?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-<!-- todo : yet to confirm the enum as CoreWebView2OriginFeature is allready seen in the experimental -->
-* [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs.crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+* `CoreWebView2OriginFeature` Enum:
+   * [ReputationChecking](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeature?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+
+* `CoreWebView2ProcessFailedEventArgs` Class:
+   * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs.crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
 * [CoreWebView2CrashReport Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2CrashReport.BucketId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#bucketid)
-* [CoreWebView2CrashReport.CrashReportId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreportid)
-* [CoreWebView2CrashReport.ExceptionCode Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#exceptioncode)
-* [CoreWebView2CrashReport.FaultingModuleName Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmodulename)
-* [CoreWebView2CrashReport.FaultingModuleVersion Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmoduleversion)
-* [CoreWebView2CrashReport.FaultOffset Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultoffset)
-* [CoreWebView2CrashReport.ReportTime Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#reporttime)
-* [CoreWebView2ProcessFailedEventArgs Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
-* [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreport)
+   * [CoreWebView2CrashReport.BucketId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#bucketid)
+   * [CoreWebView2CrashReport.CrashReportId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreportid)
+   * [CoreWebView2CrashReport.ExceptionCode Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#exceptioncode)
+   * [CoreWebView2CrashReport.FaultingModuleName Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmodulename)
+   * [CoreWebView2CrashReport.FaultingModuleVersion Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmoduleversion)
+   * [CoreWebView2CrashReport.FaultOffset Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultoffset)
+   * [CoreWebView2CrashReport.ReportTime Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#reporttime)
 
+* `CoreWebView2OriginFeature` Enum:
+   * [ReputationChecking](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeature?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true) - todo: add this link, like in .NET?
+
+* `CoreWebView2ProcessFailedEventArgs` Class:
+   * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreport)
 
 ##### [Win32/C++](#tab/win32cpp)
 
-  * `COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING`
 * [ICoreWebView2ExperimentalCrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true)
-  * [ICoreWebView2ExperimentalCrashReport::get_BucketId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_bucketid)
-  * [ICoreWebView2ExperimentalCrashReport::get_CrashReportId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreportid)
-  * [ICoreWebView2ExperimentalCrashReport::get_ExceptionCode](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_exceptioncode)
-  * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleName](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmodulename)
-  * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleVersion](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmoduleversion)
-  * [ICoreWebView2ExperimentalCrashReport::get_FaultOffset](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultoffset)
-  * [ICoreWebView2ExperimentalCrashReport::get_ReportTime](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_reporttime)
-* [ICoreWebView2ExperimentalProcessFailedEventArgs2](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true)
-  * [ICoreWebView2ExperimentalProcessFailedEventArgs2::get_CrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreport)
+   * [ICoreWebView2ExperimentalCrashReport::get_BucketId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_bucketid)
+   * [ICoreWebView2ExperimentalCrashReport::get_CrashReportId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreportid)
+   * [ICoreWebView2ExperimentalCrashReport::get_ExceptionCode](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_exceptioncode)
+   * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleName](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmodulename)
+   * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleVersion](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmoduleversion)
+   * [ICoreWebView2ExperimentalCrashReport::get_FaultOffset](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultoffset)
+   * [ICoreWebView2ExperimentalCrashReport::get_ReportTime](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_reporttime)
 
+* [ICoreWebView2ExperimentalProcessFailedEventArgs2](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true)
+   * [ICoreWebView2ExperimentalProcessFailedEventArgs2::get_CrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreport)
+
+* `COREWEBVIEW2_ORIGIN_FEATURE` enum:
+   * [COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING](/microsoft-edge/webview2/reference/win32/webview2experimental-idl?view=webview2-1.0.4126-prerelease&preserve-view=true#corewebview2_origin_feature_reputation_checking)
 
 ---
 
@@ -114,18 +118,15 @@ This Prerelease SDK includes the following bug fixes.
 <!-- ---------- -->
 ###### Runtime-only
 
-* Added fix for reentrancy for frame deletion 
-* Fixed object wrapper access related UAF 
-* Stamp browser-authoritative origin on Host pipe to fix WebMessageReceivedEventArgs.Source spoof 
-* Restricting access to singleton host pipe in deprecated webview2 
-* Removed origin parameter from the methods accessing native object 
-* Harden WebView2 virtual-host kDeny enforcement against renderer spoofing and NTFS-junction escapes.  
-* Fix window to Visual UIA tree 
-* Fixed regression in AddScriptToExecuteOnDocumentCreated API.
-* Implement OnRendererResponsive for hang outcome tracking 
-
-
-
+* Fixed the reentrancy for frame deletion.
+* Fixed object wrapper access for a User Authorization File (UAF).
+* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs.Source` spoof.
+* Restricted the access to a singleton host pipe, in a deprecated WebView2.
+* Removed the `origin` parameter from methods that access a native object.
+* Hardened WebView2 virtual-host `kDeny` enforcement against renderer spoofing and New Technology File System (NTFS)-junction escapes.
+* Fixed the window-to-visual UI Automation (UIA) tree.
+* Fixed a regression in the `AddScriptToExecuteOnDocumentCreated` API.
+* Implemented `OnRendererResponsive` for hang outcome tracking.
 
 <!-- end of Prerelease SDK 1.0.4126-prerelease, for Runtime 150 (Jul. 6, 2026) -->
 
@@ -133,7 +134,7 @@ This Prerelease SDK includes the following bug fixes.
 <!-- ====================================================================== -->
 ## Release SDK 1.0.4078.44, for Runtime 150 (Jul. 6, 2026)
 
-Release Date: July 06, 2026
+Release Date: Jul. 6, 2026
 
 [NuGet package for WebView2 SDK 1.0.4078.44](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4078.44)
 
@@ -151,19 +152,19 @@ No additional APIs have been promoted from Phase 2: Stable in Prerelease, to Pha
 
 This Release SDK includes the following bug fixes.
 
+
 <!-- ---------- -->
 ###### Runtime-only
 
-* Added fix for reentrancy for frame deletion
-* Fixed object wrapper access related UAF
-* Stamp browser-authoritative origin on Host pipe to fix WebMessageReceivedEventArgs.Source spoof
-* Restricting access to singleton host pipe in deprecated webview2
-* Removed origin parameter from the methods accessing native object
-* Harden WebView2 virtual-host kDeny enforcement against renderer spoofing and NTFS-junction escapes. 
-* Fix window to Visual UIA tree
+* Fixed the reentrancy for frame deletion.
+* Fixed object wrapper access for a User Authorization File (UAF).
+* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs.Source` spoof.
+* Restricted the access to a singleton host pipe, in a deprecated WebView2.
+* Removed the `origin` parameter from methods that access a native object.
+* Hardened WebView2 virtual-host `kDeny` enforcement against renderer spoofing and New Technology File System (NTFS)-junction escapes.
+* Fixed the window-to-visual UI Automation (UIA) tree.
 
-
-<!-- end of Release SDK 1.0.nnnn.nn, for Runtime 150 (Jul. 6, 2026) -->
+<!-- end of Release SDK 1.0.4078.44, for Runtime 150 (Jul. 6, 2026) -->
 
 
 <!-- ====================================================================== -->
@@ -179,7 +180,7 @@ For full API compatibility, this Prerelease version of the WebView2 SDK requires
 <!-- ------------------------------ -->
 #### Breaking changes
 
- 
+
 <!-- ---------- -->
 ###### Enable Windows shell handwriting support for WebView2 in WindowToVisual mode
 
@@ -223,16 +224,16 @@ See also:
 ###### Deprecation of DevToolsProtocolExtension NuGet package
 
 [NuGet package for DevToolsProtocolExtension 1.0.2901](https://www.nuget.org/packages/Microsoft.Web.WebView2.DevToolsProtocolExtension)
- 
+
 The `Microsoft.Web.WebView2.DevToolsProtocolExtension` NuGet package is being deprecated, and no further versions of this package will be published.  This deprecation is not linked to any WebView2 Release SDK or Prerelease SDK.
- 
+
 The DevToolsProtocolExtension package provides a strongly-typed .NET wrapper over the Chrome DevTools Protocol (CDP) for use in WebView2 apps.  The existing published versions (`1.0.824`, `1.0.2271`, and `1.0.2901`) remain available on NuGet Gallery and are not being removed.
 
 See also:
 * [[Deprecation] Microsoft.Web.WebView2.DevToolsProtocolExtension NuGet package](https://github.com/MicrosoftEdge/WebView2Announcements/issues/135)
- 
+
 **Recommended alternative:**
- 
+
 All CDP calls can be made directly via the WebView2 CDP APIs, without using the extension package.  See [Use the Chrome DevTools Protocol (CDP) in WebView2 apps](../how-to/chromium-devtools-protocol.md) and the following:
 
 ##### [.NET/C#](#tab/dotnetcsharp)
@@ -1136,7 +1137,7 @@ For full API compatibility, this Prerelease version of the WebView2 SDK requires
 The `ProcessFailed` event fires when a WebView2-associated process (such as a renderer or GPU process) exits unexpectedly, allowing apps to respond with recovery logic or diagnostics.
 
 Before this change: The `CoreWebView2ProcessFailedEventArgs.Reason` property returned `Unexpected` for three distinct exit scenarios (normal exit, abnormal exit, and code integrity failure), making it impossible for apps to distinguish between them.
- 
+
 After this change: When the `msWebView2GranularProcessFailedReason` feature flag is enabled, the `CoreWebView2ProcessFailedEventArgs.Reason` property returns the following new, granular `CoreWebView2ProcessFailedReason` enum values, instead of `Unexpected`:
 
 * `NormalExit` — The process exited normally (exit code 0).
@@ -1146,7 +1147,7 @@ After this change: When the `msWebView2GranularProcessFailedReason` feature flag
 * `IntegrityFailure` — The OS terminated the process due to a code integrity failure, such as when a DLL fails Windows Code Integrity verification.
 
 The `msWebView2GranularProcessFailedReason` feature flag is disabled by default in releases 148 and 149, giving apps two releases to proactively test.  Starting in release 150, the feature will be enabled by default, and apps will receive the granular values.  To validate your WebView2 app's behavior, enable the feature flag, as follows:
- 
+
 `set WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--enable-features=msWebView2GranularProcessFailedReason`
 
 This is a bug fix for the Runtime and SDK.  These enum members are a modification of an existing stable API, and are available as part of this Prerelease SDK.
@@ -1197,11 +1198,11 @@ The following APIs are in Phase 1: Experimental in Prerelease, and have been add
 ###### Origin Configuration API for WebView2
 
 The Origin Configuration API enables WebView2 apps to apply different feature and security policies based on the origin of hosted content.  By default, WebView2 enforces a uniform policy across all origins.  This API allows apps to selectively enable or disable specific features (such as Enhanced Security Mode) for individual origins or origin patterns.
- 
+
 Use the `SetOriginFeatures` method on `CoreWebView2Profile` to configure feature settings for one or more origins.  Origins can be specified as exact strings (such as `https://contoso.com`) or wildcard patterns (such as `https://[*.]contoso.com`) to match subdomains, protocols, or ports.
 
 When multiple configurations apply to the same origin, the most specific pattern takes precedence, evaluated by hostname, then scheme, then port.
- 
+
 Use `GetEffectiveFeaturesForOrigin` to asynchronously retrieve the computed feature settings for a given origin.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
@@ -1489,7 +1490,7 @@ Going forward, WebView2 will rely on the `AreWebViewScriptApisEnabledForServiceW
 
 You can proactively validate your WebView2 app's behavior by enabling service worker JavaScript API exposure in your WebView2 app.
 To do so, configure your app to enable the following setting:
- 
+
 ```
 AreWebViewScriptApisEnabledForServiceWorkers = true
 ```

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -56,7 +56,7 @@ The CrashReport API provides crash diagnostic data when a WebView2 process fails
 
 CrashReport is null when the failure did not produce a crash report (normal exit, external kill, launch failure, hang), and may also be null for certain crash-type failures where no report was produced. Host apps should always check for null before accessing properties.
 
-#### Configure per-origin reputation checking (SmartScreen) settings
+###### Configure per-origin reputation checking (SmartScreen) settings
 
 The `ReputationChecking` feature allows a WebView2 app to skip SmartScreen reputation checks for navigations and downloads from specific trusted origins. The `ReputationChecking` feature is an `enum` member in the `CoreWebView2OriginFeature` enum.
 When this feature is set to `Disabled` for an origin, phishing and malware reputation checks are bypassed for that origin. If not configured for an origin, the global `IsReputationCheckingRequired` setting applies. If `IsReputationCheckingRequired` is set to `false`, setting this feature to `Enabled` for a specific origin will not re-enable reputation checks for that origin. `IsReputationCheckingRequired` takes precedence.

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -27,6 +27,11 @@ todo: update links in announcements, since the Prerelease headings & Release hea
 
 The following new features and bug fixes are in the WebView2 Release SDK and Prerelease SDK, for SDKs during the past year.
 
+#### Upcoming release cadence change
+
+The next major version, 151, is the last release on the 4-week cadence. Starting with version 152 (Aug 24, 2026), the WebView2 Runtime moves to a 2-week cadence, aligned with Microsoft Edge (the WebView2 SDK continues on its monthly cadence). See the announcement for details.
+[WebView2 Runtime moves to a 2-week release cadence](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137)
+
 
 <!-- ====================================================================== -->
 ## Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 6, 2026)
@@ -45,9 +50,16 @@ The following APIs are in Phase 1: Experimental in Prerelease, and have been add
 
 
 <!-- ---------- -->
-###### CoreWebView2CrashReport
+###### Crash Report in ProcessFailed event
 
-Provides a crash report.  todo: real description
+The CrashReport API provides crash diagnostic data when a WebView2 process fails with a crash. When a ProcessFailed event is raised, the host application can access the CrashReport property on the ProcessFailedEventArgs to retrieve crash signature details including the exception code, faulting module name and version, fault offset, crash report ID, bucket ID, and the time the crash was reported.
+
+CrashReport is null when the failure did not produce a crash report (normal exit, external kill, launch failure, hang), and may also be null for certain crash-type failures where no report was produced. Host apps should always check for null before accessing properties.
+
+#### Configure per-origin reputation checking (SmartScreen) settings
+
+The `ReputationChecking` feature allows a WebView2 app to skip SmartScreen reputation checks for navigations and downloads from specific trusted origins. The `ReputationChecking` feature is an `enum` member in the `CoreWebView2OriginFeature` enum.
+When this feature is set to `Disabled` for an origin, phishing and malware reputation checks are bypassed for that origin. If not configured for an origin, the global `IsReputationCheckingRequired` setting applies. If `IsReputationCheckingRequired` is set to `false`, setting this feature to `Enabled` for a specific origin will not re-enable reputation checks for that origin. `IsReputationCheckingRequired` takes precedence.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -78,7 +90,7 @@ Provides a crash report.  todo: real description
    * [CoreWebView2CrashReport.ReportTime Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#reporttime)
 
 * `CoreWebView2OriginFeature` Enum:
-   * [ReputationChecking](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeature?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true) - todo: add this link, like in .NET?
+   * [ReputationChecking](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeature?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
 
 * `CoreWebView2ProcessFailedEventArgs` Class:
    * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreport)
@@ -108,7 +120,6 @@ Provides a crash report.  todo: real description
 
 No APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, in this Prerelease SDK.
 
-
 <!-- ------------------------------ -->
 #### Bug fixes
 
@@ -120,7 +131,7 @@ This Prerelease SDK includes the following bug fixes.
 
 * Fixed the reentrancy for frame deletion.
 * Fixed object wrapper access for a User Authorization File (UAF).
-* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs.Source` spoof.
+* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs`.Source spoof
 * Restricted the access to a singleton host pipe, in a deprecated WebView2.
 * Removed the `origin` parameter from methods that access a native object.
 * Hardened WebView2 virtual-host `kDeny` enforcement against renderer spoofing and New Technology File System (NTFS)-junction escapes.
@@ -158,7 +169,7 @@ This Release SDK includes the following bug fixes.
 
 * Fixed the reentrancy for frame deletion.
 * Fixed object wrapper access for a User Authorization File (UAF).
-* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs.Source` spoof.
+* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs`.Source spoof
 * Restricted the access to a singleton host pipe, in a deprecated WebView2.
 * Removed the `origin` parameter from methods that access a native object.
 * Hardened WebView2 virtual-host `kDeny` enforcement against renderer spoofing and New Technology File System (NTFS)-junction escapes.

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 07/06/2026
+ms.date: 07/07/2026
 ---
 # Release notes for the WebView2 SDK
 <!--
@@ -29,9 +29,9 @@ The following new features and bug fixes are in the WebView2 Release SDK and Pre
 
 
 <!-- ====================================================================== -->
-## Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 6, 2026)
+## Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 7, 2026)
 
-Release Date: Jul. 6, 2026
+Release Date: Jul. 7, 2026
 
 [NuGet package for WebView2 SDK 1.0.4126-prerelease](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4126-prerelease)
 
@@ -146,7 +146,7 @@ Older supporting APIs:
    * `Disabled`
 
 * `CoreWebView2Settings` Class:
-   * [CoreWebView2Settings.IsReputationCheckingRequired](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired)
+   * [CoreWebView2Settings.IsReputationCheckingRequired Property](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired)
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
@@ -163,7 +163,7 @@ Older supporting APIs:
    * `Disabled`
 
 * `CoreWebView2Settings` Class:
-   * [CoreWebView2Settings.IsReputationCheckingRequired](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isreputationcheckingrequired)
+   * [CoreWebView2Settings.IsReputationCheckingRequired Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isreputationcheckingrequired)
 
 ##### [Win32/C++](#tab/win32cpp)
 
@@ -211,13 +211,13 @@ This Prerelease SDK includes the following bug fixes.
 * Fixed a regression in the `AddScriptToExecuteOnDocumentCreated` API.
 * Implemented `OnRendererResponsive` for hang outcome tracking.
 
-<!-- end of Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 6, 2026) -->
+<!-- end of Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 7, 2026) -->
 
 
 <!-- ====================================================================== -->
-## Release SDK 1.0.4078.44, for Runtime 150 (Jul. 6, 2026)
+## Release SDK 1.0.4078.44, for Runtime 150 (Jul. 7, 2026)
 
-Release Date: Jul. 6, 2026
+Release Date: Jul. 7, 2026
 
 [NuGet package for WebView2 SDK 1.0.4078.44](https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4078.44)
 
@@ -262,7 +262,7 @@ This Release SDK includes the following bug fixes.
 * Fixed the window-to-visual UI Automation (UIA) tree.
 * Fixed a regression in the `AddScriptToExecuteOnDocumentCreated` API.
 
-<!-- end of Release SDK 1.0.4078.44, for Runtime 150 (Jul. 6, 2026) -->
+<!-- end of Release SDK 1.0.4078.44, for Runtime 150 (Jul. 7, 2026) -->
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -39,11 +39,11 @@ For full API compatibility, this Prerelease version of the WebView2 SDK requires
 
 
 <!-- ------------------------------ -->
-#### WebView2 Runtime is changing to a 2-week cadence
+#### WebView2 Runtime is changing to a 2-week release cadence
 
-Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week cadence.
+Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week release cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week release cadence.
 
-The WebView2 SDK continues on its monthly cadence.
+The WebView2 SDK continues on its monthly release cadence.
 
 See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
 
@@ -178,11 +178,11 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
-#### WebView2 Runtime is changing to a 2-week cadence
+#### WebView2 Runtime is changing to a 2-week release cadence
 
-Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week cadence.
+Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week release cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week release cadence.
 
-The WebView2 SDK continues on its monthly cadence.
+The WebView2 SDK continues on its monthly release cadence.
 
 See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -27,11 +27,6 @@ todo: update links in announcements, since the Prerelease headings & Release hea
 
 The following new features and bug fixes are in the WebView2 Release SDK and Prerelease SDK, for SDKs during the past year.
 
-#### Upcoming release cadence change
-
-The next major version, 151, is the last release on the 4-week cadence. Starting with version 152 (Aug 24, 2026), the WebView2 Runtime moves to a 2-week cadence, aligned with Microsoft Edge (the WebView2 SDK continues on its monthly cadence). See the announcement for details.
-[WebView2 Runtime moves to a 2-week release cadence](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137)
-
 
 <!-- ====================================================================== -->
 ## Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 6, 2026)
@@ -42,6 +37,10 @@ Release Date: Jul. 6, 2026
 
 For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 151.0.4126.0 or higher.
 
+#### Upcoming release cadence change
+
+The next major version, 151, is the last release on the 4-week cadence. Starting with version 152 (Aug 24, 2026), the WebView2 Runtime moves to a 2-week cadence, aligned with Microsoft Edge (the WebView2 SDK continues on its monthly cadence). See the announcement for details.
+[WebView2 Runtime moves to a 2-week release cadence](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137)
 
 <!-- ------------------------------ -->
 #### Experimental APIs (Phase 1: Experimental in Prerelease)
@@ -151,6 +150,10 @@ Release Date: Jul. 6, 2026
 
 For full API compatibility, this Release version of the WebView2 SDK requires WebView2 Runtime version 150.0.4078.44 or higher.
 
+#### Upcoming release cadence change
+
+The next major version, 151, is the last release on the 4-week cadence. Starting with version 152 (Aug 24, 2026), the WebView2 Runtime moves to a 2-week cadence, aligned with Microsoft Edge (the WebView2 SDK continues on its monthly cadence). See the announcement for details.
+[WebView2 Runtime moves to a 2-week release cadence](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137)
 
 <!-- ------------------------------ -->
 #### Promotions to Phase 3 (Stable in Release)
@@ -174,6 +177,7 @@ This Release SDK includes the following bug fixes.
 * Removed the `origin` parameter from methods that access a native object.
 * Hardened WebView2 virtual-host `kDeny` enforcement against renderer spoofing and New Technology File System (NTFS)-junction escapes.
 * Fixed the window-to-visual UI Automation (UIA) tree.
+* Fixed a regression in the `AddScriptToExecuteOnDocumentCreated` API.
 
 <!-- end of Release SDK 1.0.4078.44, for Runtime 150 (Jul. 6, 2026) -->
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -77,6 +77,50 @@ The CrashReport API provides crash diagnostic data when a WebView2 process fails
 
 `ProcessFailedEventArgs.CrashReport` may also be `null` for certain crash-type failures where no report was produced.  Host apps should always check for `null` before accessing properties.
 
+##### [.NET/C#](#tab/dotnetcsharp)
+
+* [CoreWebView2CrashReport Class](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.BucketId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.bucketid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.CrashReportId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.crashreportid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.ExceptionCode Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.exceptioncode?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.FaultingModuleName Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmodulename?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.FaultingModuleVersion Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmoduleversion?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.FaultOffset Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultoffset?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.ReportTime Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.reporttime?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+
+* `CoreWebView2ProcessFailedEventArgs` Class:
+   * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs.crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
+
+##### [WinRT/C#](#tab/winrtcsharp)
+
+* [CoreWebView2CrashReport Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
+   * [CoreWebView2CrashReport.BucketId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#bucketid)
+   * [CoreWebView2CrashReport.CrashReportId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreportid)
+   * [CoreWebView2CrashReport.ExceptionCode Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#exceptioncode)
+   * [CoreWebView2CrashReport.FaultingModuleName Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmodulename)
+   * [CoreWebView2CrashReport.FaultingModuleVersion Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmoduleversion)
+   * [CoreWebView2CrashReport.FaultOffset Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultoffset)
+   * [CoreWebView2CrashReport.ReportTime Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#reporttime)
+
+* `CoreWebView2ProcessFailedEventArgs` Class:
+   * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreport)
+
+##### [Win32/C++](#tab/win32cpp)
+
+* [ICoreWebView2ExperimentalCrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true)
+   * [ICoreWebView2ExperimentalCrashReport::get_BucketId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_bucketid)
+   * [ICoreWebView2ExperimentalCrashReport::get_CrashReportId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreportid)
+   * [ICoreWebView2ExperimentalCrashReport::get_ExceptionCode](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_exceptioncode)
+   * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleName](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmodulename)
+   * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleVersion](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmoduleversion)
+   * [ICoreWebView2ExperimentalCrashReport::get_FaultOffset](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultoffset)
+   * [ICoreWebView2ExperimentalCrashReport::get_ReportTime](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_reporttime)
+
+* [ICoreWebView2ExperimentalProcessFailedEventArgs2](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true)
+   * [ICoreWebView2ExperimentalProcessFailedEventArgs2::get_CrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreport)
+
+---
+
 
 <!-- ---------- -->
 ###### Configure per-origin reputation checking (SmartScreen) settings
@@ -89,20 +133,8 @@ If `CoreWebView2Settings.IsReputationCheckingRequired` is set to `false`, settin
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
-* [CoreWebView2CrashReport Class](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.BucketId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.bucketid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.CrashReportId Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.crashreportid?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.ExceptionCode Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.exceptioncode?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.FaultingModuleName Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmodulename?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.FaultingModuleVersion Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultingmoduleversion?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.FaultOffset Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.faultoffset?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.ReportTime Property](/dotnet/api/microsoft.web.webview2.core.corewebview2crashreport.reporttime?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-
 * `CoreWebView2OriginFeature` Enum:
    * [ReputationChecking](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeature?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
-
-* `CoreWebView2ProcessFailedEventArgs` Class:
-   * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs.crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
 
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.SetOriginFeatures Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.setoriginfeatures)
@@ -121,20 +153,8 @@ Older supporting APIs:
 * `CoreWebView2Profile` Class:
    * [CoreWebView2Profile.SetOriginFeatures Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#setoriginfeatures)
 
-* [CoreWebView2CrashReport Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
-   * [CoreWebView2CrashReport.BucketId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#bucketid)
-   * [CoreWebView2CrashReport.CrashReportId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreportid)
-   * [CoreWebView2CrashReport.ExceptionCode Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#exceptioncode)
-   * [CoreWebView2CrashReport.FaultingModuleName Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmodulename)
-   * [CoreWebView2CrashReport.FaultingModuleVersion Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultingmoduleversion)
-   * [CoreWebView2CrashReport.FaultOffset Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#faultoffset)
-   * [CoreWebView2CrashReport.ReportTime Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#reporttime)
-
 * `CoreWebView2OriginFeature` Enum:
    * [ReputationChecking](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeature?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
-
-* `CoreWebView2ProcessFailedEventArgs` Class:
-   * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreport)
 
 Older supporting APIs:
 
@@ -146,18 +166,6 @@ Older supporting APIs:
    * [CoreWebView2Settings.IsReputationCheckingRequired](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isreputationcheckingrequired)
 
 ##### [Win32/C++](#tab/win32cpp)
-
-* [ICoreWebView2ExperimentalCrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true)
-   * [ICoreWebView2ExperimentalCrashReport::get_BucketId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_bucketid)
-   * [ICoreWebView2ExperimentalCrashReport::get_CrashReportId](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreportid)
-   * [ICoreWebView2ExperimentalCrashReport::get_ExceptionCode](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_exceptioncode)
-   * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleName](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmodulename)
-   * [ICoreWebView2ExperimentalCrashReport::get_FaultingModuleVersion](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultingmoduleversion)
-   * [ICoreWebView2ExperimentalCrashReport::get_FaultOffset](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_faultoffset)
-   * [ICoreWebView2ExperimentalCrashReport::get_ReportTime](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true#get_reporttime)
-
-* [ICoreWebView2ExperimentalProcessFailedEventArgs2](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true)
-   * [ICoreWebView2ExperimentalProcessFailedEventArgs2::get_CrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreport)
 
 * `ICoreWebView2Profile`:
    * [ICoreWebView2Profile::SetOriginFeatures](/microsoft-edge/webview2/reference/win32/icorewebview2profile?view=webview2-1.0.4126-prerelease&preserve-view=true#setoriginfeatures)

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -37,10 +37,16 @@ Release Date: Jul. 6, 2026
 
 For full API compatibility, this Prerelease version of the WebView2 SDK requires the WebView2 Runtime that ships with Microsoft Edge version 151.0.4126.0 or higher.
 
+
+<!-- ------------------------------ -->
 #### Upcoming release cadence change
 
-The next major version, 151, is the last release on the 4-week cadence. Starting with version 152 (Aug 24, 2026), the WebView2 Runtime moves to a 2-week cadence, aligned with Microsoft Edge (the WebView2 SDK continues on its monthly cadence). See the announcement for details.
-[WebView2 Runtime moves to a 2-week release cadence](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137)
+Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week cadence.
+
+The WebView2 SDK continues on its monthly cadence.
+
+See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
+
 
 <!-- ------------------------------ -->
 #### Experimental APIs (Phase 1: Experimental in Prerelease)
@@ -49,16 +55,35 @@ The following APIs are in Phase 1: Experimental in Prerelease, and have been add
 
 
 <!-- ---------- -->
-###### Crash Report in ProcessFailed event
+###### Crash Report in `ProcessFailed` event
 
-The CrashReport API provides crash diagnostic data when a WebView2 process fails with a crash. When a ProcessFailed event is raised, the host application can access the CrashReport property on the ProcessFailedEventArgs to retrieve crash signature details including the exception code, faulting module name and version, fault offset, crash report ID, bucket ID, and the time the crash was reported.
+The CrashReport API provides crash diagnostic data when a WebView2 process fails with a crash.  When a `ProcessFailed` event is raised, the host application can access the `CrashReport` property on the `ProcessFailedEventArgs` to retrieve crash signature details, including:
+* The exception code.
+* The faulting module name and version.
+* The fault offset.
+* The crash report ID.
+* The bucket ID.
+* The time the crash was reported.
 
-CrashReport is null when the failure did not produce a crash report (normal exit, external kill, launch failure, hang), and may also be null for certain crash-type failures where no report was produced. Host apps should always check for null before accessing properties.
+`ProcessFailedEventArgs.CrashReport` is `null` when the failure didn't produce a crash report, such as in these scenarios:
+* A normal exit.
+* An external kill of the process.
+* A launch failure.
+* A hang.
 
+`ProcessFailedEventArgs.CrashReport` may also be `null` for certain crash-type failures where no report was produced.  Host apps should always check for `null` before accessing properties.
+
+
+<!-- ---------- -->
 ###### Configure per-origin reputation checking (SmartScreen) settings
 
-The `ReputationChecking` feature allows a WebView2 app to skip SmartScreen reputation checks for navigations and downloads from specific trusted origins. The `ReputationChecking` feature is an `enum` member in the `CoreWebView2OriginFeature` enum.
-When this feature is set to `Disabled` for an origin, phishing and malware reputation checks are bypassed for that origin. If not configured for an origin, the global `IsReputationCheckingRequired` setting applies. If `IsReputationCheckingRequired` is set to `false`, setting this feature to `Enabled` for a specific origin will not re-enable reputation checks for that origin. `IsReputationCheckingRequired` takes precedence.
+The `ReputationChecking` feature allows a WebView2 app to skip SmartScreen reputation checks for navigations and downloads from specific trusted origins.  The `ReputationChecking` feature is an `enum` member in the `CoreWebView2OriginFeature` enum.
+
+When this feature is set to `Disabled` for an origin (todo: where/how do you set this feature to Disabled?  in edge://flags?), phishing and malware reputation checks are bypassed for that origin.  If this feature isn't configured for an origin, the global `IsReputationCheckingRequired` setting applies.  todo: maybe change to: the `IsReputationCheckingRequired` setting, which is global, applies.
+
+If `IsReputationCheckingRequired` is set to `false`, setting this feature to `Enabled` for an origin (todo: where/how do you set this feature to Enabled for an origin?  in edge://flags?) will not re-enable reputation checks for that origin.  `IsReputationCheckingRequired` takes precedence.
+
+todo: link to IsReputationCheckingRequired; where is this?  on what type?
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -119,6 +144,7 @@ When this feature is set to `Disabled` for an origin, phishing and malware reput
 
 No APIs have been promoted from Phase 1: Experimental in Prerelease, to Phase 2: Stable in Prerelease, in this Prerelease SDK.
 
+
 <!-- ------------------------------ -->
 #### Bug fixes
 
@@ -130,7 +156,7 @@ This Prerelease SDK includes the following bug fixes.
 
 * Fixed the reentrancy for frame deletion.
 * Fixed object wrapper access for a User Authorization File (UAF).
-* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs`.Source spoof
+* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs.Source` spoof.
 * Restricted the access to a singleton host pipe, in a deprecated WebView2.
 * Removed the `origin` parameter from methods that access a native object.
 * Hardened WebView2 virtual-host `kDeny` enforcement against renderer spoofing and New Technology File System (NTFS)-junction escapes.
@@ -150,10 +176,16 @@ Release Date: Jul. 6, 2026
 
 For full API compatibility, this Release version of the WebView2 SDK requires WebView2 Runtime version 150.0.4078.44 or higher.
 
+
+<!-- ------------------------------ -->
 #### Upcoming release cadence change
 
-The next major version, 151, is the last release on the 4-week cadence. Starting with version 152 (Aug 24, 2026), the WebView2 Runtime moves to a 2-week cadence, aligned with Microsoft Edge (the WebView2 SDK continues on its monthly cadence). See the announcement for details.
-[WebView2 Runtime moves to a 2-week release cadence](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137)
+Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week cadence.
+
+The WebView2 SDK continues on its monthly cadence.
+
+See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
+
 
 <!-- ------------------------------ -->
 #### Promotions to Phase 3 (Stable in Release)
@@ -172,7 +204,7 @@ This Release SDK includes the following bug fixes.
 
 * Fixed the reentrancy for frame deletion.
 * Fixed object wrapper access for a User Authorization File (UAF).
-* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs`.Source spoof
+* Stamped the browser-authoritative origin on the host pipe, to prevent a `WebMessageReceivedEventArgs.Source` spoof.
 * Restricted the access to a singleton host pipe, in a deprecated WebView2.
 * Removed the `origin` parameter from methods that access a native object.
 * Hardened WebView2 virtual-host `kDeny` enforcement against renderer spoofing and New Technology File System (NTFS)-junction escapes.

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -77,13 +77,11 @@ The CrashReport API provides crash diagnostic data when a WebView2 process fails
 <!-- ---------- -->
 ###### Configure per-origin reputation checking (SmartScreen) settings
 
-The `ReputationChecking` feature allows a WebView2 app to skip SmartScreen reputation checks for navigations and downloads from specific trusted origins.  The `ReputationChecking` feature is an `enum` member in the `CoreWebView2OriginFeature` enum.
+The `ReputationChecking` feature allows a WebView2 app to skip SmartScreen reputation checks for navigations and downloads from specific trusted origins.  `ReputationChecking` is a member of the `CoreWebView2OriginFeature` enum.
 
-When this feature is set to `Disabled` for an origin (todo: where/how do you set this feature to Disabled?  in edge://flags?), phishing and malware reputation checks are bypassed for that origin.  If this feature isn't configured for an origin, the global `IsReputationCheckingRequired` setting applies.  todo: maybe change to: the `IsReputationCheckingRequired` setting, which is global, applies.
+When this feature is set to `CoreWebView2OriginFeatureState.Disabled` for an origin, phishing and malware reputation checks are bypassed for that origin.  If this feature isn't configured for an origin, the `CoreWebView2Settings.IsReputationCheckingRequired` setting, which is global, applies; the preference at the browser-process level is applied for all the processes utilizing it.
 
-If `IsReputationCheckingRequired` is set to `false`, setting this feature to `Enabled` for an origin (todo: where/how do you set this feature to Enabled for an origin?  in edge://flags?) will not re-enable reputation checks for that origin.  `IsReputationCheckingRequired` takes precedence.
-
-todo: link to IsReputationCheckingRequired; where is this?  on what type?
+If `CoreWebView2Settings.IsReputationCheckingRequired` is set to `false`, setting `CoreWebView2OriginFeatureState.Enabled` for an origin doesn't re-enable reputation checks for that origin; `CoreWebView2Settings.IsReputationCheckingRequired` takes precedence.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 
@@ -102,7 +100,22 @@ todo: link to IsReputationCheckingRequired; where is this?  on what type?
 * `CoreWebView2ProcessFailedEventArgs` Class:
    * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/dotnet/api/microsoft.web.webview2.core.corewebview2processfailedeventargs.crashreport?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
 
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.SetOriginFeatures Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.setoriginfeatures)
+
+Older supporting APIs:
+
+* [CoreWebView2OriginFeatureState` Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeaturestate)
+   * `Enabled`
+   * `Disabled`
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsReputationCheckingRequired](/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isreputationcheckingrequired)
+
 ##### [WinRT/C#](#tab/winrtcsharp)
+
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.SetOriginFeatures Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#setoriginfeatures)
 
 * [CoreWebView2CrashReport Class](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
    * [CoreWebView2CrashReport.BucketId Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2crashreport?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#bucketid)
@@ -119,6 +132,15 @@ todo: link to IsReputationCheckingRequired; where is this?  on what type?
 * `CoreWebView2ProcessFailedEventArgs` Class:
    * [CoreWebView2ProcessFailedEventArgs.CrashReport Property](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2processfailedeventargs?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#crashreport)
 
+Older supporting APIs:
+
+* [CoreWebView2OriginFeatureState` Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeaturestate)
+   * `Enabled`
+   * `Disabled`
+
+* `CoreWebView2Settings` Class:
+   * [CoreWebView2Settings.IsReputationCheckingRequired](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings#isreputationcheckingrequired)
+
 ##### [Win32/C++](#tab/win32cpp)
 
 * [ICoreWebView2ExperimentalCrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalcrashreport?view=webview2-1.0.4126-prerelease&preserve-view=true)
@@ -133,8 +155,21 @@ todo: link to IsReputationCheckingRequired; where is this?  on what type?
 * [ICoreWebView2ExperimentalProcessFailedEventArgs2](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true)
    * [ICoreWebView2ExperimentalProcessFailedEventArgs2::get_CrashReport](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprocessfailedeventargs2?view=webview2-1.0.4126-prerelease&preserve-view=true#get_crashreport)
 
+* `ICoreWebView2Profile`:
+   * [ICoreWebView2Profile::SetOriginFeatures](/microsoft-edge/webview2/reference/win32/icorewebview2profile?view=webview2-1.0.4126-prerelease&preserve-view=true#setoriginfeatures)
+
 * `COREWEBVIEW2_ORIGIN_FEATURE` enum:
    * [COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING](/microsoft-edge/webview2/reference/win32/webview2experimental-idl?view=webview2-1.0.4126-prerelease&preserve-view=true#corewebview2_origin_feature_reputation_checking)
+
+Older supporting APIs:
+
+* `ICoreWebView2Settings8`:
+   * [ICoreWebView2Settings8::get_IsReputationCheckingRequired](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#get_isreputationcheckingrequired)
+   * [ICoreWebView2Settings8::put_IsReputationCheckingRequired](/microsoft-edge/webview2/reference/win32/icorewebview2settings8#put_isreputationcheckingrequired)
+
+* [COREWEBVIEW2_ORIGIN_FEATURE_STATE enum](/microsoft-edge/webview2/reference/win32/webview2experimental-idl#corewebview2_origin_feature_state)
+   * `COREWEBVIEW2_ORIGIN_FEATURE_STATE_ENABLED`
+   * `COREWEBVIEW2_ORIGIN_FEATURE_STATE_DISABLED`
 
 ---
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -39,7 +39,7 @@ For full API compatibility, this Prerelease version of the WebView2 SDK requires
 
 
 <!-- ------------------------------ -->
-#### Upcoming release cadence change
+#### WebView2 Runtime is changing to a 2-week cadence
 
 Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week cadence.
 
@@ -178,7 +178,7 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
-#### Upcoming release cadence change
+#### WebView2 Runtime is changing to a 2-week cadence
 
 Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week cadence.
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -39,7 +39,11 @@ For full API compatibility, this Prerelease version of the WebView2 SDK requires
 
 
 <!-- ------------------------------ -->
-#### WebView2 Runtime is changing to a 2-week release cadence
+#### General changes
+
+
+<!-- ---------- -->
+###### WebView2 Runtime is changing to a 2-week release cadence
 
 Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week release cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week release cadence.
 
@@ -213,7 +217,11 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
-#### WebView2 Runtime is changing to a 2-week release cadence
+#### General changes
+
+
+<!-- ---------- -->
+###### WebView2 Runtime is changing to a 2-week release cadence
 
 Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week release cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week release cadence.
 


### PR DESCRIPTION
Rendered article sections for review:

* **Release notes for the WebView2 SDK** > **Prerelease SDK 1.0.4126-prerelease, for Runtime 151 (Jul. 7, 2026)**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/?branch=pr-en-us-3835#prerelease-sdk-104126-prerelease-for-runtime-151-jul-7-2026
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/wv2-relnotes-150/microsoft-edge/webview2/release-notes/index.md#prerelease-sdk-104126-prerelease-for-runtime-151-jul-7-2026
   * Planned live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#prerelease-sdk-104126-prerelease-for-runtime-151-jul-7-2026
   * New section.

* **Release notes for the WebView2 SDK** > **Release SDK 1.0.4078.44, for Runtime 150 (Jul. 7, 2026)**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/?branch=pr-en-us-3809#release-sdk-10407844-for-runtime-150-jul-7-2026
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/wv2-relnotes-149/microsoft-edge/webview2/release-notes/index.md#release-sdk-10407844-for-runtime-150-jul-7-2026
   * Planned live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#release-sdk-10407844-for-runtime-150-jul-7-2026
   * New section.

* **Archived release notes for the WebView2 SDK**
   * `/webview2/release-notes/archive.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/archive?branch=pr-en-us-3809
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/wv2-relnotes-150/microsoft-edge/webview2/release-notes/archive.md
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/archive
   * Moved v138 sections to archive.

AB#62741472
