### PR TITLE
Manifest timeline for Partner Center and Microsoft Edge

### DIFF
--- a/microsoft-edge/extensions/developer-guide/devtools-extension.md
+++ b/microsoft-edge/extensions/developer-guide/devtools-extension.md
@@ -113,7 +113,7 @@ This file is required, for an extension.  The manifest contains the following in
 | `name` | The name of the extension that will appear under `edge://extensions/`. |
 | `description` | The description of the extension that will be displayed under the name of the extension. |
 | `version` | The version of the extension that will appear next to the name of the extension. |
-| `manifest_version` | Determines the set of features that the extension will be using, such as network request modification.  The current version is version `3`.  To learn more about this version and the differences with version `2`, see [Overview and timelines for migrating to Manifest V3](../developer-guide/manifest-v3.md). |
+| `manifest_version` | Determines the set of features that the extension will be using, such as network request modification.  The current version is version `3`.  To learn more about this version and the differences with version `2`, see [Timeline for migrating to Manifest V3](../developer-guide/manifest-v3.md). |
 | `devtools_page` | The path to an HTML file that's run every time DevTools is opened, and loads the extension's JavaScript files.  This page isn't rendered in DevTools. |
 | `content_scripts` | The JavaScript or CSS files to use when the user opens specified webpages.  See [Content scripts](https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts) in the Chrome docs. |
 | `permissions` | The local device requires permissions to view its system memory capacity, since the script calls API for that. |
@@ -387,7 +387,7 @@ See also:
 <!-- toc order, except promoted 1st item: -->
 * [Sample: Custom DevTools tool](./devtools-extension-sample.md)<!-- toc bucket 5 -->
 * [Overview of DevTools](../../devtools/overview.md)<!-- top of whole toc -->
-* [Overview and timelines for migrating to Manifest V3](../developer-guide/manifest-v3.md)<!-- toc bucket 5, much higher than present article -->
+* [Timeline for migrating to Manifest V3](../developer-guide/manifest-v3.md)<!-- toc bucket 5, much higher than present article -->
 * [Supported APIs for Microsoft Edge extensions](../developer-guide/api-support.md)<!-- toc bucket 5, slightly higher than present article -->
 * [Get started developing an extension](../getting-started/index.md)<!-- toc bucket 2 -->
 * [Sample: Picture viewer pop-up webpage](../samples/picture-viewer-popup-webpage.md)<!-- toc bucket 3 -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -31,9 +31,8 @@ For enterprise customers:
 
 | Date | Changes |
 |---|---|
-| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest V3. |
-| Aug. 2026 | If your extension uses Manifest V2:  <br/>* At Partner Center, a Manifest V2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone). |
-| TBD | For enterprise users, in Microsoft Edge, support for Manifest V2 will be removed:  <br/>* The [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) policy will be removed.  <br/>* Extensions that use Manifest V2 will no longer work, even on enterprise-managed devices. |
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have **Visibility** set to **Public** or **Hidden**.  <br/>* To publish a new extension, use Manifest V3. |
+| Aug. 2026 | If your extension uses Manifest V2, at Partner Center, a Manifest V2 deprecation warning is displayed. |
 | TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  <br/>* You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
 
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: extensions
-ms.date: 08/03/2026
+ms.date: 08/04/2026
 ---
 # Overview and timelines for migrating to Manifest V3
 
