### PR TITLE
Remove the WV2 cadence note

### DIFF
--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -47,8 +47,6 @@ For full API compatibility, this Prerelease version of the WebView2 SDK requires
 
 Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week release cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week release cadence.
 
-The WebView2 SDK continues on its monthly release cadence.
-
 See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
 
 
@@ -232,8 +230,6 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 ###### WebView2 Runtime is changing to a 2-week release cadence
 
 Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week release cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week release cadence.
-
-The WebView2 SDK continues on its monthly release cadence.
 
 See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -223,18 +223,6 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
-#### General changes
-
-
-<!-- ---------- -->
-###### WebView2 Runtime is changing to a 2-week release cadence
-
-Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-week release cadence.  This is aligned with Microsoft Edge.  WebView2 Runtime version 151 is the final release that's on a 4-week release cadence.
-
-See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
-
-
-<!-- ------------------------------ -->
 #### Promotions to Phase 3 (Stable in Release)
 
 No additional APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, in this Release SDK.

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -223,6 +223,16 @@ For full API compatibility, this Release version of the WebView2 SDK requires We
 
 
 <!-- ------------------------------ -->
+#### General changes
+
+
+<!-- ---------- -->
+###### WebView2 Runtime is changing to a 2-week release cadence
+
+See [WebView2 Runtime is changing to a 2-week release cadence](#webview2-runtime-is-changing-to-a-2-week-release-cadence), in the Prerelease section above.
+
+
+<!-- ------------------------------ -->
 #### Promotions to Phase 3 (Stable in Release)
 
 No additional APIs have been promoted from Phase 2: Stable in Prerelease, to Phase 3: Stable in Release, in this Release SDK.


### PR DESCRIPTION
Rendered article sections for review:

* **Release notes for the WebView2 SDK** > **WebView2 Runtime is changing to a 2-week release cadence**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/index?branch=pr-en-us-3851
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/
   * Removed "The WebView2 SDK continues on its monthly release cadence."
   * Removed details from Release > General changes, linked to Prerelease section entry.

AB# pending
