### PR TITLE
"Dev. secure wv2 apps: Overrides for elevated host apps"

### DIFF
--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -97,13 +97,20 @@ For an elevated WebView2 host app process during development, use the appropriat
 
 When the host process is running elevated:
 
-* `WEBVIEW2_*` environment variable overrides (flags) are ignored.  See [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
+* `WEBVIEW2_*` environment variable overrides (flags) are ignored.  See:
+   * [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
 
-* Configuration flags that are specified within the WebView2 app via the WebView2 API are honored.  See [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
+* Configuration flags that are specified within the WebView2 app via the WebView2 API are honored.  See:
+   * [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
-* `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.
+* `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.  See:
+   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
+   * [Test upcoming APIs and features](../how-to/set-preview-channel.md)
+   * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md)
 
-* `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.
+* `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.  See:
+   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
+   * [Test upcoming APIs and features](../how-to/set-preview-channel.md)
 
 Non-elevated WebView2 apps honor all of the supported override mechanisms.
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -91,7 +91,7 @@ WebView2 cannot be run as a system user.  This restriction blocks scenarios such
 
 
 <!-- ====================================================================== -->
-## Security hardening for elevated WebView2 hosts
+## Overrides for elevated WebView2 host apps
 
 _todo: can heading be a task/verb?_
 
@@ -105,11 +105,11 @@ _("elevated" is in this section of this article, not in other sections in this a
 
 To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.  (Non-elevated WebView2 apps honor all of the supported override mechanisms.)
 
-When the host is running elevated:
+When the host process is running elevated:
 
-* `WEBVIEW2_*` environment variable overrides are ignored.  See [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
+* `WEBVIEW2_*` environment variable overrides (flags) are ignored.  See [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
 
-* Configuration that's passed directly by the WebView2 application through the WebView2 API are honored.  See [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
+* Configuration flags that are specified within the WebView2 app via the WebView2 API are honored.  See [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
 * `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -94,24 +94,26 @@ WebView2 cannot be run as a system user.  This restriction blocks scenarios such
 ## Security hardening for elevated WebView2 hosts
 
 _todo: can heading be a task/verb?_
-_what's the recommended Dev action here?_
-_this is system-describing docs; need task-oriented docs_
-_how do you use this section's info to "Develop secure WebView2 apps", per "follow the below practices to improve the security of your WebView2 application"?_
-_"elevated" is in this section of this article, not in other sections in this article_
 
-To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
+_what's the recommended Dev action here?_
+
+_this is system-describing docs; need task-oriented docs_
+
+_how do you use this section's info to "Develop secure WebView2 apps", per "follow the below practices to improve the security of your WebView2 application"?_
+
+_("elevated" is in this section of this article, not in other sections in this article)_
+
+To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.  (Non-elevated WebView2 apps honor all of the supported override mechanisms.)
 
 When the host is running elevated:
 
 * `WEBVIEW2_*` environment variable overrides are ignored.  See [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
 
-* Configuration that's passed directly by the WebView2 application through the WebView2 API continues to be honored.  See [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
+* Configuration that's passed directly by the WebView2 application through the WebView2 API are honored.  See [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
 * `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.
 
-* `HKEY_LOCAL_MACHINE` (HKLM) policy overrides continue to be honored.
-
-This change only affects elevated processes.  Non-elevated applications continue to use all supported override mechanisms as before.
+* `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.
 
 See also:
 * [Distribute your app and the WebView2 Runtime](./distribution.md) - Find "elevated".

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 06/27/2024
+ms.date: 07/09/2026
 ---
 # Develop secure WebView2 apps
 
@@ -88,3 +88,36 @@ When navigating to a new document, use the `ContentLoading` event and `RemoveHos
 ## WebView2 cannot be run as a system user
 
 WebView2 cannot be run as a system user.  This restriction blocks scenarios such as building a Credential Provider.
+
+
+<!-- ====================================================================== -->
+## Security hardening for elevated WebView2 hosts
+
+_todo: can heading be a task/verb?_
+_what's the recommended Dev action here?_
+_this is system-describing docs; need task-oriented docs_
+_how do you use this section's info to "Develop secure WebView2 apps", per "follow the below practices to improve the security of your WebView2 application"?_
+_"elevated" is in this section of this article, not in other sections in this article_
+
+To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
+
+When the host is running elevated:
+
+* `WEBVIEW2_*` environment variable overrides are ignored.  See [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
+
+* Configuration that's passed directly by the WebView2 application through the WebView2 API continues to be honored.  See [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
+
+* `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.
+
+* `HKEY_LOCAL_MACHINE` (HKLM) policy overrides continue to be honored.
+
+This change only affects elevated processes.  Non-elevated applications continue to use all supported override mechanisms as before.
+
+See also:
+* [Distribute your app and the WebView2 Runtime](./distribution.md) - Find "elevated".
+
+
+<!-- ====================================================================== -->
+## See also
+
+* [Development best practices for WebView2 apps](./developer-guide.md)

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -91,19 +91,9 @@ WebView2 cannot be run as a system user.  This restriction blocks scenarios such
 
 
 <!-- ====================================================================== -->
-## Overrides for elevated WebView2 host apps
+## For elevated host app, use appropriate override flags
 
-_todo: can heading be a task/verb?_
-
-_what's the recommended Dev action here?_
-
-_this is system-describing docs; need task-oriented docs_
-
-_how do you use this section's info to "Develop secure WebView2 apps", per "follow the below practices to improve the security of your WebView2 application"?_
-
-_("elevated" is in this section of this article, not in other sections in this article)_
-
-To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
+For an elevated WebView2 host app process during development, use the appropriate type of override flags.  To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
 
 When the host process is running elevated:
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -104,13 +104,13 @@ When the host process is running elevated:
    * [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
 * `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.  See:
-   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
    * [Test upcoming APIs and features](../how-to/set-preview-channel.md)
+   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
    * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md)
 
 * `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.  See:
-   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
    * [Test upcoming APIs and features](../how-to/set-preview-channel.md)
+   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
 
 Non-elevated WebView2 apps honor all of the supported override mechanisms.
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -91,7 +91,7 @@ WebView2 cannot be run as a system user.  This restriction blocks scenarios such
 
 
 <!-- ====================================================================== -->
-## For elevated host app, use appropriate override flags
+## For an elevated host app, use appropriate override flags
 
 For an elevated WebView2 host app process during development, use the appropriate type of override flags.  To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -104,12 +104,12 @@ When the host process is running elevated:
    * [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
 * `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.  See:
-   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
+   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) (and other sections) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
    * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_CURRENT_USER`.
    * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md) - Find `HKEY_CURRENT_USER`.
 
 * `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.  See:
-   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
+   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) (and other sections) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
    * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_LOCAL_MACHINE`.
 
 Non-elevated WebView2 apps honor all of the supported override mechanisms.

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 07/10/2026
+ms.date: 07/14/2026
 ---
 # Develop secure WebView2 apps
 
@@ -105,7 +105,7 @@ For an elevated WebView2 host app process, use the appropriate type of override 
 
 When the host process is running elevated:
 
-* `WEBVIEW2_*` environment variable overrides (flags) are ignored.  See:
+* `WEBVIEW2_*` environment variable overrides (flags) are ignored, including `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`.  See:
    * [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
 
 * Configuration flags that are specified within the WebView2 app via the WebView2 API are honored.  See:
@@ -118,6 +118,8 @@ When the host process is running elevated:
       * [Setting the browser executable folder (for local testing)](../how-to/set-preview-channel.md#setting-the-browser-executable-folder-for-local-testing) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
    * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_CURRENT_USER`.
    * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md) - Find `HKEY_CURRENT_USER`.
+
+* `AdditionalBrowserArguments` registry overrides that are under `HKCU` are ignored.
 
 * `HKEY_LOCAL_MACHINE` (`HKLM`) policy overrides are honored.  See:
    * _Test upcoming APIs and features_

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: webview
-ms.date: 07/09/2026
+ms.date: 07/10/2026
 ---
 # Develop secure WebView2 apps
 
@@ -103,13 +103,19 @@ When the host process is running elevated:
 * Configuration flags that are specified within the WebView2 app via the WebView2 API are honored.  See:
    * [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
-* `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.  See:
-   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) (and other sections) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
+* `HKEY_CURRENT_USER` (`HKCU`) policy overrides are ignored.  See:
+   * _Test upcoming APIs and features_
+      * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
+      * [How to use `ChannelSearchKind` to ensure that a particular channel is used](../how-to/set-preview-channel.md#how-to-use-channelsearchkind-to-ensure-that-a-particular-channel-is-used) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
+      * [Setting the browser executable folder (for local testing)](../how-to/set-preview-channel.md#setting-the-browser-executable-folder-for-local-testing) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
    * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_CURRENT_USER`.
    * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md) - Find `HKEY_CURRENT_USER`.
 
-* `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.  See:
-   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) (and other sections) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
+* `HKEY_LOCAL_MACHINE` (`HKLM`) policy overrides are honored.  See:
+   * _Test upcoming APIs and features_
+      * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
+      * [How to use `ChannelSearchKind` to ensure that a particular channel is used](../how-to/set-preview-channel.md#how-to-use-channelsearchkind-to-ensure-that-a-particular-channel-is-used) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
+      * [Setting the browser executable folder (for local testing)](../how-to/set-preview-channel.md#setting-the-browser-executable-folder-for-local-testing) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
    * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_LOCAL_MACHINE`.
 
 Non-elevated WebView2 apps honor all of the supported override mechanisms.

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -103,7 +103,7 @@ _how do you use this section's info to "Develop secure WebView2 apps", per "foll
 
 _("elevated" is in this section of this article, not in other sections in this article)_
 
-To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.  (Non-elevated WebView2 apps honor all of the supported override mechanisms.)
+To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
 
 When the host process is running elevated:
 
@@ -114,6 +114,8 @@ When the host process is running elevated:
 * `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.
 
 * `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.
+
+Non-elevated WebView2 apps honor all of the supported override mechanisms.
 
 See also:
 * [Distribute your app and the WebView2 Runtime](./distribution.md) - Find "elevated".

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -112,21 +112,17 @@ When the host process is running elevated:
    * [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
 * `HKEY_CURRENT_USER` (`HKCU`) policy overrides are ignored.  See:
-   * _Test upcoming APIs and features_
-      * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
-      * [How to use `ChannelSearchKind` to ensure that a particular channel is used](../how-to/set-preview-channel.md#how-to-use-channelsearchkind-to-ensure-that-a-particular-channel-is-used) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
-      * [Setting the browser executable folder (for local testing)](../how-to/set-preview-channel.md#setting-the-browser-executable-folder-for-local-testing) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
-   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_CURRENT_USER`.
+   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
+   * [How to use `ChannelSearchKind` to ensure that a particular channel is used](../how-to/set-preview-channel.md#how-to-use-channelsearchkind-to-ensure-that-a-particular-channel-is-used) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
+   * [Setting the browser executable folder (for local testing)](../how-to/set-preview-channel.md#setting-the-browser-executable-folder-for-local-testing) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
    * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md) - Find `HKEY_CURRENT_USER`.
 
 * `AdditionalBrowserArguments` registry overrides that are under `HKCU` are ignored.
 
 * `HKEY_LOCAL_MACHINE` (`HKLM`) policy overrides are honored.  See:
-   * _Test upcoming APIs and features_
-      * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
-      * [How to use `ChannelSearchKind` to ensure that a particular channel is used](../how-to/set-preview-channel.md#how-to-use-channelsearchkind-to-ensure-that-a-particular-channel-is-used) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
-      * [Setting the browser executable folder (for local testing)](../how-to/set-preview-channel.md#setting-the-browser-executable-folder-for-local-testing) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
-   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_LOCAL_MACHINE`.
+   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
+   * [How to use `ChannelSearchKind` to ensure that a particular channel is used](../how-to/set-preview-channel.md#how-to-use-channelsearchkind-to-ensure-that-a-particular-channel-is-used) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
+   * [Setting the browser executable folder (for local testing)](../how-to/set-preview-channel.md#setting-the-browser-executable-folder-for-local-testing) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
 
 Non-elevated WebView2 apps honor all of the supported override mechanisms.
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -93,7 +93,7 @@ WebView2 cannot be run as a system user.  This restriction blocks scenarios such
 <!-- ====================================================================== -->
 ## For an elevated host app, use appropriate override flags
 
-For an elevated WebView2 host app process during development, use the appropriate type of override flags.  To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
+For an elevated WebView2 host app process, use the appropriate type of override flags.  To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
 
 When the host process is running elevated:
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -104,13 +104,13 @@ When the host process is running elevated:
    * [Setting browser flags programmatically through code](./webview-features-flags.md#setting-browser-flags-programmatically-through-code) in _WebView2 browser flags_.
 
 * `HKEY_CURRENT_USER` (HKCU) policy overrides are ignored.  See:
-   * [Test upcoming APIs and features](../how-to/set-preview-channel.md)
-   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
-   * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md)
+   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKCU`.
+   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_CURRENT_USER`.
+   * [Debug WebView2 apps with Visual Studio Code](../how-to/debug-visual-studio-code.md) - Find `HKEY_CURRENT_USER`.
 
 * `HKEY_LOCAL_MACHINE` (HKLM) policy overrides are honored.  See:
-   * [Test upcoming APIs and features](../how-to/set-preview-channel.md)
-   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_.
+   * [Switching the channel search order (recommended)](../how-to/set-preview-channel.md#switching-the-channel-search-order-recommended) in _Test upcoming APIs and features_ - Select the **Registry key** tab, and then Find `HKLM`.
+   * [Detect if a WebView2 Runtime is already installed](./distribution.md#detect-if-a-webview2-runtime-is-already-installed) in _Distribute your app and the WebView2 Runtime_ - Find `HKEY_LOCAL_MACHINE`.
 
 Non-elevated WebView2 apps honor all of the supported override mechanisms.
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -91,7 +91,15 @@ WebView2 cannot be run as a system user.  This restriction blocks scenarios such
 
 
 <!-- ====================================================================== -->
-## For an elevated host app, use appropriate override flags
+## Recommended privilege level for WebView2 host applications
+
+As a security best practice, we recommend hosting WebView2 in a process that runs at standard (non-elevated) user integrity.  Following the principle of least privilege, applications should avoid running the WebView2-hosting component with elevated (administrator) privileges.
+
+If your application requires elevated privileges for certain operations, we recommend isolating that work in a separate, dedicated process and keeping the WebView2 host component de-elevated.  This keeps the browser-hosting surface at the lowest privilege level necessary, and aligns with recommended Windows application security practices.
+
+
+<!-- ------------------------------ -->
+#### For an elevated host app, use appropriate override flags
 
 For an elevated WebView2 host app process, use the appropriate type of override flags.  To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -101,7 +101,7 @@ If your application requires elevated privileges for certain operations, we reco
 <!-- ------------------------------ -->
 #### For an elevated host app, use appropriate override flags
 
-For an elevated WebView2 host app process, use the appropriate type of override flags.  To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
+For an elevated WebView2 host app process, use the appropriate type of override flags.  An elevated process is a High Integrity Level (High IL) process.  To help protect elevated processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.
 
 When the host process is running elevated:
 

--- a/microsoft-edge/webview2/concepts/security.md
+++ b/microsoft-edge/webview2/concepts/security.md
@@ -105,7 +105,7 @@ _("elevated" is in this section of this article, not in other sections in this a
 
 To help protect elevated (High Integrity) processes from configuration that can be modified by standard users, WebView2 ignores certain user-scoped override mechanisms when the host process is running elevated.  (Non-elevated WebView2 apps honor all of the supported override mechanisms.)
 
-When the host is running elevated:
+When the host process is running elevated:
 
 * `WEBVIEW2_*` environment variable overrides are ignored.  See [Setting browser flags in your local device environment](./webview-features-flags.md#setting-browser-flags-in-your-local-device-environment) in _WebView2 browser flags_.
 

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -33,11 +33,15 @@ You can set browser flags in your local device environment, or set browser flags
 
 To test forthcoming features or to diagnose issues, we recommend using browser flags in your local device environment, via setting the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable or via registry keys.  For more information, see the following Win32 API Reference: [CreateCoreWebView2EnvironmentWithOptions](/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions).
 
+Flags that are set via the local device environment are ignored for elevated apps; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
+
 
 <!-- ====================================================================== -->
 ## Setting browser flags programmatically through code
 
 Instead of setting browser flags in your local device environment, an alternative approach is to set browser flags programmatically, by passing the browser flags as the `AdditionalBrowserArguments` property of `CoreWebView2EnvironmentOptions`.  If you set browser flags programmatically, be sure to remove the flags in code before shipping your app, to avoid accidentally shipping the flags in production.
+
+Flags that are set via code are honored for elevated apps; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -33,7 +33,7 @@ You can set browser flags in your local device environment, or set browser flags
 
 To test forthcoming features or to diagnose issues, we recommend using browser flags in your local device environment, via setting the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable or via registry keys.  For more information, see the following Win32 API Reference: [CreateCoreWebView2EnvironmentWithOptions](/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions).
 
-Elevated apps ignore flags that are set via the local device environment; see [For elevated host app, use appropriate override flags](./security.md#for-elevated-host-app-use-appropriate-override-flags) in _Develop secure WebView2 apps_.
+Elevated apps ignore flags that are set via the local device environment; see [For an elevated host app, use appropriate override flags](./security.md#for-an-elevated-host-app-use-appropriate-override-flags) in _Develop secure WebView2 apps_.
 
 
 <!-- ====================================================================== -->
@@ -41,7 +41,7 @@ Elevated apps ignore flags that are set via the local device environment; see [F
 
 Instead of setting browser flags in your local device environment, an alternative approach is to set browser flags programmatically, by passing the browser flags as the `AdditionalBrowserArguments` property of `CoreWebView2EnvironmentOptions`.  If you set browser flags programmatically, be sure to remove the flags in code before shipping your app, to avoid accidentally shipping the flags in production.
 
-Elevated apps honor flags that are set via code; see [For elevated host app, use appropriate override flags](./security.md#for-elevated-host-app-use-appropriate-override-flags) in _Develop secure WebView2 apps_.
+Elevated apps honor flags that are set via code; see [For an elevated host app, use appropriate override flags](./security.md#for-an-elevated-host-app-use-appropriate-override-flags) in _Develop secure WebView2 apps_.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -33,7 +33,7 @@ You can set browser flags in your local device environment, or set browser flags
 
 To test forthcoming features or to diagnose issues, we recommend using browser flags in your local device environment, via setting the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable or via registry keys.  For more information, see the following Win32 API Reference: [CreateCoreWebView2EnvironmentWithOptions](/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions).
 
-Flags that are set via the local device environment are ignored for elevated apps; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
+Elevated apps ignore flags that are set via the local device environment; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
 
 
 <!-- ====================================================================== -->
@@ -41,7 +41,7 @@ Flags that are set via the local device environment are ignored for elevated app
 
 Instead of setting browser flags in your local device environment, an alternative approach is to set browser flags programmatically, by passing the browser flags as the `AdditionalBrowserArguments` property of `CoreWebView2EnvironmentOptions`.  If you set browser flags programmatically, be sure to remove the flags in code before shipping your app, to avoid accidentally shipping the flags in production.
 
-Flags that are set via code are honored for elevated apps; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
+Elevated apps honor flags that are set via code; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/concepts/webview-features-flags.md
+++ b/microsoft-edge/webview2/concepts/webview-features-flags.md
@@ -33,7 +33,7 @@ You can set browser flags in your local device environment, or set browser flags
 
 To test forthcoming features or to diagnose issues, we recommend using browser flags in your local device environment, via setting the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable or via registry keys.  For more information, see the following Win32 API Reference: [CreateCoreWebView2EnvironmentWithOptions](/microsoft-edge/webview2/reference/win32/webview2-idl#createcorewebview2environmentwithoptions).
 
-Elevated apps ignore flags that are set via the local device environment; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
+Elevated apps ignore flags that are set via the local device environment; see [For elevated host app, use appropriate override flags](./security.md#for-elevated-host-app-use-appropriate-override-flags) in _Develop secure WebView2 apps_.
 
 
 <!-- ====================================================================== -->
@@ -41,7 +41,7 @@ Elevated apps ignore flags that are set via the local device environment; see [O
 
 Instead of setting browser flags in your local device environment, an alternative approach is to set browser flags programmatically, by passing the browser flags as the `AdditionalBrowserArguments` property of `CoreWebView2EnvironmentOptions`.  If you set browser flags programmatically, be sure to remove the flags in code before shipping your app, to avoid accidentally shipping the flags in production.
 
-Elevated apps honor flags that are set via code; see [Overrides for elevated WebView2 host apps](./security.md#overrides-for-elevated-webview2-host-apps) in _Develop secure WebView2 apps_.
+Elevated apps honor flags that are set via code; see [For elevated host app, use appropriate override flags](./security.md#for-elevated-host-app-use-appropriate-override-flags) in _Develop secure WebView2 apps_.
 
 ##### [.NET/C#](#tab/dotnetcsharp)
 

--- a/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
+++ b/microsoft-edge/webview2/how-to/debug-visual-studio-code.md
@@ -45,7 +45,7 @@ The following code demonstrates launching the app from Visual Studio Code (rathe
 <!-- ---------------------------------- -->
 #### Using a registry value
 
-Instead of setting the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable, you can add a new registry value named `<myApp.exe>` with data `--remote-debugging-port=9222` to the registry under registry key `Computer\HKEY_CURRENT_USER\Software\Policies\Microsoft\Edge\WebView2\AdditionalBrowserArguments`, so that the debugger can find the proper port.  For more information, see [WewbView2 browser flags](../concepts/webview-features-flags.md).
+Instead of setting the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable, you can add a new registry value named `<myApp.exe>` with data `--remote-debugging-port=9222` to the registry under registry key `Computer\HKEY_CURRENT_USER\Software\Policies\Microsoft\Edge\WebView2\AdditionalBrowserArguments`, so that the debugger can find the proper port.  For more information, see [WebView2 browser flags](../concepts/webview-features-flags.md).
 
 
 <!-- ---------------------------------- -->
@@ -155,7 +155,7 @@ You also need to add a new REGKEY `<myApp.exe> = --remote-debugging-port=9222` u
 <!-- ---------------------------------- -->
 #### Using an environment variable
 
-Instead of adding the above registry key, you can set the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable to `--remote-debugging-port=9222`.  Make sure that your application is started after the environment variable is set, and make sure that your application inherits the environment variable.  For more information, see [WewbView2 browser flags](../concepts/webview-features-flags.md).
+Instead of adding the above registry key, you can set the `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` environment variable to `--remote-debugging-port=9222`.  Make sure that your application is started after the environment variable is set, and make sure that your application inherits the environment variable.  For more information, see [WebView2 browser flags](../concepts/webview-features-flags.md).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -50,6 +50,12 @@ Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-wee
 See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
 
 
+<!-- ====================================================================== -->
+## Run your WebView2 host application at standard user integrity rather than elevated
+
+Run your WebView2 host application at standard user integrity rather than elevated.  See [Recommended privilege level for WebView2 host applications](../concepts/security.md#recommended-privilege-level-for-webview2-host-applications) in _Develop secure WebView2 apps_.
+
+
 <!-- ------------------------------ -->
 #### Experimental APIs (Phase 1: Experimental in Prerelease)
 

--- a/microsoft-edge/webview2/release-notes/index.md
+++ b/microsoft-edge/webview2/release-notes/index.md
@@ -50,8 +50,8 @@ Starting with version 152 (Aug. 24, 2026), the WebView2 Runtime moves to a 2-wee
 See [[Announcement] WebView2 Runtime moves to a 2-week release cadence (starting v152)](https://github.com/MicrosoftEdge/WebView2Announcements/issues/137).
 
 
-<!-- ====================================================================== -->
-## Run your WebView2 host application at standard user integrity rather than elevated
+<!-- ---------- -->
+###### Run your WebView2 host application at standard user integrity rather than elevated
 
 Run your WebView2 host application at standard user integrity rather than elevated.  See [Recommended privilege level for WebView2 host applications](../concepts/security.md#recommended-privilege-level-for-webview2-host-applications) in _Develop secure WebView2 apps_.
 


### PR DESCRIPTION
Rendered article sections for review:

* **Develop secure WebView2 apps** > **For an elevated host app, use appropriate override flags**
   * `\webview2\concepts\security.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/security?branch=pr-en-us-3853#for-an-elevated-host-app-use-appropriate-override-flags
   * External preview: 
   * Planned live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/security#for-an-elevated-host-app-use-appropriate-override-flags
   * New section.

* **WebView2 browser flags** > **Setting browser flags in your local device environment**
   * `/webview2/concepts/webview-features-flags.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags?branch=pr-en-us-3853#setting-browser-flags-in-your-local-device-environment
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/concepts/webview-features-flags#setting-browser-flags-in-your-local-device-environment
   * Added:
      * Elevated apps ignore flags that are set via the local device environment.
      * Elevated apps honor flags that are set via code.

* **Debug WebView2 apps with Visual Studio Code** > **Using a registry value**
   * `/webview2/how-to/debug-visual-studio-code.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/how-to/debug-visual-studio-code?branch=pr-en-us-3853#using-a-registry-value
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/how-to/debug-visual-studio-code#using-a-registry-value
   * Changed `WewbView2` to `WebView2` in link text.

* **Release notes for the WebView2 SDK** > **Run your WebView2 host application at standard user integrity rather than elevated**
   * `/webview2/release-notes/index.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/webview2/release-notes/index?branch=pr-en-us-3853#run-your-webview2-host-application-at-standard-user-integrity-rather-than-elevated
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/webview2/release-notes/#run-your-webview2-host-application-at-standard-user-integrity-rather-than-elevated
   * New section.

AB#63027499