@@ -40,8 +40,9 @@ An overview of the changes involved, as described in [Migrate an extension from 
 <!-- ---------------------------------------------------------------------- -->
 ## Manifest timeline for the Chromium browser engine
 
-Chromium has revised the timelines for ending support for Manifest V2.  See:
+Chromium has revised the timelines for ending support for Manifest V2.
 
+See:
 * [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium -->
 * [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium --> in _Resuming the transition to Manifest V3_.
 
@@ -49,33 +50,30 @@ Chromium has revised the timelines for ending support for Manifest V2.  See:
 <!-- ---------------------------------------------------------------------- -->
 ## Manifest timeline for Microsoft Edge and Partner Center
 
-To help you plan the migration of your extension from Manifest V2 to Manifest V3, consider the following schedule for support for Manifest V2 and V3 in Microsoft Edge and Microsoft Partner Center.
+To help you plan the migration of your extension from Manifest Version 2 to Manifest Version 3, the following schedule shows the planned support for Manifest Version 2 and V3 at Microsoft Partner Center (and the Edge Add-ons store), and in Microsoft Edge.
 
-The Microsoft Edge team will independently decide on MV3 migration timelines for Microsoft Edge extensions and share an update here.  We continue to analyze the concerns raised by extension developers and explore the optimal path for the Microsoft Edge extensions ecosystem.  Meanwhile, to plan the migration of your extension from Manifest V2 to Manifest V3, see [Manifest timeline for the Chromium browser engine](#manifest-timeline-for-the-chromium-browser-engine), above.
+If your extension still uses Manifest Version 2, migrate to Manifest Version 3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest Version 3 version of your extension is ready, submit the update through Microsoft Partner Center.
 
+For enterprise customers, extensions that use Manifest Version 2 will continue to be supported until further notice.  Deprecation of Manifest Version 2 extensions for enterprise customers is expected to begin in early 2027.
 
-**The Microsoft Edge team is currently in the process of updating this MV3 migration timeline.**
-
-| Timeframe | Microsoft Partner Center changes | Microsoft Edge changes |
-|--- |--- |--- |
-| Jul. 2022 (already in effect) | Microsoft Partner Center will no longer accept new Manifest V2 extensions with visibility set as `Hidden` or `Public`. | No change. |
-| TBD | Microsoft Partner Center will no longer accept updates to existing Manifest V2 extensions. Developers can submit updates for migrating a V2 extension to V3. | Microsoft Edge stops running Manifest V2 extensions. Enterprises can allow Manifest V2 extensions to run on Microsoft Edge, by using enterprise policies. |
-| TBD | No change. | Manifest V2 extensions will no longer function in Microsoft Edge, even with the use of enterprise policies. |
-
-Manifest V2 extensions will continue to be supported through Enterprise policies at least until the date in the Chromium Manifest V2 support timeline.
-
-Microsoft continues to iteratively improve the platform and address the feedback shared by extension developers.  Share your questions, comments, and concerns:
-* [Contact the Microsoft Edge extensions team](../contact.md)
-* [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) - forum about Microsoft Edge at Microsoft Tech Community.
-* [@MSEdgeDev](https://twitter.com/msedgedev/) - Microsoft Edge team on X (Twitter).
-
-<!-- deleted, n/a, 2020: https://techcommunity.microsoft.com/t5/articles/manifest-v3-changes-are-now-available-in-microsoft-edge/m-p/1780254 -->
+| Date | Changes |
+|---|---|
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions with visibility set to `Public` or `Hidden`.  <br/>To publish a new extension, use Manifest Version 3. |
+| Aug. 2026 | If your extension uses Manifest Version 2:  <br/>At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users.  <br/>In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users. |
+| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed.  <br/>The `ExtensionManifestV2Availability` policy will be removed.  <br/>Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
+| TBD | Microsoft Partner Center (and thus the Edge Add-ons store) no longer accepts updates to extensions that continue to use Manifest Version 2.  <br/>You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
 
 
 <!-- ---------------------------------------------------------------------- -->
 ## See also
 
 * [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
+* [Contact the Microsoft Edge extensions team](../contact.md)
+
+Chromium docs: 
 * [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium -->
 * [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium --> in _Resuming the transition to Manifest V3_.
+
+External:
 * [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) - Browse and install extensions for Microsoft Edge.
+* [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) - forum about Microsoft Edge at Microsoft Tech Community.

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -20,7 +20,7 @@ Users browse and install extensions for Microsoft Edge from the [Microsoft Edge 
 
 Migrating from Manifest V2 to Manifest V3 brings several structural changes to how extensions are handled by the browser.
 
-In Oct. 2020, Microsoft announced the [decision to embrace Manifest V3](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/) to help reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.
+In Oct. 2020, Microsoft announced the decision to embrace Manifest V3, to help reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.  See [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/).
 
 Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
 
@@ -43,8 +43,8 @@ An overview of the changes involved, as described in [Migrate an extension from 
 Chromium has revised the timelines for ending support for Manifest V2.
 
 See:
-* [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium -->
-* [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium --> in _Resuming the transition to Manifest V3_.
+* [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok here -->
+* [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok here --> in _Resuming the transition to Manifest V3_.
 
 
 <!-- ---------------------------------------------------------------------- -->
@@ -58,7 +58,7 @@ If your extension still uses Manifest Version 2, migrate to Manifest Version 3 n
 |---|---|
 | Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest Version 3. |
 | Aug. 2026 | If your extension uses Manifest Version 2:  <br/>* At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone). |
-| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed:  <br/>* The `ExtensionManifestV2Availability` policy will be removed.  <br/>* Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
+| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed:  <br/>* The [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) policy will be removed.  <br/>* Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
 | TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest Version 2.  <br/>* You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
 
 For enterprise customers:
@@ -68,14 +68,17 @@ For enterprise customers:
 
 <!-- ---------------------------------------------------------------------- -->
 ## See also
+<!-- all links in article -->
 
+<!-- local: -->
 * [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
-* [Contact the Microsoft Edge extensions team](../contact.md)
 
 Chromium docs: 
-* [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium -->
-* [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium --> in _Resuming the transition to Manifest V3_.
+* [Chromium project](https://www.chromium.org/Home/)
+* [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok here -->
+* [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok here --> in _Resuming the transition to Manifest V3_.
 
 External:
-* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store - Browse and install extensions for Microsoft Edge.
-* [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) - forum about Microsoft Edge at Microsoft Tech Community.
+* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
+* [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/) - blog post.
+* [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) in _Microsoft Edge - Policies_ docs.

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -25,16 +25,16 @@ Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/
 <!-- ---------------------------------------------------------------------- -->
 ## Manifest timeline for Partner Center and Microsoft Edge
 
+For enterprise customers:
+* Extensions that use Manifest V2 will continue to be supported until further notice.
+* Deprecation of Manifest V2 extensions is expected to begin in early 2027.
+
 | Date | Changes |
 |---|---|
 | Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest V3. |
 | Aug. 2026 | If your extension uses Manifest V2:  <br/>* At Partner Center, a Manifest V2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone). |
 | TBD | For enterprise users, in Microsoft Edge, support for Manifest V2 will be removed:  <br/>* The [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) policy will be removed.  <br/>* Extensions that use Manifest V2 will no longer work, even on enterprise-managed devices. |
 | TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  <br/>* You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
-
-For enterprise customers:
-* Extensions that use Manifest V2 will continue to be supported until further notice.
-* Deprecation of Manifest V2 extensions is expected to begin in early 2027.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -54,7 +54,7 @@ To help you plan the migration of your extension from Manifest Version 2 to Mani
 
 If your extension still uses Manifest Version 2, migrate to Manifest Version 3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest Version 3 version of your extension is ready, submit the update through Microsoft Partner Center.
 
-For enterprise customers, extensions that use Manifest Version 2 will continue to be supported until further notice.  Deprecation of Manifest Version 2 extensions for enterprise customers is expected to begin in early 2027.
+For enterprise customers, extensions that use Manifest Version 2 will continue to be supported until further notice. Deprecation of Manifest Version 2 extensions for enterprise customers is expected to begin in early 2027.
 
 | Date | Changes |
 |---|---|

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -12,6 +12,8 @@ ms.date: 08/07/2026
 
 To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
 
+If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
+
 In Oct. 2020, Microsoft announced the decision to embrace Manifest V3, to help reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.  See [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/).
 
 Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
@@ -30,8 +32,6 @@ Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/
 For enterprise customers:
 * Extensions that use Manifest V2 will continue to be supported until further notice.
 * Deprecation of Manifest V2 extensions is expected to begin in early 2027.
-
-If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -10,7 +10,7 @@ ms.date: 08/07/2026
 ---
 # Timeline for migrating to Manifest V3
 
-To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
+To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned end of support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
 
 | Date | Changes |
 |---|---|

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -59,8 +59,8 @@ For enterprise customers, extensions that use Manifest Version 2 will continue t
 | Date | Changes |
 |---|---|
 | Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions with visibility set to `Public` or `Hidden`.  <br/>To publish a new extension, use Manifest Version 3. |
-| Aug. 2026 | If your extension uses Manifest Version 2:  <br/>At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users.  <br/>In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users. |
-| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed.  <br/>The `ExtensionManifestV2Availability` policy will be removed.  <br/>Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
+| Aug. 2026 | If your extension uses Manifest Version 2:  <br/>At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone). |
+| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed:  <br/>The `ExtensionManifestV2Availability` policy will be removed.  <br/>Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
 | TBD | Microsoft Partner Center (and thus the Edge Add-ons store) no longer accepts updates to extensions that continue to use Manifest Version 2.  <br/>You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
 
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -12,7 +12,7 @@ ms.date: 08/07/2026
 
 A _manifest file_ is the blueprint of an extension.  A manifest file for an extension includes information such as the version number of the extension, the title of the extension, and permissions needed to run the extension.  The manifest file follows the format specified by Manifest V2 or Manifest V3.
 
-Users browse and install extensions for Microsoft Edge from [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com).
+Users browse and install extensions for Microsoft Edge from the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) site.
 
 
 <!-- ---------------------------------------------------------------------- -->
@@ -48,20 +48,22 @@ See:
 
 
 <!-- ---------------------------------------------------------------------- -->
-## Manifest timeline for Microsoft Edge and Partner Center
+## Manifest timeline for Partner Center and Microsoft Edge
 
-To help you plan the migration of your extension from Manifest Version 2 to Manifest Version 3, the following schedule shows the planned support for Manifest Version 2 and V3 at Microsoft Partner Center (and the Edge Add-ons store), and in Microsoft Edge.
+To plan the migration of your extension from Manifest Version 2 to Manifest Version 3, the following schedule shows the planned support for Manifest Version 2 at Microsoft Partner Center (and the Microsoft Edge Add-ons store), and in Microsoft Edge.
 
-If your extension still uses Manifest Version 2, migrate to Manifest Version 3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest Version 3 version of your extension is ready, submit the update through Microsoft Partner Center.
-
-For enterprise customers, extensions that use Manifest Version 2 will continue to be supported until further notice. Deprecation of Manifest Version 2 extensions for enterprise customers is expected to begin in early 2027.
+If your extension still uses Manifest Version 2, migrate to Manifest Version 3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest Version 3 version of your extension is ready, submit the update through Partner Center.
 
 | Date | Changes |
 |---|---|
-| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions with visibility set to `Public` or `Hidden`.  <br/>* To publish a new extension, use Manifest Version 3. |
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest Version 3. |
 | Aug. 2026 | If your extension uses Manifest Version 2:  <br/>* At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone). |
 | TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed:  <br/>* The `ExtensionManifestV2Availability` policy will be removed.  <br/>* Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
-| TBD | Microsoft Partner Center (and thus the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest Version 2.  <br/>* You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
+| TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest Version 2.  <br/>* You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
+
+For enterprise customers:
+* Extensions that use Manifest Version 2 will continue to be supported until further notice.
+* Deprecation of Manifest Version 2 extensions is expected to begin in early 2027.
 
 
 <!-- ---------------------------------------------------------------------- -->
@@ -75,5 +77,5 @@ Chromium docs:
 * [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium --> in _Resuming the transition to Manifest V3_.
 
 External:
-* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) - Browse and install extensions for Microsoft Edge.
+* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) site - Browse and install extensions for Microsoft Edge.
 * [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) - forum about Microsoft Edge at Microsoft Tech Community.

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -61,8 +61,7 @@ When moving from Manifest V2 to Manifest V3:
 
 * Various minor feature improvements.
 
-See also:
-* [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
+For more details, see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).
 
 
 <!-- ---------------------------------------------------------------------- -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -10,56 +10,55 @@ ms.date: 08/07/2026
 ---
 # Timeline for migrating to Manifest V3
 
-To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned support for Manifest V2:
-* At Microsoft Partner Center.
-* At the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
-* In Microsoft Edge.
-
-If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
-
-In Oct. 2020, Microsoft announced the decision to embrace Manifest V3, to help reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.  See [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/).
-
-Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
-
-
-<!-- ---------------------------------------------------------------------- -->
-## Manifest timeline for Partner Center and Microsoft Edge
-
-For enterprise customers:
-* Extensions that use Manifest V2 will continue to be supported until further notice.
-* Deprecation of Manifest V2 extensions is expected to begin in early 2027.
+To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
 
 | Date | Changes |
 |---|---|
-| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have **Visibility** set to **Public** or **Hidden**.  To publish a new extension, use Manifest V3. |
-| Aug. 2026 | If your extension uses Manifest V2, at Partner Center, a Manifest V2 deprecation warning is displayed. |
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions.  To publish a new extension, use Manifest V3. |
+| Aug. 2026 | At Partner Center, if your extension uses Manifest V2, a Manifest V2 deprecation warning is displayed. |
+| Early 2027 | For enterprise customers, deprecation of Manifest V2 extensions is expected to begin. |
 | TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
 
 
 <!-- ====================================================================== -->
-## Manifest timeline for the Chromium browser engine
+## Migrate your extension to Manifest V3
 
-Chromium has revised the timelines for ending support for Manifest V2.
+If your extension still uses Manifest V2, migrate to Manifest V3 now.
+
+After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
 
 See:
+* [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
+
+
+<!-- ====================================================================== -->
+## Background
+
+In Oct. 2020, Microsoft announced the decision to embrace Manifest V3.  Manifest V3 helps reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.
+
+See:
+* [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/)
+
+
+<!-- ====================================================================== -->
+## Timeline for Chromium changes
+
+Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
+
+For information about end of support for Manifest V2 extensions in the Chromium browser engine project, see:
 * [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok here -->
 * [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok here --> in _Resuming the transition to Manifest V3_.
 
 
-<!-- ---------------------------------------------------------------------- -->
+<!-- ====================================================================== -->
 ## See also
 <!-- all links in article -->
 
-<!-- local: -->
 * [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
-* [Contact the Microsoft Edge extensions team](../contact.md)<!-- link not in article -->
+* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
+* [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/) - blog post.
 
 Chromium docs: 
 * [Chromium project](https://www.chromium.org/Home/)
 * [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok here -->
 * [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok here --> in _Resuming the transition to Manifest V3_.
-
-External:
-* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
-* [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/) - blog post.
-* [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) in _Microsoft Edge - Policies_ docs.

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -12,7 +12,7 @@ ms.date: 08/07/2026
 
 A _manifest file_ is the blueprint of an extension.  A manifest file for an extension includes information such as the version number of the extension, the title of the extension, and permissions needed to run the extension.  The manifest file follows the format specified by Manifest V2 or Manifest V3.
 
-Users browse and install extensions for Microsoft Edge from the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) site.
+Users browse and install extensions for Microsoft Edge from the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
 
 
 <!-- ---------------------------------------------------------------------- -->
@@ -77,5 +77,5 @@ Chromium docs:
 * [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok, section is re: v2-v3 migration in chromium --> in _Resuming the transition to Manifest V3_.
 
 External:
-* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) site - Browse and install extensions for Microsoft Edge.
+* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store - Browse and install extensions for Microsoft Edge.
 * [Microsoft Edge Insider](https://techcommunity.microsoft.com/t5/microsoft-edge-insider/ct-p/MicrosoftEdgeInsider) - forum about Microsoft Edge at Microsoft Tech Community.

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -10,7 +10,10 @@ ms.date: 08/07/2026
 ---
 # Timeline for migrating to Manifest V3
 
-To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
+To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned support for Manifest V2:
+* At Microsoft Partner Center.
+* At the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
+* In Microsoft Edge.
 
 If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: extensions
-ms.date: 04/26/2024
+ms.date: 08/03/2026
 ---
 # Overview and timelines for migrating to Manifest V3
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -64,7 +64,7 @@ When moving from Manifest V2 to Manifest V3:
 
 * Various minor feature improvements.
 
-For more details, see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).
+For details, see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).
 
 
 <!-- ---------------------------------------------------------------------- -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -58,10 +58,10 @@ For enterprise customers, extensions that use Manifest Version 2 will continue t
 
 | Date | Changes |
 |---|---|
-| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions with visibility set to `Public` or `Hidden`.  <br/>To publish a new extension, use Manifest Version 3. |
-| Aug. 2026 | If your extension uses Manifest Version 2:  <br/>At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone). |
-| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed:  <br/>The `ExtensionManifestV2Availability` policy will be removed.  <br/>Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
-| TBD | Microsoft Partner Center (and thus the Edge Add-ons store) no longer accepts updates to extensions that continue to use Manifest Version 2.  <br/>You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions with visibility set to `Public` or `Hidden`.  <br/>* To publish a new extension, use Manifest Version 3. |
+| Aug. 2026 | If your extension uses Manifest Version 2:  <br/>* At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone). |
+| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed:  <br/>* The `ExtensionManifestV2Availability` policy will be removed.  <br/>* Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
+| TBD | Microsoft Partner Center (and thus the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest Version 2.  <br/>* You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
 
 
 <!-- ---------------------------------------------------------------------- -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -47,26 +47,6 @@ See:
 * [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok here --> in _Resuming the transition to Manifest V3_.
 
 
-<!-- ====================================================================== -->
-## Overview of changes in Manifest V3
-
-Migrating an extension from using Manifest V2 to using Manifest V3 brings several structural changes to how extensions are handled by the browser.
-
-When moving from Manifest V2 to Manifest V3:
-
-* Background pages have been replaced by service workers.
-
-* Network request modifications are now handled by the new `declarativeNetRequest` API.
-
-* Remotely hosted code is no longer allowed.  An extension can only run JavaScript that's included within its own package.
-
-* Support for Promises has been added to many methods.  Callbacks are still supported, as an alternative.
-
-* Various minor feature improvements.
-
-For details, see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).
-
-
 <!-- ---------------------------------------------------------------------- -->
 ## See also
 <!-- all links in article -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -39,7 +39,7 @@ See [Manifest V3 changes are now available to test in Microsoft Edge](https://bl
 <!-- ====================================================================== -->
 ## Timeline for Chromium changes
 
-Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
+Microsoft Edge is based on the Chromium browser engine.  Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
 
 For information about end of support for Manifest V2 extensions in the Chromium browser engine project, see:
 * [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok here -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -31,7 +31,9 @@ See [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-
 <!-- ====================================================================== -->
 ## Background
 
-In Oct. 2020, Microsoft announced the decision to embrace Manifest V3.  Manifest V3 helps reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.
+In Oct. 2020, Microsoft announced the decision to embrace Manifest V3, which:
+* Reduces fragmentation of the web, for developers.
+* Enhances privacy, security, and performance, for end users.
 
 See [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/).
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -50,20 +50,20 @@ See:
 <!-- ---------------------------------------------------------------------- -->
 ## Manifest timeline for Partner Center and Microsoft Edge
 
-To plan the migration of your extension from Manifest Version 2 to Manifest Version 3, the following schedule shows the planned support for Manifest Version 2 at Microsoft Partner Center, at the Microsoft Edge Add-ons store, and in Microsoft Edge.
+To plan the migration of your extension from Manifest V2 to Manifest V3, the following schedule shows the planned support for Manifest V2 at Microsoft Partner Center, at the Microsoft Edge Add-ons store, and in Microsoft Edge.
 
-If your extension still uses Manifest Version 2, migrate to Manifest Version 3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest Version 3 version of your extension is ready, submit the update through Partner Center.
+If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
 
 | Date | Changes |
 |---|---|
-| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest Version 2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest Version 3. |
-| Aug. 2026 | If your extension uses Manifest Version 2:  <br/>* At Partner Center, a Manifest Version 2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest Version 2 deprecation warning is displayed, for some end-users (and later, for everyone). |
-| TBD | For enterprise users, in Microsoft Edge, support for Manifest Version 2 will be removed:  <br/>* The [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) policy will be removed.  <br/>* Extensions that use Manifest Version 2 will no longer work, even on enterprise-managed devices. |
-| TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest Version 2.  <br/>* You can submit an update that migrates a Manifest Version 2 extension to Manifest Version 3. |
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest V3. |
+| Aug. 2026 | If your extension uses Manifest V2:  <br/>* At Partner Center, a Manifest V2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone). |
+| TBD | For enterprise users, in Microsoft Edge, support for Manifest V2 will be removed:  <br/>* The [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) policy will be removed.  <br/>* Extensions that use Manifest V2 will no longer work, even on enterprise-managed devices. |
+| TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  <br/>* You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
 
 For enterprise customers:
-* Extensions that use Manifest Version 2 will continue to be supported until further notice.
-* Deprecation of Manifest Version 2 extensions is expected to begin in early 2027.
+* Extensions that use Manifest V2 will continue to be supported until further notice.
+* Deprecation of Manifest V2 extensions is expected to begin in early 2027.
 
 
 <!-- ---------------------------------------------------------------------- -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -53,6 +53,7 @@ See:
 
 <!-- local: -->
 * [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
+* [Contact the Microsoft Edge extensions team](../contact.md)<!-- link not in article -->
 
 Chromium docs: 
 * [Chromium project](https://www.chromium.org/Home/)

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -6,7 +6,7 @@ ms.author: msedgedevrel
 ms.topic: article
 ms.service: microsoft-edge
 ms.subservice: extensions
-ms.date: 08/04/2026
+ms.date: 08/07/2026
 ---
 # Overview and timelines for migrating to Manifest V3
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -1,5 +1,5 @@
 ---
-title: Overview and timelines for migrating to Manifest V3
+title: Timeline for migrating to Manifest V3
 description: Timelines for migration from Manifest V2 to V3, and overview of V3, which reduces fragmentation of the web for developers and enhances privacy, security, and performance for end users.
 author: MSEdgeTeam
 ms.author: msedgedevrel
@@ -8,23 +8,19 @@ ms.service: microsoft-edge
 ms.subservice: extensions
 ms.date: 08/07/2026
 ---
-# Overview and timelines for migrating to Manifest V3
+# Timeline for migrating to Manifest V3
 
-A _manifest file_ is the blueprint of an extension.  A manifest file for an extension includes information such as the version number of the extension, the title of the extension, and permissions needed to run the extension.  The manifest file follows the format specified by Manifest V2 or Manifest V3.
-
-Users browse and install extensions for Microsoft Edge from the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
-
-
-<!-- ---------------------------------------------------------------------- -->
-## Overview of changes in Manifest V3
-
-Migrating from Manifest V2 to Manifest V3 brings several structural changes to how extensions are handled by the browser.
+Migrating an extension from using Manifest V2 to using Manifest V3 brings several structural changes to how extensions are handled by the browser.
 
 In Oct. 2020, Microsoft announced the decision to embrace Manifest V3, to help reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.  See [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/).
 
 Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
 
-An overview of the changes involved, as described in [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md):
+
+<!-- ====================================================================== -->
+## Overview of changes in Manifest V3
+
+When moving from Manifest V2 to Manifest V3:
 
 * Background pages have been replaced by service workers.
 
@@ -36,8 +32,11 @@ An overview of the changes involved, as described in [Migrate an extension from 
 
 * Various minor feature improvements.
 
+See also:
+* [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
 
-<!-- ---------------------------------------------------------------------- -->
+
+<!-- ====================================================================== -->
 ## Manifest timeline for the Chromium browser engine
 
 Chromium has revised the timelines for ending support for Manifest V2.
@@ -50,7 +49,7 @@ See:
 <!-- ---------------------------------------------------------------------- -->
 ## Manifest timeline for Partner Center and Microsoft Edge
 
-To plan the migration of your extension from Manifest V2 to Manifest V3, the following schedule shows the planned support for Manifest V2 at Microsoft Partner Center, at the Microsoft Edge Add-ons store, and in Microsoft Edge.
+To plan the migration of your extension from Manifest V2 to Manifest V3, the following schedule shows the planned support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
 
 If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -31,9 +31,9 @@ For enterprise customers:
 
 | Date | Changes |
 |---|---|
-| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have **Visibility** set to **Public** or **Hidden**.  <br/>* To publish a new extension, use Manifest V3. |
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have **Visibility** set to **Public** or **Hidden**.  To publish a new extension, use Manifest V3. |
 | Aug. 2026 | If your extension uses Manifest V2, at Partner Center, a Manifest V2 deprecation warning is displayed. |
-| TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  <br/>* You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
+| TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -23,12 +23,9 @@ To plan the migration of your extension from Manifest V2 to Manifest V3, the fol
 <!-- ====================================================================== -->
 ## Migrate your extension to Manifest V3
 
-If your extension still uses Manifest V2, migrate to Manifest V3 now.
+If your extension still uses Manifest V2, migrate to Manifest V3 now.  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
 
-After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
-
-See:
-* [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
+See [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).
 
 
 <!-- ====================================================================== -->
@@ -36,8 +33,7 @@ See:
 
 In Oct. 2020, Microsoft announced the decision to embrace Manifest V3.  Manifest V3 helps reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.
 
-See:
-* [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/)
+See [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/).
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -50,7 +50,7 @@ See:
 <!-- ---------------------------------------------------------------------- -->
 ## Manifest timeline for Partner Center and Microsoft Edge
 
-To plan the migration of your extension from Manifest Version 2 to Manifest Version 3, the following schedule shows the planned support for Manifest Version 2 at Microsoft Partner Center (and the Microsoft Edge Add-ons store), and in Microsoft Edge.
+To plan the migration of your extension from Manifest Version 2 to Manifest Version 3, the following schedule shows the planned support for Manifest Version 2 at Microsoft Partner Center, at the Microsoft Edge Add-ons store, and in Microsoft Edge.
 
 If your extension still uses Manifest Version 2, migrate to Manifest Version 3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest Version 3 version of your extension is ready, submit the update through Partner Center.
 

--- a/microsoft-edge/extensions/developer-guide/manifest-v3.md
+++ b/microsoft-edge/extensions/developer-guide/manifest-v3.md
@@ -1,6 +1,6 @@
 ---
 title: Timeline for migrating to Manifest V3
-description: Timelines for migration from Manifest V2 to V3, and overview of V3, which reduces fragmentation of the web for developers and enhances privacy, security, and performance for end users.
+description: Timeline for migration from Manifest V2 to V3, which reduces fragmentation of the web for developers and enhances privacy, security, and performance for end users.
 author: MSEdgeTeam
 ms.author: msedgedevrel
 ms.topic: article
@@ -10,15 +10,44 @@ ms.date: 08/07/2026
 ---
 # Timeline for migrating to Manifest V3
 
-Migrating an extension from using Manifest V2 to using Manifest V3 brings several structural changes to how extensions are handled by the browser.
+To plan the migration of your extension from Manifest V2 to Manifest V3, the following timeline shows the planned support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
 
 In Oct. 2020, Microsoft announced the decision to embrace Manifest V3, to help reduce fragmentation of the web for all developers and enhance privacy, security, and performance for end users.  See [Manifest V3 changes are now available to test in Microsoft Edge](https://blogs.windows.com/msedgedev/2020/10/14/extension-manifest-chromium-edge/).
 
 Manifest V3 is an initiative of the [Chromium project](https://www.chromium.org/Home/).
 
 
+<!-- ---------------------------------------------------------------------- -->
+## Manifest timeline for Partner Center and Microsoft Edge
+
+| Date | Changes |
+|---|---|
+| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest V3. |
+| Aug. 2026 | If your extension uses Manifest V2:  <br/>* At Partner Center, a Manifest V2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone). |
+| TBD | For enterprise users, in Microsoft Edge, support for Manifest V2 will be removed:  <br/>* The [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) policy will be removed.  <br/>* Extensions that use Manifest V2 will no longer work, even on enterprise-managed devices. |
+| TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  <br/>* You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
+
+For enterprise customers:
+* Extensions that use Manifest V2 will continue to be supported until further notice.
+* Deprecation of Manifest V2 extensions is expected to begin in early 2027.
+
+If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
+
+
+<!-- ====================================================================== -->
+## Manifest timeline for the Chromium browser engine
+
+Chromium has revised the timelines for ending support for Manifest V2.
+
+See:
+* [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok here -->
+* [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok here --> in _Resuming the transition to Manifest V3_.
+
+
 <!-- ====================================================================== -->
 ## Overview of changes in Manifest V3
+
+Migrating an extension from using Manifest V2 to using Manifest V3 brings several structural changes to how extensions are handled by the browser.
 
 When moving from Manifest V2 to Manifest V3:
 
@@ -34,35 +63,6 @@ When moving from Manifest V2 to Manifest V3:
 
 See also:
 * [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md)
-
-
-<!-- ====================================================================== -->
-## Manifest timeline for the Chromium browser engine
-
-Chromium has revised the timelines for ending support for Manifest V2.
-
-See:
-* [Manifest V2 support timeline](https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline)<!-- chrome link ok here -->
-* [The phase-out timeline](https://developer.chrome.com/blog/resuming-the-transition-to-mv3#the_phase-out_timeline)<!-- chrome link ok here --> in _Resuming the transition to Manifest V3_.
-
-
-<!-- ---------------------------------------------------------------------- -->
-## Manifest timeline for Partner Center and Microsoft Edge
-
-To plan the migration of your extension from Manifest V2 to Manifest V3, the following schedule shows the planned support for Manifest V2 at Microsoft Partner Center, at the [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store, and in Microsoft Edge.
-
-If your extension still uses Manifest V2, migrate to Manifest V3 now; see [Migrate an extension from Manifest V2 to V3](./migrate-your-extension-from-manifest-v2-to-v3.md).  After the Manifest V3 version of your extension is ready, submit the update through Partner Center.
-
-| Date | Changes |
-|---|---|
-| Jul. 2022 | Partner Center (and the Edge Add-ons store) no longer accepts new Manifest V2 extensions that have `Public` or `Hidden` visibility.  <br/>* To publish a new extension, use Manifest V3. |
-| Aug. 2026 | If your extension uses Manifest V2:  <br/>* At Partner Center, a Manifest V2 deprecation warning is displayed.  <br/>* At the Edge Add-ons store, on the extension's product detail page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone).  <br/>* In Microsoft Edge, on the **Manage extensions** page, a Manifest V2 deprecation warning is displayed, for some end-users (and later, for everyone). |
-| TBD | For enterprise users, in Microsoft Edge, support for Manifest V2 will be removed:  <br/>* The [ExtensionManifestV2Availability](/deployedge/microsoft-edge-policies/extensionmanifestv2availability) policy will be removed.  <br/>* Extensions that use Manifest V2 will no longer work, even on enterprise-managed devices. |
-| TBD | Partner Center (and the Edge Add-ons store) will no longer accept updates to extensions that continue to use Manifest V2.  <br/>* You can submit an update that migrates a Manifest V2 extension to Manifest V3. |
-
-For enterprise customers:
-* Extensions that use Manifest V2 will continue to be supported until further notice.
-* Deprecation of Manifest V2 extensions is expected to begin in early 2027.
 
 
 <!-- ---------------------------------------------------------------------- -->

--- a/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
+++ b/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
@@ -14,6 +14,9 @@ ms.date: 05/26/2021
 
 This article lists important aspects of Manifest V3, which is the current version of the Chromium Extensions platform.  For guidance on migrating your extension to Manifest V3 from the Chromium project, see [Migrate to Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate)<!-- chrome link ok -->.
 
+See also:
+* [Overview of changes in Manifest V3](./manifest-v3.md) in _Timeline for migrating to Manifest V3_.
+
 
 <!-- ====================================================================== -->
 ## Remotely hosted code
@@ -74,3 +77,23 @@ The Microsoft Edge extensions team publishes updates at our blog.  You can provi
 | removed | `"persistent": false,` |
 | If `background` is included, `service_ worker` is required | If `background` is included, `service_ worker` is optional |
 | Separated into two different keys: `"permissions": [...], "host_permissions": [...],` | `"permissions": [...],` |
+
+
+<!-- ====================================================================== -->
+## See also
+<!-- all links in article -->
+
+* [Overview of changes in Manifest V3](./manifest-v3.md) in _Timeline for migrating to Manifest V3_.
+
+External:
+* [Manifest V3 changes are now available in Microsoft Edge](https://techcommunity.microsoft.com/t5/articles/manifest-v3-changes-are-now-available-in-microsoft-edge/m-p/1780254) - blog post.
+* [Extensions](/deployedge/microsoft-edge-policies#extensions) in _Microsoft Edge – Policies_.
+* [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com) store.
+
+Chromium docs:
+* [Migrate to Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate)<!-- chrome link ok -->
+* [Use eval() in sandboxed iframes](https://developer.chrome.com/docs/extensions/how-to/security/sandboxing-eval)<!-- chrome link ok, extension ref docs are there -->
+* [Changes to Cross-Origin Requests in Chrome Extension Content Scripts](https://www.chromium.org/Home/chromium-security/extension-content-script-fetches).
+* [Web Request API](https://developer.chrome.com/docs/extensions/reference/webRequest)<!-- chrome link ok, extension ref docs are there -->
+* [Declarative Net Request API](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest)<!-- chrome link ok, extension ref docs are there -->
+* [Migrate to a service worker](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers)<!-- chrome link ok -->

--- a/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
+++ b/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
@@ -14,8 +14,25 @@ ms.date: 05/26/2021
 
 This article lists important aspects of Manifest V3, which is the current version of the Chromium Extensions platform.  For guidance on migrating your extension to Manifest V3 from the Chromium project, see [Migrate to Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate)<!-- chrome link ok -->.
 
-See also:
-* [Overview of changes in Manifest V3](./manifest-v3.md#overview-of-changes-in-manifest-v3) in _Timeline for migrating to Manifest V3_.
+
+<!-- ====================================================================== -->
+## Overview of changes in Manifest V3
+
+Migrating an extension from using Manifest V2 to using Manifest V3 brings several structural changes to how extensions are handled by the browser:
+
+* Remotely hosted code is no longer allowed.  An extension can only run JavaScript that's included within its own package.  See [Remotely hosted code](#remotely-hosted-code), below.
+
+* Edge extensions can use controls that enable you to allow or restrict access to websites at runtime.  See [Run-time host permissions](#run-time-host-permissions), below.
+
+* Content scripts are required to have the same permissions as the webpage into which the scripts are injected.  See [Cross-origin requests in content scripts](#cross-origin-requests-in-content-scripts), below.
+
+* Network request modifications are now handled by the new `declarativeNetRequest` API.  See [Web Request API](#web-request-api), below.
+
+* Background pages have been replaced by service workers.  See [Background service workers](#background-service-workers), below.
+
+* Support for Promises has been added to many methods.  Callbacks are still supported, as an alternative.
+
+* Various minor feature improvements.
 
 
 <!-- ====================================================================== -->
@@ -25,13 +42,15 @@ Today, some parts of the extensions code are hosted remotely, and aren't include
 
 To ensure that the extensions at Microsoft Edge Add-ons are validated, the Microsoft Edge extensions team disallows extensions from using remotely hosted code.  This change makes extensions more secure.
 
-Developers will need to package and submit all code that is used by the extension, for validation.  Alternatively, you can use the `eval()` function in a sandboxed iframe. See [Use eval() in sandboxed iframes](https://developer.chrome.com/docs/extensions/how-to/security/sandboxing-eval)<!-- chrome link ok, extension ref docs are there -->.
+You'll need to package and submit all code that is used by the extension, for validation.  Alternatively, you can use the `eval()` function in a sandboxed iframe. See [Use eval() in sandboxed iframes](https://developer.chrome.com/docs/extensions/how-to/security/sandboxing-eval)<!-- chrome link ok, extension ref docs are there -->.
 
 
 <!-- ====================================================================== -->
 ## Run-time host permissions
 
-At installation time, it's possible for extensions to request blanket permissions to access all sites and content.  These permissions allow extensions to operate with minimum intervention, and so present a risk for user privacy and security.  To improve transparency, the Microsoft Edge extensions team provides controls that enable users to allow or restrict access to websites at runtime.
+At installation time, it's possible for extensions to request blanket permissions to access all sites and content.  These permissions allow extensions to operate with minimum intervention, and so present a risk for user privacy and security.
+
+To improve transparency, the Microsoft Edge extensions team provides controls that enable users to allow or restrict access to websites at runtime.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
+++ b/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md
@@ -15,7 +15,7 @@ ms.date: 05/26/2021
 This article lists important aspects of Manifest V3, which is the current version of the Chromium Extensions platform.  For guidance on migrating your extension to Manifest V3 from the Chromium project, see [Migrate to Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate)<!-- chrome link ok -->.
 
 See also:
-* [Overview of changes in Manifest V3](./manifest-v3.md) in _Timeline for migrating to Manifest V3_.
+* [Overview of changes in Manifest V3](./manifest-v3.md#overview-of-changes-in-manifest-v3) in _Timeline for migrating to Manifest V3_.
 
 
 <!-- ====================================================================== -->

--- a/microsoft-edge/extensions/landing/index.yml
+++ b/microsoft-edge/extensions/landing/index.yml
@@ -89,7 +89,7 @@ landingContent:
     linkLists:
       - linkListType: how-to-guide
         links:
-          - text: Overview and timelines for migrating to Manifest V3
+          - text: Timeline for migrating to Manifest V3
             url: ../developer-guide/manifest-v3.md
 
           - text: Migrate an extension from Manifest V2 to V3

--- a/microsoft-edge/extensions/publish/publish-extension.md
+++ b/microsoft-edge/extensions/publish/publish-extension.md
@@ -364,7 +364,7 @@ If the extension executes remote code:
 The extension should avoid the use of remote code unless absolutely necessary.  Remote code requires additional review, and might increase certification time.
 
 See also:
-* [Overview of changes in Manifest V3](../developer-guide/manifest-v3.md#overview-of-changes-in-manifest-v3), in _Timeline for migrating to Manifest V3_.
+* [Overview of changes in Manifest V3](../developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md#overview-of-changes-in-manifest-v3) in _Migrate an extension from Manifest V2 to V3_.
 * [Remove remotely hosted code](https://developer.chrome.com/docs/extensions/develop/migrate/improve-security#remove-remote-code) in _Improve extension security_, in Chrome docs.
 
 
@@ -802,7 +802,7 @@ If you experience issues when registering as an extension developer or when subm
 * [Extension concepts and architecture](../getting-started/index.md)<!-- bucket 2 -->
 * [Port a Chrome extension to Microsoft Edge](../developer-guide/port-chrome-extension.md)<!-- bucket 4 -->
 * [Manifest file format for extensions](../getting-started/manifest-format.md)<!-- bucket 5 top -->
-   * [Overview of changes in Manifest V3](../developer-guide/manifest-v3.md#overview-of-changes-in-manifest-v3), in _Timeline for migrating to Manifest V3_.<!-- bucket 5 -->
+* [Overview of changes in Manifest V3](../developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md#overview-of-changes-in-manifest-v3) in _Migrate an extension from Manifest V2 to V3_.<!-- bucket 5 -->
 * [Register as a Microsoft Edge extension developer](./create-dev-account.md)<!-- bucket 6 -->
 * [Best practices for extensions](../developer-guide/best-practices.md)<!-- bucket 10 -->
 * [Contact the Microsoft Edge extensions team](../contact.md)<!-- bottom -->

--- a/microsoft-edge/extensions/publish/publish-extension.md
+++ b/microsoft-edge/extensions/publish/publish-extension.md
@@ -364,7 +364,7 @@ If the extension executes remote code:
 The extension should avoid the use of remote code unless absolutely necessary.  Remote code requires additional review, and might increase certification time.
 
 See also:
-* [Overview of changes in Manifest V3](../developer-guide/manifest-v3.md#overview-of-changes-in-manifest-v3), in _Overview and timelines for migrating to Manifest V3_.
+* [Overview of changes in Manifest V3](../developer-guide/manifest-v3.md#overview-of-changes-in-manifest-v3), in _Timeline for migrating to Manifest V3_.
 * [Remove remotely hosted code](https://developer.chrome.com/docs/extensions/develop/migrate/improve-security#remove-remote-code) in _Improve extension security_, in Chrome docs.
 
 
@@ -802,7 +802,7 @@ If you experience issues when registering as an extension developer or when subm
 * [Extension concepts and architecture](../getting-started/index.md)<!-- bucket 2 -->
 * [Port a Chrome extension to Microsoft Edge](../developer-guide/port-chrome-extension.md)<!-- bucket 4 -->
 * [Manifest file format for extensions](../getting-started/manifest-format.md)<!-- bucket 5 top -->
-   * [Overview of changes in Manifest V3](../developer-guide/manifest-v3.md#overview-of-changes-in-manifest-v3), in _Overview and timelines for migrating to Manifest V3_.<!-- bucket 5 -->
+   * [Overview of changes in Manifest V3](../developer-guide/manifest-v3.md#overview-of-changes-in-manifest-v3), in _Timeline for migrating to Manifest V3_.<!-- bucket 5 -->
 * [Register as a Microsoft Edge extension developer](./create-dev-account.md)<!-- bucket 6 -->
 * [Best practices for extensions](../developer-guide/best-practices.md)<!-- bucket 10 -->
 * [Contact the Microsoft Edge extensions team](../contact.md)<!-- bottom -->

--- a/microsoft-edge/toc.yml
+++ b/microsoft-edge/toc.yml
@@ -1274,7 +1274,7 @@
 
                 - name: Migrating to V3
                   items:
-                    - name: Overview and timelines for migrating to Manifest V3
+                    - name: Timeline for migrating to Manifest V3
                       href: ./extensions/developer-guide/manifest-v3.md
 
                     - name: Migrate an extension from Manifest V2 to V3


### PR DESCRIPTION
Rendered article sections for review:

* **Timeline for migrating to Manifest V3** > **Manifest timeline for Partner Center and Microsoft Edge**
   * `/extensions/developer-guide/manifest-v3.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/developer-guide/manifest-v3?branch=pr-en-us-3892#manifest-timeline-for-partner-center-and-microsoft-edge
   * External preview: 
   * Before/live: https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/manifest-v3#manifest-timeline-for-microsoft-edge-and-partner-center
   * Planned live: https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/manifest-v3#manifest-timeline-for-partner-center-and-microsoft-edge
   * Rewrote section.
   * Structural edit of article.
      * Narrowed the article title from **Overview and timelines for migrating to Manifest V3**.
      * Restricted article's focus to the intended scope of article.
         * Moved "overview of manifests" info to the Migrate article that already has detailed equiv. sections.
         * Restricted the focus of each section, per the heading.
      * Cross-linked with the articles that are designed to focus on the peripheral topics.
      * Moved Chrome timeline section below this section, to emphasize timeline for Partner Center & Edge.

---
### Incidental files

* **Add a custom tool in Microsoft Edge DevTools** > **heading**
   * `/extensions/developer-guide/devtools-extension.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/developer-guide/devtools-extension?branch=pr-en-us-3892
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/devtools-extension
   * In `manifest_version` row, & in h2 See Also, changed link text from **Overview and timelines for migrating to Manifest V3** to **Timeline for migrating to Manifest V3**.

* **Migrate an extension from Manifest V2 to V3** > **heading**
   * `/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3?branch=pr-en-us-3892
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions/developer-guide/migrate-your-extension-from-manifest-v2-to-v3
   * Moved section **Overview of changes in Manifest V3** to this article, from Timeline article.
   * Added standard h2 See also section, w/ all the links in the article.

* **Microsoft Edge extensions documentation** - extensions landing page
   * `/extensions/landing/index.yml`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/landing/index?branch=pr-en-us-3892
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions/landing/
   * Changed title in card from **Overview and timelines for migrating to Manifest V3** to **Timeline for migrating to Manifest V3**.

* **Publish a Microsoft Edge extension** > **heading**
   * `/extensions/publish/publish-extension.md`
   * Internal preview: https://review.learn.microsoft.com/microsoft-edge/extensions/publish/publish-extension?branch=pr-en-us-3892
   * External preview: 
   * Before/live: https://learn.microsoft.com/microsoft-edge/extensions/publish/publish-extension
   * Changed link text from **Overview and timelines for migrating to Manifest V3** to **Timeline for migrating to Manifest V3**.

* `toc.yml`
   * Changed title from **Overview and timelines for migrating to Manifest V3** to **Timeline for migrating to Manifest V3**.

AB#63412056
