### PR TITLE
Remove mentions of outdated Edge versions 138, 148

### DIFF
--- a/microsoft-edge/web-platform/languagedetector-api.md
+++ b/microsoft-edge/web-platform/languagedetector-api.md
@@ -89,7 +89,7 @@ An initial download of the model is required the first time a website calls the 
 
 To see the Language Detector API in action, and view existing code that uses this API:
 
-1. In Microsoft Edge 148 or later, go to [Language Detector API playground](https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/languagedetector-api/) in a new window or tab.
+1. Go to [Language Detector API playground](https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/languagedetector-api/) in a new window or tab.
 
 1. In the information banner at the top, check the status: it initially reads: **On-device API and model available.**
 

--- a/microsoft-edge/web-platform/translator-api.md
+++ b/microsoft-edge/web-platform/translator-api.md
@@ -55,12 +55,6 @@ To learn about the Language Detector API, see [Detect languages with the Languag
 
 
 <!-- ====================================================================== -->
-## Availability of the Translator API
-
-The Translator API is available in Microsoft Edge 148 or later.
-
-
-<!-- ====================================================================== -->
 ## Benefits of the Translator API
 
 The Translator API uses a task-specific model for machine translation that runs on the same device where the inputs to and outputs of the model are used (that is, locally).  This approach has the following benefits compared to cloud-based solutions:
@@ -99,7 +93,7 @@ An initial download of the on-device translation model is required the first tim
 
 To see the Translator API in action, and review existing code that uses the API:
 
-1. In Microsoft Edge 148 or later, go to [Translator API playground](https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/translator-api/) in a new window or tab.
+1. Go to [Translator API playground](https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/translator-api/) in a new window or tab.
 
 1. In the information banner at the top, check the status: it initially reads: **On-device API and model downloadable.  The model for a specified language pair will be downloaded the first time the API is used.**
 

--- a/microsoft-edge/web-platform/translator-api.md
+++ b/microsoft-edge/web-platform/translator-api.md
@@ -16,7 +16,6 @@ Use the Translator API to translate text between different languages from JavaSc
 <!-- https://github.com/captainbrosset/WebToc -->
 * [Introduction](#introduction)
 * [Use the Language Detector API with the Translator API](#use-the-language-detector-api-with-the-translator-api)
-* [Availability of the Translator API](#availability-of-the-translator-api)
 * [Benefits of the Translator API](#benefits-of-the-translator-api)
 * [Alternatives to the Translator API](#alternatives-to-the-translator-api)
 * [Disclaimer](#disclaimer)

--- a/microsoft-edge/web-platform/writing-assistance-apis.md
+++ b/microsoft-edge/web-platform/writing-assistance-apis.md
@@ -53,9 +53,7 @@ For introductory information about the Summarizer API, Writer API, and Rewriter 
 <!-- ====================================================================== -->
 ## Availability of the Writing Assistance APIs
 
-The Writer API and the Rewriter APIs are available as a developer preview in the Microsoft Edge Canary and Edge Dev channels, starting with version 138.0.3309.2.
-
-The Summarizer API has been enabled by default since Microsoft Edge 138.
+The Writer API and the Rewriter APIs are available as a developer preview in the Microsoft Edge Canary and Edge Dev channels, starting with version 138.0.3309.2.  The Summarizer API has been enabled by default since that version.
 
 The Writing Assistance APIs are optimized for tasks specific to generating, modifying, and summarizing text content.  To learn more about an alternative for more custom prompt engineering scenarios that may not be served by these APIs, see [Prompt a built-in language model with the Prompt API](./prompt-api.md).
 
@@ -189,7 +187,7 @@ To use the Writer API or the Rewriter API in Microsoft Edge:
    * **Writer API for on-device language model**.  (Through Edge 149, this flag's label was **Writer API for Phi mini**.)
    * **Rewriter API for on-device language model**.  (Through Edge 149, this flag's label was **Rewriter API for Phi mini**.)
 
-   (Starting with Microsoft Edge 138, the Summarizer API is enabled by default.  Prior to Microsoft Edge 138, to enable the Summarizer API, you had to enter **Summarization API for Phi mini** here, and then enable that flag.)
+   (The Summarizer API is enabled by default.  In earlier versions of Microsoft Edge, to enable the Summarizer API, you had to enter **Summarization API for Phi mini** here, and then enable that flag.)
 
 1. Next to the flag for the API, select **Enabled**:
 


### PR DESCRIPTION
Rendered article sections for review:

* **Translate text with the Translator API** > **heading**
   * `/web-platform/translator-api.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/translator-api?branch=pr-en-us-3854
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/translator-api
   * Removed mention of Edge version.

* **Detect languages with the Language Detector API** > **heading**
   * `/web-platform/languagedetector-api.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/languagedetector-api?branch=pr-en-us-3854
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/languagedetector-api
   * Removed mention of Edge version.

* **Summarize, write, and rewrite text with the Writing Assistance APIs** > **heading**
   * `/web-platform/writing-assistance-apis.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/web-platform/writing-assistance-apis?branch=pr-en-us-3854
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/web-platform/writing-assistance-apis
   * Removed mention of Edge version.

AB#63043737
