### PR TITLE
2-week release cadence for "RelNotes for WebView2 SDK"

### DIFF
--- a/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
+++ b/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
@@ -52,7 +52,7 @@ Enterprises can continue to use the blocking behavior of the Web Request API for
 <!-- ====================================================================== -->
 ## Background service workers
 
-Service workers are available for testing in the Canary preview channel of Microsoft Edge.  To migrate your extensions from background pages to service workers, see [Migrate to a service worker](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers)<!-- chrome link ok -->.  The Microsoft Edge extensions team is evaluating and investigating the impact that this change brings to both developers and users.
+To migrate your extensions from background pages to service workers, see [Migrate to a service worker](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers)<!-- chrome link ok -->.  
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/progressive-web-apps/whats-new/pwa.md
+++ b/microsoft-edge/progressive-web-apps/whats-new/pwa.md
@@ -244,15 +244,17 @@ We expect the [protocol handlers origin trial](#protocol-handlers-origin-trial) 
 <!-- ====================================================================== -->
 ## What's new in Microsoft Edge 94
 
-Microsoft Edge version 94 moved to Stable on Sep. 23, 2021. This release cycle was short — just 3 weeks from Microsoft Edge 93 Stable to Microsoft Edge 94 Stable, as we snapped to the new [4-week release cycle](https://blogs.windows.com/msedgedev/2021/03/12/new-release-cycles-microsoft-edge-extended-stable/).  This new release cadence matches the new cadence of Chromium milestones, described in [Speeding up Chrome's release cycle](https://blog.chromium.org/2021/03/speeding-up-release-cycle.html).
-
-Due to the shortened release cycle of Microsoft Edge version 94, we focused on stabilizing the release cycle logistics, and we shifted feature development to Microsoft Edge version 95.
+Microsoft Edge version 94 moved to Stable on Sep. 23, 2021.  This release cycle was 3 weeks, from Microsoft Edge 93 Stable to Microsoft Edge 94 Stable.  Due to the 3-week release cycle of Microsoft Edge version 94, we focused on stabilizing the release cycle logistics, and we shifted feature development to Microsoft Edge version 95.
 
 The origin trials remain active for the following features:
 * [Window Controls Overlay for desktop PWAs](#window-controls-overlay-origin-trials).
 * [URL Handlers](#url-handlers-origin-trial).
 
 We expect the [protocol handlers origin trial](#protocol-handlers-origin-trial) to end with Microsoft Edge version 94 as we take final feedback and get ready to move the protocol handlers feature to Stable.  In case you are enrolled in the origin trial for protocol handlers, we plan to end the trial period after Microsoft Edge version 94.  We'll then determine when this feature will become Stable.
+
+See also:
+* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
+* [Speeding up Chrome's release cycle](https://blog.chromium.org/2021/03/speeding-up-release-cycle.html)
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -31,9 +31,7 @@ See [Windows Server Update Services (WSUS)](./enterprise.md#windows-server-updat
 
 During development and testing, a WebView2 app can use either option as the backing web platform:
 
-* The WebView2 Runtime.  The Runtime generally provides the same web platform capabilities and update release cadence as the Stable channel of the Microsoft Edge browser.  Use the WebView2 Runtime in a production environment or to develop and test against the web platform that your users have today.
-
-   * For the release cadence of the WebView2 SDK, see [Release cadence](./versioning.md#release-cadence) in _Prerelease and Release SDKs for WebView2_.
+* The WebView2 Runtime.  The Runtime generally provides the same web platform capabilities and update release cadence as the Stable channel of the Microsoft Edge browser; see [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule).  Use the WebView2 Runtime in a production environment or to develop and test against the web platform that your users have today.
 
 * A preview (Insider) Microsoft Edge browser channel.  These Microsoft Edge preview channels are Beta, Dev, and Canary.  Use this approach to test your app for forward-compatibility, so that you know if a breaking change is coming that will require updating your app.  See [Test upcoming APIs and features](../how-to/set-preview-channel.md).
 

--- a/microsoft-edge/webview2/concepts/distribution.md
+++ b/microsoft-edge/webview2/concepts/distribution.md
@@ -31,7 +31,9 @@ See [Windows Server Update Services (WSUS)](./enterprise.md#windows-server-updat
 
 During development and testing, a WebView2 app can use either option as the backing web platform:
 
-* The WebView2 Runtime.  The Runtime generally provides the same web platform capabilities and update cadence as the Stable channel of the Microsoft Edge browser.  Use the WebView2 Runtime in a production environment or to develop and test against the web platform that your users have today.
+* The WebView2 Runtime.  The Runtime generally provides the same web platform capabilities and update release cadence as the Stable channel of the Microsoft Edge browser.  Use the WebView2 Runtime in a production environment or to develop and test against the web platform that your users have today.
+
+   * For the release cadence of the WebView2 SDK, see [Release cadence](./versioning.md#release-cadence) in _Prerelease and Release SDKs for WebView2_.
 
 * A preview (Insider) Microsoft Edge browser channel.  These Microsoft Edge preview channels are Beta, Dev, and Canary.  Use this approach to test your app for forward-compatibility, so that you know if a breaking change is coming that will require updating your app.  See [Test upcoming APIs and features](../how-to/set-preview-channel.md).
 

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -113,7 +113,7 @@ The WebView2 Runtime has a 2-week release cadence.  See:
 <!-- ------------------------------ -->
 #### Microsoft Edge
 
-The Microsoft Edge browser (Stable version) has a 4-week release cadence.  See [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule).
+The Microsoft Edge browser (Stable version) has a 2-week release cadence.  See [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -89,31 +89,9 @@ For more information about automatic updating of the Evergreen Runtime, see:
 <!-- ====================================================================== -->
 ## Release cadence
 
-
-<!-- ------------------------------ -->
-#### WebView2 SDK
-
-The WebView2 Prerelease SDK & the WebView2 Release SDK have a monthly release cadence.  See [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
-
-
-<!-- ------------------------------ -->
-#### WebView2 release notes
-
-The WebView2 Release notes have a 2-week release cadence.  See [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
-
-
-<!-- ------------------------------ -->
-#### WebView2 Runtime
-
-The WebView2 Runtime has a 2-week release cadence.  See:
-* [Distribute your app and the WebView2 Runtime](./distribution.md)
-* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
-
-
-<!-- ------------------------------ -->
-#### Microsoft Edge
-
-The Microsoft Edge browser (Stable version) has a 2-week release cadence.  See [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule).
+See:
+* [Release cadence](../release-notes/about.md#release-cadence) in _About release notes for the WebView2 SDK_.
+* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -89,14 +89,31 @@ For more information about automatic updating of the Evergreen Runtime, see:
 <!-- ====================================================================== -->
 ## Release cadence
 
-New versions of the WebView2 SDK are shipped at the same general cadence as the Microsoft Edge browser.
 
-todo: say two-week release cadence?
+<!-- ------------------------------ -->
+#### WebView2 SDK
 
-For the release cadence of the WebView2 Runtime, see [Distribute your app and the WebView2 Runtime](./distribution.md).
+The WebView2 Prerelease SDK & the WebView2 Release SDK have a monthly release cadence.  See [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
 
-See also:
-* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
+
+<!-- ------------------------------ -->
+#### WebView2 release notes
+
+The WebView2 Release notes have a 2-week release cadence.  See [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
+
+
+<!-- ------------------------------ -->
+#### WebView2 Runtime
+
+The WebView2 Runtime has a 2-week release cadence.  See:
+* [Distribute your app and the WebView2 Runtime](./distribution.md)
+* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
+
+
+<!-- ------------------------------ -->
+#### Microsoft Edge
+
+The Microsoft Edge browser (Stable version) has a 4-week release cadence.  See [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/concepts/versioning.md
+++ b/microsoft-edge/webview2/concepts/versioning.md
@@ -89,7 +89,14 @@ For more information about automatic updating of the Evergreen Runtime, see:
 <!-- ====================================================================== -->
 ## Release cadence
 
-New versions of the WebView2 SDK are shipped at the same general cadence as the Microsoft Edge browser, which is approximately every four weeks.
+New versions of the WebView2 SDK are shipped at the same general cadence as the Microsoft Edge browser.
+
+todo: say two-week release cadence?
+
+For the release cadence of the WebView2 Runtime, see [Distribute your app and the WebView2 Runtime](./distribution.md).
+
+See also:
+* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
 
 
 <!-- ====================================================================== -->
@@ -219,7 +226,7 @@ If your code determines that an API is unavailable in the client's installed Web
 * [Release SDK 1.0.622.22, for Runtime 86 (Oct. 19, 2020)](../release-notes/archive.md#release-sdk-1062222-for-runtime-86-oct-19-2020) in _Archived release notes for the WebView2 SDK_.<!-- bucket 12 -->
 
 Microsoft Edge Enterprise documentation:
-* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)<!-- not in article body -->
+* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
 
 Downloads:
 * [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) - SDK.

--- a/microsoft-edge/webview2/release-notes/about.md
+++ b/microsoft-edge/webview2/release-notes/about.md
@@ -23,7 +23,7 @@ See also:
 
 
 <!-- ====================================================================== -->
-## Cadence of WebView2 release notes
+## Cadence of WebView2 release notes: 2 weeks
 
 The WebView2 Release notes have a 2-week release cadence.
 
@@ -36,7 +36,7 @@ See:
 
 
 <!-- ====================================================================== -->
-## Release cadence of WebView2 SDK
+## Release cadence of WebView2 SDK: monthly
 
 The WebView2 Prerelease SDK & the WebView2 Release SDK have a monthly release cadence.
 
@@ -45,7 +45,7 @@ See:
 
 
 <!-- ====================================================================== -->
-## Release cadence of WebView2 Runtime
+## Release cadence of WebView2 Runtime: 2 weeks
 
 The WebView2 Runtime has a 2-week release cadence.
 
@@ -55,7 +55,7 @@ See:
 
 
 <!-- ====================================================================== -->
-## Release cadence of Microsoft Edge
+## Release cadence of Microsoft Edge: 2 weeks
 
 The Microsoft Edge browser (Stable version) has a 2-week release cadence.
 

--- a/microsoft-edge/webview2/release-notes/about.md
+++ b/microsoft-edge/webview2/release-notes/about.md
@@ -50,7 +50,7 @@ See:
 The WebView2 Runtime has a 2-week release cadence.
 
 See:
-* [Distribute your app and the WebView2 Runtime](./distribution.md)
+* [Distribute your app and the WebView2 Runtime](../concepts/distribution.md)
 * [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
 
 

--- a/microsoft-edge/webview2/release-notes/about.md
+++ b/microsoft-edge/webview2/release-notes/about.md
@@ -23,6 +23,47 @@ See also:
 
 
 <!-- ====================================================================== -->
+## Cadence of WebView2 release notes
+
+The WebView2 Release notes have a 2-week release cadence.
+
+Release notes include:
+* Bug fixes for the WebView2 SDK (which has a monthly release cadence).
+* Bug fixes for the WebView2 Runtime (which has a 2-week release cadence).
+
+See:
+* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
+
+
+<!-- ====================================================================== -->
+## Release cadence of WebView2 SDK
+
+The WebView2 Prerelease SDK & the WebView2 Release SDK have a monthly release cadence.
+
+See:
+* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
+
+
+<!-- ====================================================================== -->
+## Release cadence of WebView2 Runtime
+
+The WebView2 Runtime has a 2-week release cadence.
+
+See:
+* [Distribute your app and the WebView2 Runtime](./distribution.md)
+* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
+
+
+<!-- ====================================================================== -->
+## Release cadence of Microsoft Edge
+
+The Microsoft Edge browser (Stable version) has a 2-week release cadence.
+
+See:
+* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
+
+
+<!-- ====================================================================== -->
 ## Phases of adding APIs
 
 New APIs are added in three phases, as follows:

--- a/microsoft-edge/webview2/release-notes/about.md
+++ b/microsoft-edge/webview2/release-notes/about.md
@@ -10,7 +10,7 @@ ms.date: 03/20/2024
 ---
 # About release notes for the WebView2 SDK
 
-The WebView2 team updates the WebView2 Release SDK and the WebView2 Prerelease SDK on a four-week cadence.  These release notes contain the latest information on product announcements, additions, modifications, and breaking changes to the APIs.
+The WebView2 team periodically updates the WebView2 Release SDK and the WebView2 Prerelease SDK.  These release notes contain the latest information on product announcements, additions, modifications, and breaking changes to the APIs.
 
 You can view the list of [Microsoft.Web.WebView2](https://www.nuget.org/packages/Microsoft.Web.WebView2) SDK packages at the NuGet site.
 

--- a/microsoft-edge/webview2/release-notes/about.md
+++ b/microsoft-edge/webview2/release-notes/about.md
@@ -18,49 +18,20 @@ Generally, release notes apply across the supported platforms, which are listed 
 
 Release notes entries correspond to historical releases of WebView2, and are not updated over time.  References to "new features" and "experimental APIs" might become outdated as new versions of WebView2 are released.
 
-See also:
-* [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
-
 
 <!-- ====================================================================== -->
-## Cadence of WebView2 release notes: 2 weeks
+## Release cadence
 
-The WebView2 Release notes have a 2-week release cadence.
-
-Release notes include:
-* Bug fixes for the WebView2 SDK (which has a monthly release cadence).
-* Bug fixes for the WebView2 Runtime (which has a 2-week release cadence).
-
-See:
-* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
-
-
-<!-- ====================================================================== -->
-## Release cadence of WebView2 SDK: monthly
-
-The WebView2 Prerelease SDK & the WebView2 Release SDK have a monthly release cadence.
-
-See:
-* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
-
-
-<!-- ====================================================================== -->
-## Release cadence of WebView2 Runtime: 2 weeks
-
-The WebView2 Runtime has a 2-week release cadence.
-
-See:
-* [Distribute your app and the WebView2 Runtime](../concepts/distribution.md)
-* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
-
-
-<!-- ====================================================================== -->
-## Release cadence of Microsoft Edge: 2 weeks
-
-The Microsoft Edge browser (Stable version) has a 2-week release cadence.
+The following have a 2-week release cadence:
+* WebView2 Release notes.
+* WebView2 Release SDK.
+* WebView2 Prerelease SDK.
+* Microsoft Edge.
+* WebView2 Runtime.
 
 See:
 * [Microsoft Edge release schedule](/deployedge/microsoft-edge-release-schedule)
+* [WebView2 Runtime is changing to a 2-week release cadence](../release-notes/index.md#webview2-runtime-is-changing-to-a-2-week-release-cadence) in _Release notes for the WebView2 SDK_.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/about.md
+++ b/microsoft-edge/webview2/release-notes/about.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 03/20/2024
+ms.date: 07/14/2026
 ---
 # About release notes for the WebView2 SDK
 
@@ -26,7 +26,6 @@ The following have a 2-week release cadence:
 * WebView2 Release notes.
 * WebView2 Release SDK.
 * WebView2 Prerelease SDK.
-* Microsoft Edge.
 * WebView2 Runtime.
 
 See:

--- a/microsoft-edge/webview2/release-notes/archive.md
+++ b/microsoft-edge/webview2/release-notes/archive.md
@@ -20,7 +20,7 @@ if change h2 headings pattern, enter work item: update links in announcements
 
 <!-- todo: update links in announcements -->
 
-The following features and bug fixes are in the WebView2 Release SDK and Prerelease SDK, for SDKs over one year old.
+The following features and bug fixes are in the WebView2 Release SDK and Prerelease SDK, for earlier SDKs.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -25,7 +25,7 @@ when change an h2 heading or move h2 sections from index.md to archive.md, enter
 todo: update links in announcements, since the Prerelease headings & Release headings in index.md & archive.md changed; AB#62191954
 -->
 
-The following new features and bug fixes are in the WebView2 Release SDK and Prerelease SDK, for SDKs during the past year.
+The following new features and bug fixes are in the WebView2 Release SDK and Prerelease SDK.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -137,11 +137,11 @@ If `CoreWebView2Settings.IsReputationCheckingRequired` is set to `false`, settin
    * [ReputationChecking](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeature?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
 
 * `CoreWebView2Profile` Class:
-   * [CoreWebView2Profile.SetOriginFeatures Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.setoriginfeatures)
+   * [CoreWebView2Profile.SetOriginFeatures Method](/dotnet/api/microsoft.web.webview2.core.corewebview2profile.setoriginfeatures?view=webview2-dotnet-1.0.4126-prerelease&preserve-view=true)
 
 Older supporting APIs:
 
-* [CoreWebView2OriginFeatureState` Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeaturestate)
+* [CoreWebView2OriginFeatureState Enum](/dotnet/api/microsoft.web.webview2.core.corewebview2originfeaturestate)
    * `Enabled`
    * `Disabled`
 
@@ -150,15 +150,15 @@ Older supporting APIs:
 
 ##### [WinRT/C#](#tab/winrtcsharp)
 
-* `CoreWebView2Profile` Class:
-   * [CoreWebView2Profile.SetOriginFeatures Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile#setoriginfeatures)
-
 * `CoreWebView2OriginFeature` Enum:
    * [ReputationChecking](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeature?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true)
 
+* `CoreWebView2Profile` Class:
+   * [CoreWebView2Profile.SetOriginFeatures Method](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2profile?view=webview2-winrt-1.0.4126-prerelease&preserve-view=true#setoriginfeatures)
+
 Older supporting APIs:
 
-* [CoreWebView2OriginFeatureState` Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeaturestate)
+* [CoreWebView2OriginFeatureState Enum](/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2originfeaturestate)
    * `Enabled`
    * `Disabled`
 
@@ -167,11 +167,11 @@ Older supporting APIs:
 
 ##### [Win32/C++](#tab/win32cpp)
 
-* `ICoreWebView2Profile`:
-   * [ICoreWebView2Profile::SetOriginFeatures](/microsoft-edge/webview2/reference/win32/icorewebview2profile?view=webview2-1.0.4126-prerelease&preserve-view=true#setoriginfeatures)
+* `ICoreWebView2ExperimentalProfile16`:
+   * [ICoreWebView2ExperimentalProfile16::SetOriginFeatures](/microsoft-edge/webview2/reference/win32/icorewebview2experimentalprofile16?view=webview2-1.0.4126-prerelease&preserve-view=true#setoriginfeatures)
 
 * `COREWEBVIEW2_ORIGIN_FEATURE` enum:
-   * [COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING](/microsoft-edge/webview2/reference/win32/webview2experimental-idl?view=webview2-1.0.4126-prerelease&preserve-view=true#corewebview2_origin_feature_reputation_checking)
+   * [COREWEBVIEW2_ORIGIN_FEATURE_REPUTATION_CHECKING](/microsoft-edge/webview2/reference/win32/webview2experimental-idl?view=webview2-1.0.4126-prerelease&preserve-view=true#corewebview2_origin_feature)
 
 Older supporting APIs:
 


### PR DESCRIPTION
Rendered article sections for review:

* **Distribute your app and the WebView2 Runtime** > **Runtime or browser support during development or production**
   * `/webview2/concepts/distribution.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/distribution?branch=pr-en-us-3850#runtime-or-browser-support-during-development-or-production
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution#runtime-or-browser-support-during-development-or-production
   * Changed "update cadence" to "update release cadence".

* **Prerelease and Release SDKs for WebView2** > **Release cadence**
   * `/webview2/concepts/versioning.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/versioning?branch=pr-en-us-3850#release-cadence
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/versioning#release-cadence
   * Linked to About relnotes > Release cadence, and Edge schedule.

* **About release notes for the WebView2 SDK**
   * `/webview2/release-notes/about.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/about?branch=pr-en-us-3850
   * External preview: https://github.com/MicrosoftDocs/edge-developer/blob/user/mikehoffms/relnotes-cadence/microsoft-edge/webview2/release-notes/about.md
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/about
   * Added section about cadence.

* **Archived release notes for the WebView2 SDK**
   * `/webview2/release-notes/archive.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/archive?branch=pr-en-us-3850
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/archive
   * Changed from "SDKs over one year old" to "earlier SDKs".

* **Release notes for the WebView2 SDK** > **Configure per-origin reputation checking (SmartScreen) settings**
   * `\webview2\release-notes\index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/index?branch=pr-en-us-3850#configure-per-origin-reputation-checking-smartscreen-settings
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#configure-per-origin-reputation-checking-smartscreen-settings
   * Fixed API Ref links.
   * Deleted "for SDKs during the past year."

* **What's new in PWAs** > **What's new in Microsoft Edge 94**
   * `\progressive-web-apps\whats-new\pwa.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/progressive-web-apps/whats-new/pwa?branch=pr-en-us-3850#whats-new-in-microsoft-edge-94
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/progressive-web-apps/whats-new/pwa#whats-new-in-microsoft-edge-94
   * Removed mention of 4-week cycle.

* **Migrate an extension from Manifest V2 to V3** > **Background service workers**
   * `\extensions\developer-guide\migrate-your-extension-from-manifest-v2-to-v3.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3?branch=pr-en-us-3850#background-service-workers
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3#background-service-workers
   * Condensed to just a link instead of "extensions team is evaluating and investigating the impact that this change brings".

AB#62592043 - wv2
AB#62592047 - PWA
AB#59450117 - Extensions
