### PR TITLE
Add deprec. note in "Build a PWA for sidebar in Edge"

### DIFF
--- a/microsoft-edge/progressive-web-apps/how-to/sidebar.md
+++ b/microsoft-edge/progressive-web-apps/how-to/sidebar.md
@@ -6,9 +6,23 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: pwa
-ms.date: 02/20/2024
+ms.date: 07/22/2026
 ---
 # Build a PWA for the sidebar in Microsoft Edge
+
+Progressive Web Apps (PWAs) can opt-in to be pinned to the sidebar in Microsoft Edge.
+
+
+<!-- ====================================================================== -->
+## This feature is being deprecated
+
+Update July 2026: This feature is being deprecated, so that it will no longer be supported.
+
+For information about the Sidebar, see [Streamline access to your favorite sites and apps with Sidebar in Microsoft Edge](https://support.microsoft.com/edge/streamline-access-to-your-favorite-sites-and-apps-with-sidebar-in-microsoft-edge) at Microsoft Support.
+
+
+<!-- ====================================================================== -->
+## Introduction
 
 Progressive Web Apps (PWAs) can opt-in to be pinned to the sidebar in Microsoft Edge.
 

--- a/microsoft-edge/progressive-web-apps/how-to/sidebar.md
+++ b/microsoft-edge/progressive-web-apps/how-to/sidebar.md
@@ -10,13 +10,11 @@ ms.date: 07/22/2026
 ---
 # Build a PWA for the sidebar in Microsoft Edge
 
-Progressive Web Apps (PWAs) can opt-in to be pinned to the sidebar in Microsoft Edge.
-
 
 <!-- ====================================================================== -->
 ## This feature is being deprecated
 
-Update July 2026: This feature is being deprecated, so that it will no longer be supported.
+Update July 2026: This feature is being deprecated; it will soon no longer be supported.
 
 For information about the Sidebar, see [Streamline access to your favorite sites and apps with Sidebar in Microsoft Edge](https://support.microsoft.com/edge/streamline-access-to-your-favorite-sites-and-apps-with-sidebar-in-microsoft-edge) at Microsoft Support.
 


### PR DESCRIPTION
Rendered article sections for review:

* **Build a PWA for the sidebar in Microsoft Edge** > **This feature is being deprecated**
   * `\progressive-web-apps\how-to\sidebar.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/progressive-web-apps/how-to/sidebar?branch=pr-en-us-3871#this-feature-is-being-deprecated
   * External preview: 
   * Planned live: https://learn.microsoft.com/microsoft-edge/progressive-web-apps/how-to/sidebar#this-feature-is-being-deprecated
   * Added deprecation note, as an h2 section.
      * Not as an Alert, per corp style: "Avoid Note, Tip, and Important boxes—readers tend to skip over them. Placing that info directly into the article text is better."

AB#63224980
